### PR TITLE
feat: Phase 4 — Library Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Ollama should be running on `http://127.0.0.1:11434` (default). The endpoint is 
 | 1 | Core Data Layer (SQLite, LanceDB, CRUD) | ✅ Complete |
 | 2 | Capture Layer (hotkey popup) | ✅ Complete |
 | 3 | Background Worker (embeddings via Ollama) | ✅ Complete |
-| 4 | Library Layer (timeline, search, themes UI) | 🔲 Planned |
+| 4 | Library Layer (timeline, search, themes UI) | ✅ Complete |
 | 5 | Processing Layer (clustering, summaries) | 🔲 Planned |
 | 6 | Export Layer (JSON/MD/embeddings) | 🔲 Planned |
 
@@ -328,6 +328,29 @@ openDb().then(db => {
 ```
 
 **If Ollama is not running:** the worker logs `[worker] Ollama not available — skipping tick` and retries on the next interval. The app continues to function normally.
+
+## Phase 4 — Library Layer
+
+The library window opens automatically at startup and shows a 3-column layout: tag sidebar | entry timeline | entry detail.
+
+**To validate:**
+
+1. Run `npm start`
+2. The library window opens — your captured entries appear in the timeline (newest first)
+3. **Text search:** type in the search bar, results filter in real-time (300ms debounce)
+4. **Semantic search:** click **Semantic** mode button, type a query — if Ollama is running it returns nearest-neighbour results; otherwise a notice banner appears and text results are shown as fallback
+5. **Tag filter:** click a tag in the left sidebar — the timeline shows only entries with that tag
+6. **Entry detail:** click any entry card — the right panel shows full text, date, source, and tags
+7. **Tag navigation:** clicking a tag pill in the detail panel applies that tag as a filter
+
+**To confirm tag indexing:**
+
+```bash
+node -e "
+const { listTags } = require('./src/backend/db/tags');
+listTags().then(tags => { console.log(tags); process.exit(0); });
+"
+```
 
 ---
 

--- a/src/backend/db/search.js
+++ b/src/backend/db/search.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { openDb } = require('./connection');
+
+/**
+ * Full-text search over entry content using SQLite LIKE.
+ * Case-insensitive. Returns entries whose content contains the query string.
+ *
+ * @param {string} query
+ * @param {{ limit?: number, offset?: number }} options
+ * @returns {Promise<object[]>}
+ */
+async function searchEntriesText(query, { limit = 50, offset = 0 } = {}) {
+  const db = await openDb();
+  const pattern = `%${query}%`;
+  return db
+    .prepare(`
+      SELECT * FROM entries
+      WHERE content LIKE ?
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    `)
+    .all(pattern, limit, offset);
+}
+
+/**
+ * List entries that belong to a given tag name.
+ *
+ * @param {string} tagName
+ * @param {{ limit?: number, offset?: number }} options
+ * @returns {Promise<object[]>}
+ */
+async function listEntriesByTag(tagName, { limit = 100, offset = 0 } = {}) {
+  const db = await openDb();
+  return db
+    .prepare(`
+      SELECT e.* FROM entries e
+      INNER JOIN entry_tags et ON et.entry_id = e.id
+      INNER JOIN tags t ON t.id = et.tag_id
+      WHERE t.name = ?
+      ORDER BY e.created_at DESC
+      LIMIT ? OFFSET ?
+    `)
+    .all(tagName.trim().toLowerCase(), limit, offset);
+}
+
+/**
+ * Get a single entry with its tags.
+ * Returns { ...entry, tags: [{ id, name }] } or undefined.
+ *
+ * @param {string} id
+ * @returns {Promise<object|undefined>}
+ */
+async function getEntryWithTags(id) {
+  const db = await openDb();
+  const entry = db.prepare('SELECT * FROM entries WHERE id = ?').get(id);
+  if (!entry) return undefined;
+
+  const tags = db
+    .prepare(`
+      SELECT t.id, t.name FROM tags t
+      INNER JOIN entry_tags et ON et.tag_id = t.id
+      WHERE et.entry_id = ?
+      ORDER BY t.name ASC
+    `)
+    .all(id);
+
+  return { ...entry, tags };
+}
+
+module.exports = { searchEntriesText, listEntriesByTag, getEntryWithTags };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -3,9 +3,67 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; style-src 'self'; script-src 'self'" />
   <title>Neurologue</title>
+  <link rel="stylesheet" href="library.css" />
 </head>
 <body>
-  <p>Neurologue — library view coming soon.</p>
+  <div id="app">
+
+    <!-- ── Toolbar ─────────────────────────────────────────────────── -->
+    <div id="toolbar">
+      <span class="logo">Neurologue</span>
+      <input id="search-input" type="text" placeholder="Search entries…" autocomplete="off" />
+      <div id="search-mode">
+        <button id="btn-text" class="mode-btn active">Text</button>
+        <button id="btn-semantic" class="mode-btn">Semantic</button>
+      </div>
+      <span id="entry-count"></span>
+    </div>
+
+    <!-- ── Semantic notice ─────────────────────────────────────────── -->
+    <div id="semantic-notice">
+      Ollama not available — showing text results instead
+    </div>
+
+    <!-- ── Body ────────────────────────────────────────────────────── -->
+    <div id="body">
+
+      <!-- Sidebar: tags -->
+      <div id="sidebar">
+        <div id="sidebar-header">Tags</div>
+        <div id="tag-all">All entries</div>
+        <div id="tag-list"></div>
+      </div>
+
+      <!-- Timeline: entry list -->
+      <div id="timeline">
+        <div id="timeline-list"></div>
+        <button id="load-more-btn">Load more</button>
+      </div>
+
+      <!-- Detail panel -->
+      <div id="detail">
+        <div id="detail-placeholder">Select an entry to view</div>
+        <div id="detail-content">
+          <div id="detail-header">
+            <div id="detail-date"></div>
+            <div id="detail-source"></div>
+          </div>
+          <div id="detail-body">
+            <div id="detail-text"></div>
+            <div id="detail-tags-section">
+              <div id="detail-tags-label">Tags</div>
+              <div id="detail-tags"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /#body -->
+  </div><!-- /#app -->
+
+  <script src="library.js"></script>
 </body>
 </html>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1,0 +1,330 @@
+/* ── Reset / base ─────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --neuro-blue:   #1C2A3A;
+  --cortex-teal:  #2AA6A1;
+  --teal-hover:   #238c88;
+  --synapse-gold: #C9A84C;
+  --bg:           #0F1923;
+  --surface:      #192534;
+  --surface2:     #1f2f40;
+  --border:       #2a3d52;
+  --text:         #E8EFF5;
+  --text-muted:   #7a9ab5;
+  --text-dim:     #4a6a85;
+  --danger:       #e05c5c;
+  --radius:       6px;
+  --sidebar-w:    200px;
+  --detail-w:     360px;
+}
+
+html, body {
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
+/* ── App shell ────────────────────────────────────────────────────────── */
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* ── Toolbar ──────────────────────────────────────────────────────────── */
+#toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--neuro-blue);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+#toolbar .logo {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--cortex-teal);
+  letter-spacing: 0.04em;
+  margin-right: 8px;
+  white-space: nowrap;
+}
+
+#search-input {
+  flex: 1;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 6px 10px;
+  font-size: 13px;
+  outline: none;
+}
+#search-input:focus { border-color: var(--cortex-teal); }
+#search-input::placeholder { color: var(--text-dim); }
+
+#search-mode {
+  display: flex;
+  gap: 4px;
+}
+
+.mode-btn {
+  padding: 5px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.mode-btn.active {
+  background: var(--cortex-teal);
+  border-color: var(--cortex-teal);
+  color: #fff;
+}
+.mode-btn:hover:not(.active) { border-color: var(--cortex-teal); color: var(--text); }
+
+#entry-count {
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+/* ── Three-column body ────────────────────────────────────────────────── */
+#body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ── Sidebar ──────────────────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar-w);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+#sidebar-header {
+  padding: 10px 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+#tag-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0 8px;
+}
+
+.tag-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 12px;
+  cursor: pointer;
+  border-radius: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  gap: 6px;
+}
+.tag-item:hover { background: var(--surface2); color: var(--text); }
+.tag-item.active { background: var(--surface2); color: var(--cortex-teal); }
+.tag-item .tag-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tag-item .tag-clear {
+  font-size: 10px;
+  color: var(--text-dim);
+  padding: 1px 4px;
+  border-radius: 3px;
+  display: none;
+}
+.tag-item.active .tag-clear { display: inline; }
+.tag-item.active .tag-clear:hover { background: var(--danger); color: #fff; }
+
+.tag-all {
+  padding: 5px 12px 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.tag-all:hover { color: var(--text); }
+
+/* ── Timeline ─────────────────────────────────────────────────────────── */
+#timeline {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+#timeline-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+}
+
+.entry-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.entry-card:hover { border-color: var(--cortex-teal); }
+.entry-card.selected { border-color: var(--cortex-teal); background: var(--surface2); }
+
+.entry-card .entry-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.entry-card .entry-date { font-size: 11px; color: var(--text-dim); }
+.entry-card .entry-score { font-size: 11px; color: var(--synapse-gold); }
+
+.entry-card .entry-preview {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+.entry-card .entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+.tag-pill {
+  font-size: 11px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: 12px;
+  padding: 1px 7px;
+}
+
+.empty-state {
+  padding: 48px 24px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.8;
+}
+.empty-state strong { color: var(--text-muted); display: block; margin-bottom: 4px; }
+
+/* ── Load more ────────────────────────────────────────────────────────── */
+#load-more-btn {
+  display: none;
+  margin: 4px 12px 12px;
+  padding: 7px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: center;
+  width: calc(100% - 24px);
+}
+#load-more-btn:hover { border-color: var(--cortex-teal); color: var(--text); }
+
+/* ── Detail panel ─────────────────────────────────────────────────────── */
+#detail {
+  width: var(--detail-w);
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+#detail-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+#detail-content {
+  display: none;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+}
+
+#detail-header {
+  padding: 12px 16px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+#detail-date { font-size: 11px; color: var(--text-dim); margin-bottom: 4px; }
+#detail-source { font-size: 11px; color: var(--text-dim); }
+
+#detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+#detail-text {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#detail-tags-section {
+  margin-top: 16px;
+}
+#detail-tags-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+}
+#detail-tags { display: flex; flex-wrap: wrap; gap: 5px; }
+
+/* ── Scrollbar styling ────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+/* ── Semantic search unavailable banner ───────────────────────────────── */
+#semantic-notice {
+  display: none;
+  background: var(--surface2);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 16px;
+  font-size: 12px;
+  color: var(--synapse-gold);
+  text-align: center;
+}

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1,0 +1,265 @@
+'use strict';
+/* global window, document */
+
+// ── State ──────────────────────────────────────────────────────────────────
+const PAGE_SIZE = 50;
+let _state = {
+  entries: [],
+  offset: 0,
+  hasMore: false,
+  query: '',
+  mode: 'text',      // 'text' | 'semantic'
+  tagFilter: null,   // tag name string or null
+  selectedId: null,
+};
+
+// ── DOM refs ───────────────────────────────────────────────────────────────
+const searchInput   = document.getElementById('search-input');
+const btnText       = document.getElementById('btn-text');
+const btnSemantic   = document.getElementById('btn-semantic');
+const entryCount    = document.getElementById('entry-count');
+const timelineList  = document.getElementById('timeline-list');
+const loadMoreBtn   = document.getElementById('load-more-btn');
+const tagList       = document.getElementById('tag-list');
+const tagAll        = document.getElementById('tag-all');
+const detailPlaceholder = document.getElementById('detail-placeholder');
+const detailContent = document.getElementById('detail-content');
+const detailDate    = document.getElementById('detail-date');
+const detailSource  = document.getElementById('detail-source');
+const detailText    = document.getElementById('detail-text');
+const detailTags    = document.getElementById('detail-tags');
+const semanticNotice = document.getElementById('semantic-notice');
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function debounce(fn, ms) {
+  let t;
+  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+}
+
+// ── Render helpers ─────────────────────────────────────────────────────────
+
+function renderEntryCard(entry) {
+  const card = document.createElement('div');
+  card.className = 'entry-card' + (entry.id === _state.selectedId ? ' selected' : '');
+  card.dataset.id = entry.id;
+
+  const meta = document.createElement('div');
+  meta.className = 'entry-meta';
+
+  const date = document.createElement('span');
+  date.className = 'entry-date';
+  date.textContent = formatDate(entry.created_at);
+  meta.appendChild(date);
+
+  if (entry._distance !== undefined) {
+    const score = document.createElement('span');
+    score.className = 'entry-score';
+    score.textContent = `${(1 - entry._distance).toFixed(2)} match`;
+    meta.appendChild(score);
+  }
+  card.appendChild(meta);
+
+  const preview = document.createElement('div');
+  preview.className = 'entry-preview';
+  preview.textContent = entry.content;
+  card.appendChild(preview);
+
+  if (entry.tags && entry.tags.length > 0) {
+    const tagRow = document.createElement('div');
+    tagRow.className = 'entry-tags';
+    entry.tags.slice(0, 6).forEach((t) => {
+      const pill = document.createElement('span');
+      pill.className = 'tag-pill';
+      pill.textContent = t.name || t;
+      tagRow.appendChild(pill);
+    });
+    card.appendChild(tagRow);
+  }
+
+  card.addEventListener('click', () => selectEntry(entry.id));
+  return card;
+}
+
+function renderTimeline(entries, append = false) {
+  if (!append) timelineList.innerHTML = '';
+
+  if (entries.length === 0 && !append) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = _state.query
+      ? `<strong>No results</strong>Try a different search term`
+      : `<strong>No entries yet</strong>Press Ctrl+Shift+Space to capture your first thought`;
+    timelineList.appendChild(empty);
+  } else {
+    entries.forEach((e) => timelineList.appendChild(renderEntryCard(e)));
+  }
+}
+
+function updateCount(total) {
+  entryCount.textContent = total === 1 ? '1 entry' : `${total} entries`;
+}
+
+// ── Data loading ───────────────────────────────────────────────────────────
+
+async function loadEntries(append = false) {
+  const offset = append ? _state.offset : 0;
+  let entries = [];
+
+  try {
+    if (_state.mode === 'semantic' && _state.query.trim()) {
+      const result = await window.neurologue.searchSemantic(_state.query);
+      if (!result.ok) {
+        semanticNotice.style.display = 'block';
+        // Fall back to text search
+        entries = await window.neurologue.searchText(_state.query, { limit: PAGE_SIZE, offset });
+      } else {
+        semanticNotice.style.display = 'none';
+        entries = result.results;
+      }
+      _state.hasMore = false;
+      loadMoreBtn.style.display = 'none';
+    } else if (_state.query.trim()) {
+      entries = await window.neurologue.searchText(_state.query, { limit: PAGE_SIZE, offset });
+      _state.hasMore = entries.length === PAGE_SIZE;
+    } else {
+      entries = await window.neurologue.list({ limit: PAGE_SIZE, offset, tag: _state.tagFilter });
+      _state.hasMore = entries.length === PAGE_SIZE;
+    }
+
+    if (append) {
+      _state.entries = [..._state.entries, ...entries];
+    } else {
+      _state.entries = entries;
+      _state.offset = 0;
+    }
+    _state.offset += entries.length;
+
+    renderTimeline(entries, append);
+    updateCount(_state.entries.length + (_state.hasMore ? '+' : ''));
+    loadMoreBtn.style.display = _state.hasMore ? 'block' : 'none';
+  } catch (err) {
+    console.error('[library] loadEntries failed:', err);
+  }
+}
+
+async function loadTags() {
+  try {
+    const tags = await window.neurologue.listTags();
+    tagList.innerHTML = '';
+    tags.forEach((tag) => {
+      const item = document.createElement('div');
+      item.className = 'tag-item' + (tag.name === _state.tagFilter ? ' active' : '');
+      item.innerHTML = `<span class="tag-name">${tag.name}</span><span class="tag-clear" title="Clear filter">✕</span>`;
+      item.querySelector('.tag-name').addEventListener('click', () => applyTagFilter(tag.name));
+      item.querySelector('.tag-clear').addEventListener('click', (e) => {
+        e.stopPropagation();
+        applyTagFilter(null);
+      });
+      tagList.appendChild(item);
+    });
+  } catch (err) {
+    console.error('[library] loadTags failed:', err);
+  }
+}
+
+function applyTagFilter(tagName) {
+  _state.tagFilter = tagName;
+  _state.selectedId = null;
+  // Update sidebar active state
+  document.querySelectorAll('.tag-item').forEach((el) => {
+    el.classList.toggle('active', el.querySelector('.tag-name').textContent === tagName);
+  });
+  loadEntries();
+  clearDetail();
+}
+
+// ── Entry detail ───────────────────────────────────────────────────────────
+
+async function selectEntry(id) {
+  _state.selectedId = id;
+
+  // Update card selection highlight
+  document.querySelectorAll('.entry-card').forEach((c) => {
+    c.classList.toggle('selected', c.dataset.id === id);
+  });
+
+  try {
+    const entry = await window.neurologue.getEntry(id);
+    if (!entry) return;
+
+    detailDate.textContent = formatDate(entry.created_at);
+    detailSource.textContent = `Source: ${entry.source || 'manual'}  ·  Type: ${entry.type || 'note'}`;
+    detailText.textContent = entry.content;
+
+    detailTags.innerHTML = '';
+    if (entry.tags && entry.tags.length > 0) {
+      entry.tags.forEach((t) => {
+        const pill = document.createElement('span');
+        pill.className = 'tag-pill';
+        pill.style.cursor = 'pointer';
+        pill.textContent = t.name;
+        pill.addEventListener('click', () => applyTagFilter(t.name));
+        detailTags.appendChild(pill);
+      });
+      document.getElementById('detail-tags-section').style.display = 'block';
+    } else {
+      document.getElementById('detail-tags-section').style.display = 'none';
+    }
+
+    detailPlaceholder.style.display = 'none';
+    detailContent.style.display = 'flex';
+  } catch (err) {
+    console.error('[library] selectEntry failed:', err);
+  }
+}
+
+function clearDetail() {
+  _state.selectedId = null;
+  detailPlaceholder.style.display = 'flex';
+  detailContent.style.display = 'none';
+}
+
+// ── Search mode toggle ─────────────────────────────────────────────────────
+
+function setMode(mode) {
+  _state.mode = mode;
+  btnText.classList.toggle('active', mode === 'text');
+  btnSemantic.classList.toggle('active', mode === 'semantic');
+  if (_state.query.trim()) loadEntries();
+}
+
+// ── Event wiring ───────────────────────────────────────────────────────────
+
+const debouncedSearch = debounce(() => {
+  _state.query = searchInput.value;
+  _state.tagFilter = null;
+  document.querySelectorAll('.tag-item').forEach((el) => el.classList.remove('active'));
+  loadEntries();
+}, 300);
+
+searchInput.addEventListener('input', debouncedSearch);
+searchInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') { searchInput.value = ''; debouncedSearch(); }
+});
+
+btnText.addEventListener('click', () => setMode('text'));
+btnSemantic.addEventListener('click', () => setMode('semantic'));
+tagAll.addEventListener('click', () => applyTagFilter(null));
+loadMoreBtn.addEventListener('click', () => loadEntries(true));
+
+// ── Init ───────────────────────────────────────────────────────────────────
+
+(async () => {
+  await loadTags();
+  await loadEntries();
+})();

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -1,9 +1,14 @@
 'use strict';
-// Preload script — runs in a sandboxed context between main and renderer.
-// Exposes a safe API to the renderer via contextBridge (to be expanded in Phase 2+).
-
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('neurologue', {
   version: '0.1.0',
+
+  // ── Library ──────────────────────────────────────────────────────────────
+  list: (opts) => ipcRenderer.invoke('library:list', opts),
+  searchText: (query, opts) => ipcRenderer.invoke('library:search-text', { query, ...opts }),
+  searchSemantic: (query, opts) => ipcRenderer.invoke('library:search-semantic', { query, ...opts }),
+  getEntry: (id) => ipcRenderer.invoke('library:get-entry', { id }),
+  listTags: () => ipcRenderer.invoke('library:list-tags'),
 });
+

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,11 @@ const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
 const { createEntry } = require('./backend/db/entries');
 const { setTagsForEntry } = require('./backend/db/tags');
+const { listTags } = require('./backend/db/tags');
+const { listEntries } = require('./backend/db/entries');
+const { searchEntriesText, listEntriesByTag, getEntryWithTags } = require('./backend/db/search');
+const { searchNearest } = require('./backend/vector/store');
+const { generateEmbedding, isOllamaAvailable } = require('./worker/ollama');
 const { registerCaptureHotkey } = require('./capture/hotkey');
 const { startWorker, stopWorker } = require('./worker/index');
 
@@ -41,6 +46,46 @@ ipcMain.handle('capture:save', async (_event, { content, tags }) => {
 ipcMain.on('capture:close', (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (win) win.close();
+});
+
+// ── Library IPC ──────────────────────────────────────────────────────────────
+
+// List entries (paginated, optional tag filter)
+ipcMain.handle('library:list', async (_event, { limit = 50, offset = 0, tag } = {}) => {
+  if (tag) return listEntriesByTag(tag, { limit, offset });
+  return listEntries({ limit, offset });
+});
+
+// Full-text search
+ipcMain.handle('library:search-text', async (_event, { query, limit = 50, offset = 0 }) => {
+  if (!query || !query.trim()) return listEntries({ limit, offset });
+  return searchEntriesText(query, { limit, offset });
+});
+
+// Semantic search — requires Ollama to be running
+ipcMain.handle('library:search-semantic', async (_event, { query, topN = 10 }) => {
+  const available = await isOllamaAvailable();
+  if (!available) return { ok: false, reason: 'ollama_unavailable', results: [] };
+  const queryVector = await generateEmbedding(query);
+  const hits = await searchNearest(queryVector, topN);
+  // Enrich with full entry + tags
+  const entries = await Promise.all(
+    hits.map(async (h) => {
+      const entry = await getEntryWithTags(h.entry_id);
+      return entry ? { ...entry, _distance: h._distance } : null;
+    })
+  );
+  return { ok: true, results: entries.filter(Boolean) };
+});
+
+// Get a single entry with its tags
+ipcMain.handle('library:get-entry', async (_event, { id }) => {
+  return getEntryWithTags(id);
+});
+
+// List all tags (for sidebar)
+ipcMain.handle('library:list-tags', async () => {
+  return listTags();
 });
 
 app.whenReady().then(async () => {

--- a/tests/unit/db/search.test.js
+++ b/tests/unit/db/search.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+let tmpDir;
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-search-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+async function makeEntry(content, tags = []) {
+  const { createEntry } = require('../../../src/backend/db/entries');
+  const { setTagsForEntry } = require('../../../src/backend/db/tags');
+  const entry = await createEntry({ content });
+  if (tags.length > 0) await setTagsForEntry(entry.id, tags);
+  return entry;
+}
+
+// ── searchEntriesText ──────────────────────────────────────────────────────
+
+describe('searchEntriesText', () => {
+  test('returns entries whose content matches the query', async () => {
+    const { searchEntriesText } = require('../../../src/backend/db/search');
+    await makeEntry('the quick brown fox');
+    await makeEntry('a lazy dog');
+    const results = await searchEntriesText('fox');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('the quick brown fox');
+  });
+
+  test('is case-insensitive', async () => {
+    const { searchEntriesText } = require('../../../src/backend/db/search');
+    await makeEntry('Neuroscience is fascinating');
+    const results = await searchEntriesText('NEUROSCIENCE');
+    expect(results).toHaveLength(1);
+  });
+
+  test('returns multiple matching entries', async () => {
+    const { searchEntriesText } = require('../../../src/backend/db/search');
+    await makeEntry('idea about memory');
+    await makeEntry('another idea about focus');
+    await makeEntry('no match here');
+    const results = await searchEntriesText('idea');
+    expect(results).toHaveLength(2);
+  });
+
+  test('returns empty array when nothing matches', async () => {
+    const { searchEntriesText } = require('../../../src/backend/db/search');
+    await makeEntry('completely unrelated content');
+    const results = await searchEntriesText('xyzzy');
+    expect(results).toHaveLength(0);
+  });
+
+  test('respects limit and offset', async () => {
+    const { searchEntriesText } = require('../../../src/backend/db/search');
+    await makeEntry('match one');
+    await makeEntry('match two');
+    await makeEntry('match three');
+    const page = await searchEntriesText('match', { limit: 2, offset: 0 });
+    expect(page).toHaveLength(2);
+    const next = await searchEntriesText('match', { limit: 2, offset: 2 });
+    expect(next).toHaveLength(1);
+  });
+});
+
+// ── listEntriesByTag ───────────────────────────────────────────────────────
+
+describe('listEntriesByTag', () => {
+  test('returns entries associated with the given tag', async () => {
+    const { listEntriesByTag } = require('../../../src/backend/db/search');
+    await makeEntry('tagged entry', ['alpha']);
+    await makeEntry('untagged entry');
+    const results = await listEntriesByTag('alpha');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('tagged entry');
+  });
+
+  test('is case-insensitive (tag name is normalised)', async () => {
+    const { listEntriesByTag } = require('../../../src/backend/db/search');
+    await makeEntry('tagged', ['ALPHA']);
+    const results = await listEntriesByTag('alpha');
+    expect(results).toHaveLength(1);
+  });
+
+  test('returns empty array for unknown tag', async () => {
+    const { listEntriesByTag } = require('../../../src/backend/db/search');
+    await makeEntry('entry with no matching tag', ['beta']);
+    const results = await listEntriesByTag('nonexistent');
+    expect(results).toHaveLength(0);
+  });
+
+  test('returns multiple entries for the same tag', async () => {
+    const { listEntriesByTag } = require('../../../src/backend/db/search');
+    await makeEntry('first', ['shared']);
+    await makeEntry('second', ['shared']);
+    await makeEntry('third', ['other']);
+    const results = await listEntriesByTag('shared');
+    expect(results).toHaveLength(2);
+  });
+});
+
+// ── getEntryWithTags ───────────────────────────────────────────────────────
+
+describe('getEntryWithTags', () => {
+  test('returns entry with tags array', async () => {
+    const { getEntryWithTags } = require('../../../src/backend/db/search');
+    const entry = await makeEntry('full entry', ['foo', 'bar']);
+    const result = await getEntryWithTags(entry.id);
+    expect(result).toBeDefined();
+    expect(result.content).toBe('full entry');
+    expect(result.tags).toHaveLength(2);
+    expect(result.tags.map((t) => t.name).sort()).toEqual(['bar', 'foo']);
+  });
+
+  test('returns entry with empty tags array when no tags', async () => {
+    const { getEntryWithTags } = require('../../../src/backend/db/search');
+    const entry = await makeEntry('no tags');
+    const result = await getEntryWithTags(entry.id);
+    expect(result.tags).toEqual([]);
+  });
+
+  test('returns undefined for unknown id', async () => {
+    const { getEntryWithTags } = require('../../../src/backend/db/search');
+    const result = await getEntryWithTags('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #16

## What's included

### Backend
- src/backend/db/search.js — \searchEntriesText\, \listEntriesByTag\, \getEntryWithTags\
- src/main.js — five IPC handlers: \library:list\, \library:search-text\, \library:search-semantic\, \library:get-entry\, \library:list-tags\

### Frontend
- src/frontend/library.css — 3-column layout using design tokens (tag sidebar 200px, timeline flex, detail panel 360px)
- src/frontend/library.js — renderer: tag sidebar, entry timeline, entry detail panel, text/semantic search with 300ms debounce, load-more pagination, Ollama fallback notice
- src/frontend/index.html — replaces placeholder with full library UI

### Tests
- 	ests/unit/db/search.test.js — 12 tests covering all three search functions (74 total, all passing)

### Docs
- README: Phase 4 marked complete, Phase 4 validation section added