### PR TITLE
Build Capture Popup (Electron)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,45 +119,52 @@ Neurologue is designed to be:
 # Tech Stack
 
 ### Frontend
-- Electron or Tauri  
-- Global hotkey  
-- Capture popup  
-- Library UI  
+- **Electron** — global hotkey, capture popup, library UI
 
 ### Backend
-- Node.js (or Python)  
-- SQLite for structured data  
-- Local vector DB (Chroma or LanceDB)  
+- **Node.js** — DB access layer, IPC, background worker
+- **sql.js** — pure-WASM SQLite (no native compilation required)
+- **LanceDB** — embedded local vector store
 
 ### AI
-- Embeddings: `bge-small-en`, `gte-small`, or similar  
-- LLM: Phi‑3 Mini or Qwen 2.5 3B via Ollama  
-- Background worker for processing  
+- Embeddings: `bge-small-en` or `gte-small` via **Ollama**
+- LLM: **Phi‑3 Mini** or **Qwen 2.5 3B** via Ollama
+- Background worker for asynchronous processing
 
 ---
 
 # Repository Structure
 ```
 /docs
-    /architecture
-        01-system-overview.md
-        02-capture-layer.md
-        03-library-layer.md
-        04-processing-layer.md
-        05-export-layer.md
-    /requirements
-        functional-requirements.md
-        nonfunctional-requirements.md
-        data-model.md
-        llm-requirements.md
-/copilot
-    copilot-bootstrap.md
-    agent-guidelines.md
+    /architecture/          — layer-by-layer design documents
+    /requirements/          — functional, non-functional, data model, LLM
+    /copilot/               — Copilot agent guidelines and bootstrap prompt
+    /brand/                 — colours, typography, logo guidelines
 /src
-    /frontend
-    /backend
-    /worker
-    /db
+    main.js                 — Electron entry point
+    config.js               — paths, Ollama endpoint, model names
+    /capture/
+        hotkey.js           — global hotkey + capture BrowserWindow
+    /frontend/
+        index.html          — main library window (placeholder)
+        preload.js          — main window contextBridge
+        capture.html        — capture popup UI
+        capture.js          — capture popup renderer logic
+        capture-preload.js  — capture popup contextBridge
+    /backend/
+        /db/
+            connection.js   — sql.js wrapper (better-sqlite3-compatible API)
+            entries.js      — entries CRUD
+            tags.js         — tags CRUD
+            themes.js       — themes CRUD
+            embeddings.js   — embeddings CRUD
+        /vector/
+            store.js        — LanceDB vector store (init, upsert, search)
+    /db/
+        migrate.js          — versioned migration runner
+        /migrations/
+            001_initial_schema.sql
+    /worker/                — background processing worker (Phase 4)
 ```
 
 
@@ -183,29 +190,111 @@ Each feature is implemented through a GitHub Issue with clear acceptance criteri
 
 # Getting Started (Development)
 
-1. Clone the repo  
-2. Install dependencies (Node, SQLite, Ollama)  
-3. Run the frontend (Electron/Tauri)  
-4. Run the backend server  
-5. Run the background worker  
+## Prerequisites
 
