### PR TITLE
test: Add worker unit tests (ollama + background worker)

### DIFF
--- a/tests/unit/worker/ollama.test.js
+++ b/tests/unit/worker/ollama.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * Tests for src/worker/ollama.js.
+ *
+ * All HTTP calls are intercepted via jest.mock('http') — no real Ollama needed.
+ */
+
+jest.mock('http', () => ({ request: jest.fn() }));
+const http = require('http');
+const { generateEmbedding, isOllamaAvailable } = require('../../../src/worker/ollama');
+
+// ---------------------------------------------------------------------------
+// Helpers to build fake HTTP request/response pairs
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulate a successful HTTP response.
+ * `end()` on the returned req triggers the response callback synchronously,
+ * fires data, then end — matching how Node streams work in tests.
+ */
+function mockHttpResponse(statusCode, body) {
+  http.request.mockImplementation((_opts, callback) => {
+    const resHandlers = {};
+    const mockRes = {
+      statusCode,
+      resume: jest.fn(),
+      on: jest.fn((event, handler) => { resHandlers[event] = handler; }),
+    };
+    return {
+      setTimeout: jest.fn(),
+      on: jest.fn(),
+      write: jest.fn(),
+      end: jest.fn(() => {
+        callback(mockRes);
+        if (resHandlers.data) {
+          resHandlers.data(Buffer.from(typeof body === 'string' ? body : JSON.stringify(body)));
+        }
+        if (resHandlers.end) resHandlers.end();
+      }),
+    };
+  });
+}
+
+/** Simulate a connection-level error (ECONNREFUSED etc.) */
+function mockHttpError(message) {
+  http.request.mockImplementation(() => {
+    const errHandlers = {};
+    return {
+      setTimeout: jest.fn(),
+      on: jest.fn((event, handler) => { errHandlers[event] = handler; }),
+      write: jest.fn(),
+      end: jest.fn(() => {
+        if (errHandlers.error) errHandlers.error(new Error(message));
+      }),
+    };
+  });
+}
+
+/** Simulate req.setTimeout firing (timeout before response). */
+function mockHttpTimeout() {
+  http.request.mockImplementation(() => {
+    let timeoutCb;
+    const mockReq = {
+      setTimeout: jest.fn((_ms, cb) => { timeoutCb = cb; }),
+      on: jest.fn(),
+      write: jest.fn(),
+      destroy: jest.fn(),
+      end: jest.fn(() => {
+        // Fire the timeout immediately instead of after 30s
+        if (timeoutCb) timeoutCb();
+      }),
+    };
+    return mockReq;
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// generateEmbedding
+// ---------------------------------------------------------------------------
+
+describe('generateEmbedding', () => {
+  test('returns a Float32Array on success', async () => {
+    mockHttpResponse(200, { embedding: [0.1, 0.2, 0.3] });
+    const result = await generateEmbedding('test text');
+    expect(result).toBeInstanceOf(Float32Array);
+    expect(result.length).toBe(3);
+    expect(result[0]).toBeCloseTo(0.1, 5);
+    expect(result[2]).toBeCloseTo(0.3, 5);
+  });
+
+  test('throws when response contains no embedding array', async () => {
+    mockHttpResponse(200, { message: 'ok but no embedding' });
+    await expect(generateEmbedding('test')).rejects.toThrow('no embedding array');
+  });
+
+  test('throws on HTTP 4xx response', async () => {
+    mockHttpResponse(400, { error: 'model not found' });
+    await expect(generateEmbedding('test')).rejects.toThrow('400');
+  });
+
+  test('throws on HTTP 5xx response', async () => {
+    mockHttpResponse(500, { error: 'internal server error' });
+    await expect(generateEmbedding('test')).rejects.toThrow('500');
+  });
+
+  test('throws on connection error', async () => {
+    mockHttpError('connect ECONNREFUSED');
+    await expect(generateEmbedding('test')).rejects.toThrow('ECONNREFUSED');
+  });
+
+  test('throws on malformed JSON response', async () => {
+    mockHttpResponse(200, 'not-json{{{');
+    await expect(generateEmbedding('test')).rejects.toThrow(/parse error/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOllamaAvailable
+// ---------------------------------------------------------------------------
+
+describe('isOllamaAvailable', () => {
+  test('returns true when Ollama responds with 2xx', async () => {
+    mockHttpResponse(200, { models: [] });
+    const result = await isOllamaAvailable();
+    expect(result).toBe(true);
+  });
+
+  test('returns true on non-5xx status (e.g. 404)', async () => {
+    // /api/tags returning 404 still means the server is up
+    mockHttpResponse(404, {});
+    const result = await isOllamaAvailable();
+    expect(result).toBe(true);
+  });
+
+  test('returns false on connection error', async () => {
+    mockHttpError('connect ECONNREFUSED');
+    const result = await isOllamaAvailable();
+    expect(result).toBe(false);
+  });
+
+  test('returns false when request times out', async () => {
+    mockHttpTimeout();
+    const result = await isOllamaAvailable();
+    expect(result).toBe(false);
+  });
+});

--- a/tests/unit/worker/worker.test.js
+++ b/tests/unit/worker/worker.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+/**
+ * Tests for src/worker/index.js.
+ *
+ * All external dependencies are mocked — no DB, no Ollama, no LanceDB.
+ * Module-level state (_running, _paused) is reset by calling stopWorker()
+ * and resumeWorker() in afterEach.
+ */
+
+// Mock all external dependencies before any require
+jest.mock('../../../src/backend/db/embeddings');
+jest.mock('../../../src/backend/db/entries');
+jest.mock('../../../src/backend/vector/store');
+jest.mock('../../../src/worker/ollama');
+
+const mockEmbeddings = require('../../../src/backend/db/embeddings');
+const mockEntries   = require('../../../src/backend/db/entries');
+const mockStore     = require('../../../src/backend/vector/store');
+const mockOllama    = require('../../../src/worker/ollama');
+
+// Flush all pending promises + microtasks (multiple rounds for chained awaits)
+async function flushAsync() {
+  for (let i = 0; i < 8; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+}
+
+function makeVector(size = 384) {
+  return new Float32Array(size).fill(0.5);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Safe defaults — Ollama up, no pending entries
+  mockOllama.isOllamaAvailable.mockResolvedValue(true);
+  mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue([]);
+  mockEmbeddings.upsertEmbedding.mockResolvedValue(undefined);
+  mockEntries.getEntryById.mockResolvedValue(undefined);
+  mockStore.upsertVector.mockResolvedValue(undefined);
+  mockOllama.generateEmbedding.mockResolvedValue(makeVector());
+});
+
+afterEach(() => {
+  const { stopWorker, resumeWorker } = require('../../../src/worker/index');
+  stopWorker();
+  resumeWorker(); // reset _paused in case a test set it
+});
+
+// ---------------------------------------------------------------------------
+// processBatch behaviour (tested via startWorker's immediate call)
+// ---------------------------------------------------------------------------
+
+describe('processBatch', () => {
+  test('skips processing when Ollama is unavailable', async () => {
+    mockOllama.isOllamaAvailable.mockResolvedValue(false);
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+    expect(mockEmbeddings.listEntriesWithoutEmbedding).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when there are no pending entries', async () => {
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue([]);
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+    expect(mockOllama.generateEmbedding).not.toHaveBeenCalled();
+  });
+
+  test('embeds each pending entry and stores in SQLite and LanceDB', async () => {
+    const ids = ['id-aaa', 'id-bbb'];
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue(ids);
+    mockEntries.getEntryById
+      .mockResolvedValueOnce({ id: 'id-aaa', content: 'first thought' })
+      .mockResolvedValueOnce({ id: 'id-bbb', content: 'second thought' });
+    const vec = makeVector();
+    mockOllama.generateEmbedding.mockResolvedValue(vec);
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    expect(mockOllama.generateEmbedding).toHaveBeenCalledTimes(2);
+    expect(mockOllama.generateEmbedding).toHaveBeenCalledWith('first thought');
+    expect(mockOllama.generateEmbedding).toHaveBeenCalledWith('second thought');
+
+    expect(mockEmbeddings.upsertEmbedding).toHaveBeenCalledTimes(2);
+    expect(mockStore.upsertVector).toHaveBeenCalledTimes(2);
+  });
+
+  test('respects BATCH_SIZE — processes at most 5 entries per tick', async () => {
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g']; // 7 pending
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue(ids);
+    mockEntries.getEntryById.mockResolvedValue({ id: 'x', content: 'content' });
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    // Only first 5 should be processed
+    expect(mockOllama.generateEmbedding).toHaveBeenCalledTimes(5);
+  });
+
+  test('skips entries that are not found in the DB', async () => {
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue(['ghost-id']);
+    mockEntries.getEntryById.mockResolvedValue(undefined); // not found
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    expect(mockOllama.generateEmbedding).not.toHaveBeenCalled();
+  });
+
+  test('catches a per-entry error and continues processing remaining entries', async () => {
+    const ids = ['fail-id', 'ok-id'];
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue(ids);
+    mockEntries.getEntryById
+      .mockResolvedValueOnce({ id: 'fail-id', content: 'bad entry' })
+      .mockResolvedValueOnce({ id: 'ok-id',   content: 'good entry' });
+    mockOllama.generateEmbedding
+      .mockRejectedValueOnce(new Error('embedding failed'))
+      .mockResolvedValueOnce(makeVector());
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    // Second entry should still be processed despite first failing
+    expect(mockEmbeddings.upsertEmbedding).toHaveBeenCalledTimes(1);
+    expect(mockStore.upsertVector).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips processing when worker is paused', async () => {
+    const { startWorker, pauseWorker } = require('../../../src/worker/index');
+    pauseWorker();
+    startWorker();
+    await flushAsync();
+
+    expect(mockOllama.isOllamaAvailable).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle: startWorker / stopWorker
+// ---------------------------------------------------------------------------
+
+describe('startWorker / stopWorker', () => {
+  test('startWorker sets running to true', () => {
+    const { startWorker, workerStatus } = require('../../../src/worker/index');
+    startWorker();
+    expect(workerStatus().running).toBe(true);
+  });
+
+  test('startWorker is a no-op if already running', async () => {
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    startWorker(); // second call
+    await flushAsync();
+    // processBatch should only have been triggered once (the initial immediate call)
+    expect(mockOllama.isOllamaAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  test('stopWorker sets running to false', () => {
+    const { startWorker, stopWorker, workerStatus } = require('../../../src/worker/index');
+    startWorker();
+    stopWorker();
+    expect(workerStatus().running).toBe(false);
+  });
+
+  test('stopWorker can be called when not running without error', () => {
+    const { stopWorker } = require('../../../src/worker/index');
+    expect(() => stopWorker()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pauseWorker / resumeWorker
+// ---------------------------------------------------------------------------
+
+describe('pauseWorker / resumeWorker', () => {
+  test('pauseWorker sets paused to true', () => {
+    const { pauseWorker, workerStatus } = require('../../../src/worker/index');
+    pauseWorker();
+    expect(workerStatus().paused).toBe(true);
+  });
+
+  test('resumeWorker sets paused to false', () => {
+    const { pauseWorker, resumeWorker, workerStatus } = require('../../../src/worker/index');
+    pauseWorker();
+    resumeWorker();
+    expect(workerStatus().paused).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workerStatus
+// ---------------------------------------------------------------------------
+
+describe('workerStatus', () => {
+  test('returns running: false and paused: false initially', () => {
+    const { workerStatus } = require('../../../src/worker/index');
+    const status = workerStatus();
+    expect(status.running).toBe(false);
+    expect(status.paused).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #13. Adds unit tests for the worker layer now that PR #11 has merged.

## New tests

### \	ests/unit/worker/ollama.test.js\ — 10 tests
\generateEmbedding\:
- Returns \Float32Array\ on success
- Throws when response has no \embedding\ array
- Throws on HTTP 4xx / 5xx
- Throws on connection error (ECONNREFUSED)
- Throws on malformed JSON response

\isOllamaAvailable\:
- Returns \	rue\ on 2xx response
- Returns \	rue\ on non-5xx (e.g. 404 — server is up)
- Returns \alse\ on connection error
- Returns \alse\ when request times out

The \http\ module is fully mocked via \jest.mock('http', factory)\ — no real network calls.

### \	ests/unit/worker/worker.test.js\ — 14 tests
\processBatch\ (via \startWorker\):
- Skips when Ollama unavailable
- Skips when no pending entries
- Embeds each entry and stores in SQLite + LanceDB
- Respects \BATCH_SIZE = 5\
- Skips entries not found in the DB
- Catches per-entry errors without stopping the batch
- Skips when worker is paused

Lifecycle:
- \startWorker\ / \stopWorker\ toggle the running flag
- \startWorker\ is a no-op if already running
- \stopWorker\ when not running does not throw
- \pauseWorker\ / \esumeWorker\ toggle the paused flag
- \workerStatus\ reports initial state

All dependencies mocked (\embeddings\, \entries\, \ector/store\, \ollama\). No DB, no Ollama, no LanceDB required.

## Result
**62 tests, 7 suites — all passing.**

Closes #14