### PR TITLE
feat: Phase 3 - Background Embedding Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Ollama should be running on `http://127.0.0.1:11434` (default). The endpoint is 
 | 0 | Foundations (design, scaffolding) | ✅ Complete |
 | 1 | Core Data Layer (SQLite, LanceDB, CRUD) | ✅ Complete |
 | 2 | Capture Layer (hotkey popup) | ✅ Complete |
-| 3 | Background Worker (embeddings via Ollama) | 🔲 In progress |
+| 3 | Background Worker (embeddings via Ollama) | ✅ Complete |
 | 4 | Library Layer (timeline, search, themes UI) | 🔲 Planned |
 | 5 | Processing Layer (clustering, summaries) | 🔲 Planned |
 | 6 | Export Layer (JSON/MD/embeddings) | 🔲 Planned |
@@ -295,6 +295,39 @@ const { listEntries } = require('./src/backend/db/entries');
 listEntries().then(rows => { console.log(rows); process.exit(0); });
 "
 ```
+
+## Phase 3 — Background worker
+
+The worker starts automatically when the app runs. It polls every 10 seconds for entries without embeddings and calls Ollama to generate them.
+
+**Prerequisites:** Ollama must be running with the embedding model pulled:
+
+```bash
+ollama serve              # if not already running as a service
+ollama pull bge-small-en  # or the model set in src/config.js
+```
+
+**To validate:**
+
+1. Start Ollama and pull the model (above)
+2. Run `npm start`
+3. Capture one or more entries via `Ctrl+Shift+Space`
+4. Wait up to 10 seconds — the worker will pick up new entries
+5. Check the console output for `[worker] Embedded entry …` messages
+6. Confirm embeddings were stored:
+
+```bash
+node -e "
+const { openDb } = require('./src/backend/db/connection');
+openDb().then(db => {
+  const rows = db.prepare('SELECT entry_id, model_name FROM embeddings').all();
+  console.log(rows);
+  process.exit(0);
+});
+"
+```
+
+**If Ollama is not running:** the worker logs `[worker] Ollama not available — skipping tick` and retries on the next interval. The app continues to function normally.
 
 ---
 

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ const { initVectorStore } = require('./backend/vector/store');
 const { createEntry } = require('./backend/db/entries');
 const { setTagsForEntry } = require('./backend/db/tags');
 const { registerCaptureHotkey } = require('./capture/hotkey');
+const { startWorker, stopWorker } = require('./worker/index');
 
 async function initialise() {
   await runMigrations();
@@ -46,6 +47,7 @@ app.whenReady().then(async () => {
   await initialise();
   createMainWindow();
   registerCaptureHotkey();
+  startWorker();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -56,7 +58,9 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
   globalShortcut.unregisterAll();
+  stopWorker();
   if (process.platform !== 'darwin') {
     app.quit();
   }
 });
+

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -1,0 +1,112 @@
+'use strict';
+
+/**
+ * Background embedding worker.
+ *
+ * Polls for entries that have no embedding, generates vectors via Ollama,
+ * and stores them in both SQLite (embeddings table) and LanceDB.
+ *
+ * Runs entirely in the main process as a recurring async task.
+ * Never blocks the UI — all operations are async with await.
+ */
+
+const { listEntriesWithoutEmbedding, upsertEmbedding } = require('../backend/db/embeddings');
+const { getEntryById } = require('../backend/db/entries');
+const { upsertVector } = require('../backend/vector/store');
+const { generateEmbedding, isOllamaAvailable } = require('./ollama');
+const config = require('../config');
+
+const POLL_INTERVAL_MS = 10_000; // check every 10 seconds
+const BATCH_SIZE = 5;            // process up to 5 entries per tick
+
+let _timer = null;
+let _running = false;
+let _paused = false;
+
+// ── Core processing ───────────────────────────────────────────────────────
+
+async function processBatch() {
+  if (_paused) return;
+
+  const available = await isOllamaAvailable();
+  if (!available) {
+    console.log('[worker] Ollama not available — skipping tick');
+    return;
+  }
+
+  const entryIds = await listEntriesWithoutEmbedding();
+  if (entryIds.length === 0) return;
+
+  const batch = entryIds.slice(0, BATCH_SIZE);
+  console.log(`[worker] Processing ${batch.length} of ${entryIds.length} pending entries`);
+
+  for (const id of batch) {
+    try {
+      const entry = await getEntryById(id);
+      if (!entry) continue;
+
+      const vector = await generateEmbedding(entry.content);
+      const modelName = config.ollama.embeddingModel;
+
+      // Store in SQLite (compact BLOB backup)
+      await upsertEmbedding(id, vector, modelName);
+
+      // Store in LanceDB (primary vector index for similarity search)
+      await upsertVector(id, vector, modelName);
+
+      console.log(`[worker] Embedded entry ${id.slice(0, 8)}…`);
+    } catch (err) {
+      // Log and continue — a single failure must not stop the batch
+      console.error(`[worker] Failed to embed entry ${id.slice(0, 8)}…: ${err.message}`);
+    }
+  }
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+
+/**
+ * Start the background worker.
+ * Safe to call multiple times — will not start a second loop.
+ */
+function startWorker() {
+  if (_running) return;
+  _running = true;
+  console.log(`[worker] Started (poll interval: ${POLL_INTERVAL_MS / 1000}s, batch: ${BATCH_SIZE})`);
+
+  // Run once immediately, then on interval
+  processBatch().catch((e) => console.error('[worker] Unexpected error:', e.message));
+
+  _timer = setInterval(() => {
+    processBatch().catch((e) => console.error('[worker] Unexpected error:', e.message));
+  }, POLL_INTERVAL_MS);
+
+  // Allow Node/Electron to exit even if the timer is still armed
+  if (_timer.unref) _timer.unref();
+}
+
+/**
+ * Stop the background worker.
+ */
+function stopWorker() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+  _running = false;
+  console.log('[worker] Stopped');
+}
+
+/**
+ * Pause/resume processing (Ollama or UI preference).
+ */
+function pauseWorker() { _paused = true;  console.log('[worker] Paused');  }
+function resumeWorker() { _paused = false; console.log('[worker] Resumed'); }
+
+/**
+ * Returns current worker state — useful for a status UI.
+ */
+function workerStatus() {
+  return { running: _running, paused: _paused };
+}
+
+module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus };

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Minimal Ollama HTTP client.
+ *
+ * Uses Node's built-in `http` module — no extra dependencies.
+ * All requests go to the base URL defined in src/config.js.
+ */
+
+const http = require('http');
+const config = require('../config');
+
+/**
+ * Send a JSON request to the Ollama API.
+ * @param {string} path  e.g. '/api/embeddings'
+ * @param {object} body  JSON-serialisable request body
+ * @returns {Promise<object>}
+ */
+function ollamaRequest(path, body) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const url = new URL(config.ollama.baseUrl);
+
+    const options = {
+      hostname: url.hostname,
+      port: url.port || 11434,
+      path,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+
+    const req = http.request(options, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        try {
+          const text = Buffer.concat(chunks).toString('utf8');
+          const json = JSON.parse(text);
+          if (res.statusCode >= 400) {
+            reject(new Error(`Ollama ${res.statusCode}: ${json.error || text}`));
+          } else {
+            resolve(json);
+          }
+        } catch (e) {
+          reject(new Error(`Ollama response parse error: ${e.message}`));
+        }
+      });
+    });
+
+    req.setTimeout(30000, () => {
+      req.destroy(new Error('Ollama request timed out after 30s'));
+    });
+
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+/**
+ * Generate an embedding vector for a piece of text.
+ * @param {string} text
+ * @returns {Promise<Float32Array>}
+ */
+async function generateEmbedding(text) {
+  const response = await ollamaRequest('/api/embeddings', {
+    model: config.ollama.embeddingModel,
+    prompt: text,
+  });
+
+  if (!Array.isArray(response.embedding)) {
+    throw new Error('Ollama returned no embedding array');
+  }
+
+  return new Float32Array(response.embedding);
+}
+
+/**
+ * Check whether Ollama is reachable and the embedding model is available.
+ * @returns {Promise<boolean>}
+ */
+function isOllamaAvailable() {
+  return new Promise((resolve) => {
+    const url = new URL(config.ollama.baseUrl);
+    const req = http.request(
+      { hostname: url.hostname, port: url.port || 11434, path: '/api/tags', method: 'GET' },
+      (res) => {
+        res.resume(); // drain
+        resolve(res.statusCode < 500);
+      }
+    );
+    req.setTimeout(3000, () => { req.destroy(); resolve(false); });
+    req.on('error', () => resolve(false));
+    req.end();
+  });
+}
+
+module.exports = { generateEmbedding, isOllamaAvailable };


### PR DESCRIPTION
## Summary

Implements the background worker that automatically generates and stores embeddings for captured entries.

## Changes

- **src/worker/ollama.js** — Minimal Ollama HTTP client (Node built-in \http\, no extra deps)
  - \generateEmbedding(text)\ → \Float32Array\ via \ge-small-en\
  - \isOllamaAvailable()\ with 3s timeout
- **\src/worker/index.js\** — Background polling worker
  - Polls every 10 seconds, batch size 5
  - Checks Ollama availability before each tick — skips gracefully if not running
  - Stores embeddings in both SQLite (\embeddings\ table) and LanceDB (\entry_embeddings\)
  - Per-entry errors are caught and logged; the batch continues
  - \_timer.unref()\ allows clean app exit
- **\src/main.js\** — Wired up: \startWorker()\ on app ready, \stopWorker()\ on quit
- **\README.md\** — Phase 3 marked complete, validation steps added

## Validation

See README Phase 3 section. Requires Ollama running with \ge-small-en\ pulled.

Closes #3