-Detailed setup instructions will be added as components are implemented.
+| Requirement | Version | Notes |
+|---|---|---|
+| Node.js | 18 LTS or later | [nodejs.org](https://nodejs.org) |
+| npm | bundled with Node | — |
+| Ollama | latest | [ollama.com](https://ollama.com) — required for Phase 3+ only |
+
+> **No C++ build toolchain required.** Neurologue uses `sql.js` (pure WASM) and LanceDB (prebuilt binaries).
+
+## Install
+
+```bash
+git clone https://github.com/codebureau/neurologue.git
+cd neurologue
+npm install
+```
+
+## Run the app
+
+```bash
+npm start
+```
+
+This launches the Electron shell. On first run, the SQLite database and LanceDB vector store are created automatically in your OS user-data directory.
+
+- **Windows:** `%APPDATA%\neurologue\`
+- **macOS:** `~/Library/Application Support/neurologue/`
+
+## Using the capture hotkey
+
+Once the app is running, press **`Ctrl+Shift+Space`** (Windows/Linux) or **`Cmd+Shift+Space`** (macOS) from anywhere on your desktop to open the capture popup.
+
+- Type your thought
+- Optionally add comma-separated tags
+- Press **`Ctrl+Enter`** or click **Save**
+- Press **`Escape`** to cancel
+
+## Setting up Ollama (Phase 3+)
+
+Ollama is only needed once the background worker is implemented (Phase 3). To prepare:
+
+```bash
+# Install Ollama, then pull the required models
+ollama pull phi3:mini
+ollama pull bge-small-en   # for embeddings (via ollama or direct)
+```
+
+Ollama should be running on `http://127.0.0.1:11434` (default). The endpoint is configurable in `src/config.js`.
 
 ---
 
 # Project Status
 
-Neurologue is currently in **early design and scaffolding**.  
-The next steps are:
+| Phase | Description | Status |
+|---|---|---|
+| 0 | Foundations (design, scaffolding) | ✅ Complete |
+| 1 | Core Data Layer (SQLite, LanceDB, CRUD) | ✅ Complete |
+| 2 | Capture Layer (hotkey popup) | ✅ Complete |
+| 3 | Background Worker (embeddings via Ollama) | 🔲 In progress |
+| 4 | Library Layer (timeline, search, themes UI) | 🔲 Planned |
+| 5 | Processing Layer (clustering, summaries) | 🔲 Planned |
+| 6 | Export Layer (JSON/MD/embeddings) | 🔲 Planned |
 
-- Implement SQLite schema  
-- Build capture popup  
-- Add background embedding worker  
-- Add semantic search  
-- Add theme clustering  
-- Add export system  
+See [ROADMAP.md](ROADMAP.md) and [GitHub Issues](https://github.com/codebureau/neurologue/issues) for detail.
 
-See GitHub Issues for the full roadmap.
+---
+
+# Validating the build
+
+## Phase 1 — Data layer
+
+Verify the database is created and all tables exist:
+
+```bash
+npm start
+# Then close the app and inspect the DB, or run:
+node -e "
+const { openDb } = require('./src/backend/db/connection');
+openDb().then(db => {
+  const t = db.prepare(\"SELECT name FROM sqlite_master WHERE type='table'\").all();
+  console.log(t.map(r => r.name));
+  process.exit(0);
+});
+"
+```
+
+Expected output: `entries, tags, entry_tags, embeddings, themes, theme_entries, schema_migrations`
+
+## Phase 2 — Capture popup
+
+1. Run `npm start`
+2. Press **`Ctrl+Shift+Space`** — the capture popup should appear within 100ms
+3. Type a thought, add optional tags, press `Ctrl+Enter`
+4. The popup closes — the entry is saved to SQLite
+5. Press `Escape` to close without saving
+
+To confirm an entry was written:
+
+```bash
+node -e "
+const { listEntries } = require('./src/backend/db/entries');
+listEntries().then(rows => { console.log(rows); process.exit(0); });
+"
+```
 
 ---
 

--- a/src/capture/hotkey.js
+++ b/src/capture/hotkey.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { BrowserWindow, globalShortcut, app } = require('electron');
+const path = require('path');
+
+const HOTKEY = 'CommandOrControl+Shift+Space';
+
+let _captureWin = null;
+
+/**
+ * Open (or focus) the capture popup window.
+ */
+function openCaptureWindow() {
+  if (_captureWin && !_captureWin.isDestroyed()) {
+    _captureWin.focus();
+    return;
+  }
+
+  _captureWin = new BrowserWindow({
+    width: 560,
+    height: 260,
+    frame: false,
+    resizable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, '..', 'frontend', 'capture-preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  _captureWin.loadFile(path.join(__dirname, '..', 'frontend', 'capture.html'));
+
+  _captureWin.once('ready-to-show', () => {
+    _captureWin.show();
+    _captureWin.focus();
+  });
+
+  _captureWin.on('blur', () => {
+    // Close the popup if it loses focus (user clicked away)
+    if (_captureWin && !_captureWin.isDestroyed()) {
+      _captureWin.close();
+    }
+  });
+
+  _captureWin.on('closed', () => {
+    _captureWin = null;
+  });
+}
+
+/**
+ * Close the capture popup, if open.
+ */
+function closeCaptureWindow() {
+  if (_captureWin && !_captureWin.isDestroyed()) {
+    _captureWin.close();
+  }
+}
+
+/**
+ * Register the global hotkey. Call once after app.whenReady().
+ */
+function registerCaptureHotkey() {
+  const registered = globalShortcut.register(HOTKEY, openCaptureWindow);
+  if (!registered) {
+    console.warn(`[hotkey] Failed to register ${HOTKEY} — it may already be in use by another app.`);
+  }
+
+  app.on('will-quit', () => {
+    globalShortcut.unregister(HOTKEY);
+  });
+}
+
+module.exports = { registerCaptureHotkey, openCaptureWindow, closeCaptureWindow };

--- a/src/frontend/capture-preload.js
+++ b/src/frontend/capture-preload.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('capture', {
+  /**
+   * Save a captured entry.
+   * @param {{ content: string, tags: string[] }} data
+   * @returns {Promise<{ ok: boolean, id: string }>}
+   */
+  save: (data) => ipcRenderer.invoke('capture:save', data),
+
+  /** Close the popup without saving. */
+  close: () => ipcRenderer.send('capture:close'),
+});

--- a/src/frontend/capture.html
+++ b/src/frontend/capture.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'" />
+  <title>Capture</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    :root {
+      --neuro-blue:   #1C2A3A;
+      --cortex-teal:  #2AA6A1;
+      --insight-cyan: #5FD4E6;
+      --ink:          #0E0E0F;
+      --slate:        #3A3A3C;
+      --fog:          #D4D4D8;
+      --cloud:        #F5F5F7;
+      --white:        #FFFFFF;
+      --error-red:    #D9534F;
+      --radius:       6px;
+      --font:         'Inter', system-ui, sans-serif;
+    }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      background: transparent;
+      font-family: var(--font);
+      font-size: 14px;
+      color: var(--ink);
+      /* Allow the frameless window to be dragged by the title bar area */
+      -webkit-app-region: drag;
+      user-select: none;
+    }
+
+    .popup {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: var(--white);
+      border: 1px solid var(--fog);
+      border-radius: var(--radius);
+      overflow: hidden;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    }
+
+    /* ── Title bar ── */
+    .titlebar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 12px 6px;
+      background: var(--neuro-blue);
+      color: var(--white);
+      font-size: 12px;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      flex-shrink: 0;
+    }
+
+    .titlebar__label {
+      opacity: 0.85;
+    }
+
+    .titlebar__hint {
+      opacity: 0.45;
+      font-size: 11px;
+    }
+
+    /* ── Body ── */
+    .body {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      padding: 12px;
+      gap: 8px;
+      -webkit-app-region: no-drag;
+      user-select: text;
+      overflow: hidden;
+    }
+
+    textarea, input {
+      font-family: var(--font);
+      font-size: 14px;
+      color: var(--ink);
+      background: var(--cloud);
+      border: 1px solid var(--fog);
+      border-radius: var(--radius);
+      outline: none;
+      resize: none;
+      width: 100%;
+      transition: border-color 0.15s;
+    }
+
+    textarea:focus, input:focus {
+      border-color: var(--cortex-teal);
+    }
+
+    #content {
+      flex: 1;
+      padding: 8px 10px;
+      line-height: 1.5;
+      min-height: 0;
+    }
+
+    #tags {
+      height: 32px;
+      padding: 0 10px;
+      font-size: 13px;
+    }
+
+    #tags::placeholder, #content::placeholder {
+      color: var(--slate);
+      opacity: 0.55;
+    }
+
+    /* ── Footer ── */
+    .footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 12px 10px;
+      flex-shrink: 0;
+      -webkit-app-region: no-drag;
+    }
+
+    .footer__hint {
+      font-size: 11px;
+      color: var(--slate);
+      opacity: 0.55;
+    }
+
+    .btn-save {
+      padding: 6px 20px;
+      background: var(--cortex-teal);
+      color: var(--white);
+      border: none;
+      border-radius: var(--radius);
+      font-family: var(--font);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .btn-save:hover {
+      background: var(--insight-cyan);
+    }
+
+    .btn-save:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
+
+    /* ── Error banner ── */
+    .error {
+      display: none;
+      font-size: 12px;
+      color: var(--error-red);
+      padding: 0 12px 6px;
+    }
+
+    .error.visible {
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <div class="popup">
+    <div class="titlebar">
+      <span class="titlebar__label">Neurologue — Capture</span>
+      <span class="titlebar__hint">Esc to cancel</span>
+    </div>
+
+    <div class="body">
+      <textarea
+        id="content"
+        placeholder="What are you thinking?"
+        spellcheck="true"
+        autofocus
+      ></textarea>
+      <input
+        id="tags"
+        type="text"
+        placeholder="Tags (comma-separated, optional)"
+        spellcheck="false"
+        autocomplete="off"
+      />
+    </div>
+
+    <p class="error" id="error-msg"></p>
+
+    <div class="footer">
+      <span class="footer__hint">Ctrl+Enter to save</span>
+      <button class="btn-save" id="btn-save" disabled>Save</button>
+    </div>
+  </div>
+
+  <script src="capture.js"></script>
+</body>
+</html>

--- a/src/frontend/capture.js
+++ b/src/frontend/capture.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// capture.js — renderer process script for the capture popup.
+// Runs in contextIsolation; communicates with main via window.capture (exposed by capture-preload.js).
+
+const contentEl = document.getElementById('content');
+const tagsEl    = document.getElementById('tags');
+const saveBtn   = document.getElementById('btn-save');
+const errorMsg  = document.getElementById('error-msg');
+
+// ── Enable/disable Save based on content ──────────────────────────────────
+
+contentEl.addEventListener('input', () => {
+  saveBtn.disabled = contentEl.value.trim().length === 0;
+  hideError();
+});
+
+// ── Keyboard shortcuts ────────────────────────────────────────────────────
+
+document.addEventListener('keydown', (e) => {
+  // Escape → close without saving
+  if (e.key === 'Escape') {
+    window.capture.close();
+    return;
+  }
+
+  // Ctrl+Enter → save
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    if (!saveBtn.disabled) save();
+  }
+});
+
+// ── Save button ───────────────────────────────────────────────────────────
+
+saveBtn.addEventListener('click', save);
+
+async function save() {
+  const content = contentEl.value.trim();
+  if (!content) return;
+
+  const tags = tagsEl.value
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+
+  saveBtn.disabled = true;
+
+  try {
+    const result = await window.capture.save({ content, tags });
+    if (result.ok) {
+      window.capture.close();
+    } else {
+      showError('Failed to save. Please try again.');
+      saveBtn.disabled = false;
+    }
+  } catch (err) {
+    showError('An unexpected error occurred.');
+    saveBtn.disabled = false;
+    console.error('[capture] save error:', err);
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function showError(msg) {
+  errorMsg.textContent = msg;
+  errorMsg.classList.add('visible');
+}
+
+function hideError() {
+  errorMsg.classList.remove('visible');
+}
+
+// Auto-focus the text area when the window opens
+contentEl.focus();

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,12 @@
 'use strict';
 
-const { app, BrowserWindow, globalShortcut } = require('electron');
+const { app, BrowserWindow, globalShortcut, ipcMain } = require('electron');
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
+const { createEntry } = require('./backend/db/entries');
+const { setTagsForEntry } = require('./backend/db/tags');
+const { registerCaptureHotkey } = require('./capture/hotkey');
 
 async function initialise() {
   await runMigrations();
@@ -24,9 +27,25 @@ function createMainWindow() {
   win.loadFile(path.join(__dirname, 'frontend', 'index.html'));
 }
 
+// IPC: renderer sends { content, tags } → main writes to DB
+ipcMain.handle('capture:save', async (_event, { content, tags }) => {
+  const entry = await createEntry({ content, source: 'manual', type: 'note' });
+  if (tags && tags.length > 0) {
+    await setTagsForEntry(entry.id, tags);
+  }
+  return { ok: true, id: entry.id };
+});
+
+// IPC: renderer requests close (Escape key)
+ipcMain.on('capture:close', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (win) win.close();
+});
+
 app.whenReady().then(async () => {
   await initialise();
   createMainWindow();
+  registerCaptureHotkey();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
## Summary
Implements the capture popup (Issue #2) — the global hotkey popup for frictionless thought capture.

## Changes

### `src/capture/hotkey.js`
- Registers `Ctrl+Shift+Space` as a system-wide global hotkey via Electron's `globalShortcut`
- Opens a frameless, always-on-top `BrowserWindow` (560×260) for the capture popup
- Closes popup on blur (user clicks elsewhere) or Escape
- Unregisters hotkey cleanly on app quit

### `src/frontend/capture.html` + `capture.js`
- Multiline text area (auto-focused), tag input (comma-separated)
- Save button enabled only when content is non-empty
- `Ctrl+Enter` keyboard shortcut to save; `Escape` to cancel
- Error banner for failed saves
- Brand colours applied (Neuro Blue titlebar, Cortex Teal save button)
- CSP set to `'self'` — no inline scripts

### `src/frontend/capture-preload.js`
- Exposes `window.capture.save({ content, tags })` and `window.capture.close()` via `contextBridge`

### `src/main.js`
- `ipcMain.handle('capture:save')` → writes entry + tags to SQLite via DB access layer
- `ipcMain.on('capture:close')` → closes the popup window
- Calls `registerCaptureHotkey()` after app ready

## Architecture compliance
- Capture layer makes **zero AI calls** — entry is stored as raw text only
- No embeddings generated at capture time
- All DB writes go through the access layer from Phase 1

Closes #2
