### PR TITLE
feat: Phase 6 — Export Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Ollama should be running on `http://127.0.0.1:11434` (default). The endpoint is 
 | 3 | Background Worker (embeddings via Ollama) | ✅ Complete |
 | 4 | Library Layer (timeline, search, themes UI) | ✅ Complete |
 | 5 | Processing Layer (clustering, summaries) | ✅ Complete |
-| 6 | Export Layer (JSON/MD/embeddings) | 🔲 Planned |
+| 6 | Export Layer (JSON/MD/embeddings) | ✅ Complete |
 
 See [ROADMAP.md](ROADMAP.md) and [GitHub Issues](https://github.com/codebureau/neurologue/issues) for detail.
 
@@ -379,6 +379,29 @@ ollama pull phi3:mini      # LLM summaries
 ```js
 await window.neurologue.triggerClustering()
 ```
+
+## Phase 6 — Export Layer
+
+The **Export…** button in the top-right of the toolbar opens a native folder picker. Neurologue writes five files to the chosen directory:
+
+| File | Contents |
+|---|---|
+| `entries.json` | All entries as a JSON array (id, content, source, type, created_at, tags) |
+| `entries.md` | All entries as a single Markdown document |
+| `themes.json` | Themes + LLM summaries + member entry IDs and scores |
+| `themes.md` | Themes as a Markdown document |
+| `embeddings.jsonl` | All embeddings (entry_id, model_name, vector array) |
+
+**To validate:**
+
+1. Run `npm start`
+2. Capture some entries and wait for embeddings + themes
+3. Click **Export…** in the toolbar
+4. Choose a destination folder in the native dialog
+5. A toast notification confirms the export with entry/theme counts
+6. Open the folder — all five files should be present
+
+The resulting files are suitable for ingestion into external tools (NotebookLM, Claude, Copilot, etc.).
 
 ---
 

--- a/src/backend/export/formatters.js
+++ b/src/backend/export/formatters.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Export formatters — pure functions, no side-effects.
+ * Each formatter takes an array of enriched entry objects and returns a string.
+ *
+ * Enriched entry shape:
+ *   { id, content, source, type, created_at, tags: [{ id, name }] }
+ */
+
+// ── JSON ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Serialise entries to a JSON array.
+ * @param {object[]} entries
+ * @returns {string}
+ */
+function entriesToJson(entries) {
+  const rows = entries.map((e) => ({
+    id: e.id,
+    content: e.content,
+    source: e.source || 'manual',
+    type: e.type || 'note',
+    created_at: e.created_at,
+    tags: (e.tags || []).map((t) => t.name),
+  }));
+  return JSON.stringify(rows, null, 2);
+}
+
+/**
+ * Serialise themes to a JSON array.
+ * @param {object[]} themes   Each theme has { id, name, description, entries[] }
+ * @returns {string}
+ */
+function themesToJson(themes) {
+  const rows = themes.map((t) => ({
+    id: t.id,
+    name: t.name,
+    summary: t.description || '',
+    entries: (t.entries || []).map((e) => ({
+      id: e.entry_id || e.id,
+      score: typeof e.score === 'number' ? parseFloat(e.score.toFixed(4)) : undefined,
+    })),
+  }));
+  return JSON.stringify(rows, null, 2);
+}
+
+// ── Markdown ──────────────────────────────────────────────────────────────────
+
+/**
+ * Serialise entries to a single Markdown document.
+ * Each entry becomes an H2 section.
+ * @param {object[]} entries
+ * @returns {string}
+ */
+function entriesToMarkdown(entries) {
+  const lines = ['# Neurologue Export\n'];
+  for (const e of entries) {
+    lines.push(`## ${formatDate(e.created_at)}`);
+    lines.push('');
+    lines.push(e.content);
+    lines.push('');
+    const tagStr = (e.tags || []).map((t) => `\`${t.name}\``).join(', ');
+    if (tagStr) lines.push(`**Tags:** ${tagStr}`);
+    const meta = [`id: ${e.id}`, `source: ${e.source || 'manual'}`, `type: ${e.type || 'note'}`];
+    lines.push(`*${meta.join(' · ')}*`);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Serialise themes to a Markdown document.
+ * @param {object[]} themes
+ * @returns {string}
+ */
+function themesToMarkdown(themes) {
+  const lines = ['# Neurologue Themes\n'];
+  for (const t of themes) {
+    lines.push(`## ${t.name}`);
+    lines.push('');
+    if (t.description) {
+      lines.push(`> ${t.description}`);
+      lines.push('');
+    }
+    if (t.entries && t.entries.length > 0) {
+      lines.push(`**${t.entries.length} entries in this theme**`);
+      lines.push('');
+    }
+    lines.push('---');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+// ── Embeddings JSONL ───────────────────────────────────────────────────────────
+
+/**
+ * Serialise embeddings to JSONL (one JSON object per line).
+ * @param {{ entry_id: string, vector: Float32Array, model_name: string }[]} embeddings
+ * @returns {string}
+ */
+function embeddingsToJsonl(embeddings) {
+  return embeddings
+    .map((e) => JSON.stringify({
+      entry_id: e.entry_id,
+      model_name: e.model_name,
+      vector: Array.from(e.vector),
+    }))
+    .join('\n');
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDate(dateStr) {
+  if (!dateStr) return 'Unknown date';
+  const d = new Date(dateStr);
+  return d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+}
+
+module.exports = { entriesToJson, themesToJson, entriesToMarkdown, themesToMarkdown, embeddingsToJsonl };

--- a/src/backend/export/runner.js
+++ b/src/backend/export/runner.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Export runner — fetches all data, formats it, and writes files to a
+ * user-chosen directory.
+ *
+ * Output (all in destDir):
+ *   entries.json      — all entries as JSON array
+ *   entries.md        — all entries as Markdown
+ *   themes.json       — themes + summaries as JSON
+ *   themes.md         — themes as Markdown
+ *   embeddings.jsonl  — all embeddings as JSONL (one per line)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { openDb } = require('../db/connection');
+const { getEntryWithTags } = require('../db/search');
+const { listThemes, getEntriesForTheme } = require('../db/themes');
+const {
+  entriesToJson,
+  themesToJson,
+  entriesToMarkdown,
+  themesToMarkdown,
+  embeddingsToJsonl,
+} = require('./formatters');
+
+/**
+ * Run a full export to destDir.
+ *
+ * @param {string} destDir  Absolute path to the destination directory
+ * @param {object} [opts]
+ * @param {boolean} [opts.includeEmbeddings=true]
+ * @returns {Promise<{ files: string[], entryCount: number, themeCount: number, embeddingCount: number }>}
+ */
+async function runExport(destDir, { includeEmbeddings = true } = {}) {
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const db = await openDb();
+
+  // ── 1. Entries ────────────────────────────────────────────────────────────
+  const rawEntries = db.prepare('SELECT * FROM entries ORDER BY created_at DESC').all();
+
+  // Enrich with tags
+  const entries = await Promise.all(rawEntries.map((e) => getEntryWithTags(e.id)));
+  const validEntries = entries.filter(Boolean);
+
+  write(destDir, 'entries.json', entriesToJson(validEntries));
+  write(destDir, 'entries.md', entriesToMarkdown(validEntries));
+
+  // ── 2. Themes ─────────────────────────────────────────────────────────────
+  const themes = await listThemes();
+  const enrichedThemes = await Promise.all(
+    themes.map(async (t) => {
+      const members = await getEntriesForTheme(t.id);
+      return { ...t, entries: members };
+    })
+  );
+
+  write(destDir, 'themes.json', themesToJson(enrichedThemes));
+  write(destDir, 'themes.md', themesToMarkdown(enrichedThemes));
+
+  // ── 3. Embeddings ─────────────────────────────────────────────────────────
+  let embeddingCount = 0;
+  if (includeEmbeddings) {
+    const embRows = db.prepare('SELECT entry_id, vector, model_name FROM embeddings').all();
+    const embeddings = embRows.map((r) => {
+      const bytes = new Uint8Array(r.vector);
+      return {
+        entry_id: r.entry_id,
+        model_name: r.model_name,
+        vector: new Float32Array(bytes.buffer),
+      };
+    });
+    write(destDir, 'embeddings.jsonl', embeddingsToJsonl(embeddings));
+    embeddingCount = embeddings.length;
+  }
+
+  const files = ['entries.json', 'entries.md', 'themes.json', 'themes.md'];
+  if (includeEmbeddings) files.push('embeddings.jsonl');
+
+  return {
+    files: files.map((f) => path.join(destDir, f)),
+    entryCount: validEntries.length,
+    themeCount: enrichedThemes.length,
+    embeddingCount,
+  };
+}
+
+function write(dir, filename, content) {
+  fs.writeFileSync(path.join(dir, filename), content, 'utf8');
+}
+
+module.exports = { runExport };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -20,7 +20,11 @@
         <button id="btn-semantic" class="mode-btn">Semantic</button>
       </div>
       <span id="entry-count"></span>
+      <button id="btn-export" class="mode-btn">Export…</button>
     </div>
+
+    <!-- ── Export toast ─────────────────────────────────────────── -->
+    <div id="export-toast"></div>
 
     <!-- ── Semantic notice ─────────────────────────────────────────── -->
     <div id="semantic-notice">

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -424,3 +424,22 @@ html, body {
   color: var(--synapse-gold);
   text-align: center;
 }
+
+/* ── Export toast ─────────────────────────────────────────────────────── */
+#export-toast {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 16px;
+  font-size: 13px;
+  color: var(--text);
+  z-index: 100;
+  max-width: 320px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+}
+#export-toast.success { border-color: var(--cortex-teal); color: var(--cortex-teal); }
+#export-toast.error   { border-color: var(--danger);      color: var(--danger); }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -31,6 +31,8 @@ const detailDate    = document.getElementById('detail-date');
 const detailSource  = document.getElementById('detail-source');
 const detailText    = document.getElementById('detail-text');
 const detailTags    = document.getElementById('detail-tags');
+const exportBtn     = document.getElementById('btn-export');
+const exportToast   = document.getElementById('export-toast');
 const semanticNotice = document.getElementById('semantic-notice');
 
 // ── Utilities ──────────────────────────────────────────────────────────────
@@ -327,6 +329,39 @@ btnText.addEventListener('click', () => setMode('text'));
 btnSemantic.addEventListener('click', () => setMode('semantic'));
 tagAll.addEventListener('click', () => applyTagFilter(null));
 loadMoreBtn.addEventListener('click', () => loadEntries(true));
+
+// ── Export ─────────────────────────────────────────────────────────────────
+
+let _exportToastTimer = null;
+
+function showToast(message, type = 'success') {
+  exportToast.textContent = message;
+  exportToast.className = type;
+  exportToast.style.display = 'block';
+  clearTimeout(_exportToastTimer);
+  _exportToastTimer = setTimeout(() => { exportToast.style.display = 'none'; }, 5000);
+}
+
+exportBtn.addEventListener('click', async () => {
+  exportBtn.disabled = true;
+  exportBtn.textContent = 'Exporting…';
+  try {
+    const result = await window.neurologue.exportAll({ includeEmbeddings: true });
+    if (result.canceled) {
+      showToast('Export cancelled.', 'success');
+    } else {
+      showToast(
+        `Exported ${result.entryCount} entries, ${result.themeCount} themes to ${result.destDir}`,
+        'success'
+      );
+    }
+  } catch (err) {
+    showToast(`Export failed: ${err.message}`, 'error');
+  } finally {
+    exportBtn.disabled = false;
+    exportBtn.textContent = 'Export…';
+  }
+});
 
 // ── Init ───────────────────────────────────────────────────────────────────
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -15,5 +15,6 @@ contextBridge.exposeInMainWorld('neurologue', {
   listThemes: () => ipcRenderer.invoke('themes:list'),
   getTheme: (id) => ipcRenderer.invoke('themes:get', { id }),
   triggerClustering: () => ipcRenderer.invoke('themes:cluster'),
-});
+  // ── Export ───────────────────────────────────────────────────────────────
+  exportAll: (opts) => ipcRenderer.invoke('export:run', opts),});
 

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ const { searchNearest } = require('./backend/vector/store');
 const { generateEmbedding, isOllamaAvailable } = require('./worker/ollama');
 const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
+const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey } = require('./capture/hotkey');
 const { startWorker, stopWorker } = require('./worker/index');
 
@@ -115,7 +116,24 @@ ipcMain.handle('themes:get', async (_event, { id }) => {
 // Manually trigger clustering (for dev/debug)
 ipcMain.handle('themes:cluster', async () => {
   return runClustering();
-});;
+});
+
+// ── Export IPC ───────────────────────────────────────────────────────────────
+
+// Show native folder picker and run export to chosen directory
+ipcMain.handle('export:run', async (_event, { includeEmbeddings = true } = {}) => {
+  const { dialog } = require('electron');
+  const win = BrowserWindow.getFocusedWindow();
+  const { canceled, filePaths } = await dialog.showOpenDialog(win || undefined, {
+    title: 'Choose export folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (canceled || !filePaths || filePaths.length === 0) {
+    return { canceled: true };
+  }
+  const result = await runExport(filePaths[0], { includeEmbeddings });
+  return { canceled: false, destDir: filePaths[0], ...result };
+});
 
 app.whenReady().then(async () => {
   await initialise();

--- a/tests/unit/export/formatters.test.js
+++ b/tests/unit/export/formatters.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const {
+  entriesToJson,
+  themesToJson,
+  entriesToMarkdown,
+  themesToMarkdown,
+  embeddingsToJsonl,
+} = require('../../../src/backend/export/formatters');
+
+// ── Test data ──────────────────────────────────────────────────────────────
+
+const ENTRIES = [
+  {
+    id: 'e1',
+    content: 'The quick brown fox',
+    source: 'manual',
+    type: 'note',
+    created_at: '2026-01-15 10:00:00',
+    tags: [{ id: 't1', name: 'ideas' }, { id: 't2', name: 'test' }],
+  },
+  {
+    id: 'e2',
+    content: 'Another thought here',
+    source: 'clipboard',
+    type: 'note',
+    created_at: '2026-01-16 11:30:00',
+    tags: [],
+  },
+];
+
+const THEMES = [
+  {
+    id: 'th1',
+    name: 'Theme 1',
+    description: 'Notes about quick things',
+    entries: [
+      { entry_id: 'e1', score: 0.95 },
+      { entry_id: 'e2', score: 0.72 },
+    ],
+  },
+  {
+    id: 'th2',
+    name: 'Theme 2',
+    description: '',
+    entries: [],
+  },
+];
+
+const EMBEDDINGS = [
+  { entry_id: 'e1', model_name: 'bge-small-en', vector: new Float32Array([0.1, 0.2, 0.3]) },
+  { entry_id: 'e2', model_name: 'bge-small-en', vector: new Float32Array([0.4, 0.5, 0.6]) },
+];
+
+// ── entriesToJson ──────────────────────────────────────────────────────────
+
+describe('entriesToJson', () => {
+  test('produces valid JSON array', () => {
+    const json = entriesToJson(ENTRIES);
+    const parsed = JSON.parse(json);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(2);
+  });
+
+  test('includes expected fields', () => {
+    const parsed = JSON.parse(entriesToJson(ENTRIES));
+    const e = parsed[0];
+    expect(e).toHaveProperty('id', 'e1');
+    expect(e).toHaveProperty('content', 'The quick brown fox');
+    expect(e).toHaveProperty('source', 'manual');
+    expect(e).toHaveProperty('created_at');
+    expect(e.tags).toEqual(['ideas', 'test']);
+  });
+
+  test('handles entry with no tags', () => {
+    const parsed = JSON.parse(entriesToJson(ENTRIES));
+    expect(parsed[1].tags).toEqual([]);
+  });
+
+  test('handles empty array', () => {
+    const parsed = JSON.parse(entriesToJson([]));
+    expect(parsed).toEqual([]);
+  });
+});
+
+// ── themesToJson ───────────────────────────────────────────────────────────
+
+describe('themesToJson', () => {
+  test('produces valid JSON array', () => {
+    const parsed = JSON.parse(themesToJson(THEMES));
+    expect(parsed).toHaveLength(2);
+  });
+
+  test('includes id, name, summary, entries', () => {
+    const parsed = JSON.parse(themesToJson(THEMES));
+    const t = parsed[0];
+    expect(t).toHaveProperty('id', 'th1');
+    expect(t).toHaveProperty('name', 'Theme 1');
+    expect(t).toHaveProperty('summary', 'Notes about quick things');
+    expect(t.entries).toHaveLength(2);
+    expect(t.entries[0]).toHaveProperty('score', 0.95);
+  });
+
+  test('empty description becomes empty string summary', () => {
+    const parsed = JSON.parse(themesToJson(THEMES));
+    expect(parsed[1].summary).toBe('');
+  });
+
+  test('handles empty array', () => {
+    expect(JSON.parse(themesToJson([]))).toEqual([]);
+  });
+});
+
+// ── entriesToMarkdown ──────────────────────────────────────────────────────
+
+describe('entriesToMarkdown', () => {
+  test('produces a non-empty string', () => {
+    const md = entriesToMarkdown(ENTRIES);
+    expect(typeof md).toBe('string');
+    expect(md.length).toBeGreaterThan(0);
+  });
+
+  test('contains entry content', () => {
+    const md = entriesToMarkdown(ENTRIES);
+    expect(md).toContain('The quick brown fox');
+    expect(md).toContain('Another thought here');
+  });
+
+  test('contains tag names', () => {
+    const md = entriesToMarkdown(ENTRIES);
+    expect(md).toContain('`ideas`');
+    expect(md).toContain('`test`');
+  });
+
+  test('includes H1 heading', () => {
+    const md = entriesToMarkdown(ENTRIES);
+    expect(md).toMatch(/^# Neurologue Export/);
+  });
+
+  test('handles empty array', () => {
+    const md = entriesToMarkdown([]);
+    expect(md).toContain('# Neurologue Export');
+  });
+});
+
+// ── themesToMarkdown ───────────────────────────────────────────────────────
+
+describe('themesToMarkdown', () => {
+  test('contains theme names as H2 headings', () => {
+    const md = themesToMarkdown(THEMES);
+    expect(md).toContain('## Theme 1');
+    expect(md).toContain('## Theme 2');
+  });
+
+  test('includes summary blockquote when present', () => {
+    const md = themesToMarkdown(THEMES);
+    expect(md).toContain('> Notes about quick things');
+  });
+});
+
+// ── embeddingsToJsonl ──────────────────────────────────────────────────────
+
+describe('embeddingsToJsonl', () => {
+  test('produces one JSON object per line', () => {
+    const jsonl = embeddingsToJsonl(EMBEDDINGS);
+    const lines = jsonl.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+    lines.forEach((line) => expect(() => JSON.parse(line)).not.toThrow());
+  });
+
+  test('each line has entry_id, model_name, vector', () => {
+    const lines = embeddingsToJsonl(EMBEDDINGS).split('\n').filter(Boolean);
+    const obj = JSON.parse(lines[0]);
+    expect(obj).toHaveProperty('entry_id', 'e1');
+    expect(obj).toHaveProperty('model_name', 'bge-small-en');
+    expect(Array.isArray(obj.vector)).toBe(true);
+    expect(obj.vector).toHaveLength(3);
+  });
+
+  test('vector values are numbers', () => {
+    const lines = embeddingsToJsonl(EMBEDDINGS).split('\n').filter(Boolean);
+    const obj = JSON.parse(lines[0]);
+    obj.vector.forEach((v) => expect(typeof v).toBe('number'));
+  });
+
+  test('handles empty array', () => {
+    expect(embeddingsToJsonl([])).toBe('');
+  });
+});

--- a/tests/unit/export/runner.test.js
+++ b/tests/unit/export/runner.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+let tmpDir;
+let exportDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-export-'));
+  exportDir = path.join(tmpDir, 'export-out');
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+async function seedData() {
+  const { createEntry } = require('../../../src/backend/db/entries');
+  const { setTagsForEntry } = require('../../../src/backend/db/tags');
+  const { upsertEmbedding } = require('../../../src/backend/db/embeddings');
+  const { upsertTheme, setThemeEntries } = require('../../../src/backend/db/themes');
+
+  const e1 = await createEntry({ content: 'First entry about ideas' });
+  const e2 = await createEntry({ content: 'Second entry about memory' });
+  await setTagsForEntry(e1.id, ['ideas']);
+  await upsertEmbedding(e1.id, new Float32Array([0.1, 0.2, 0.3]), 'test-model');
+  await upsertEmbedding(e2.id, new Float32Array([0.4, 0.5, 0.6]), 'test-model');
+
+  const theme = await upsertTheme({ name: 'Test Theme', description: 'A summary' });
+  await setThemeEntries(theme.id, [
+    { entryId: e1.id, score: 0.9 },
+    { entryId: e2.id, score: 0.7 },
+  ]);
+
+  return { e1, e2, theme };
+}
+
+// ── runExport ──────────────────────────────────────────────────────────────
+
+describe('runExport', () => {
+  test('creates output directory if it does not exist', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await runExport(exportDir);
+    expect(fs.existsSync(exportDir)).toBe(true);
+  });
+
+  test('writes all expected files', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    await runExport(exportDir);
+    const files = fs.readdirSync(exportDir);
+    expect(files).toContain('entries.json');
+    expect(files).toContain('entries.md');
+    expect(files).toContain('themes.json');
+    expect(files).toContain('themes.md');
+    expect(files).toContain('embeddings.jsonl');
+  });
+
+  test('returns correct counts', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    const result = await runExport(exportDir);
+    expect(result.entryCount).toBe(2);
+    expect(result.themeCount).toBe(1);
+    expect(result.embeddingCount).toBe(2);
+  });
+
+  test('entries.json contains valid JSON with correct entry count', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    await runExport(exportDir);
+    const json = JSON.parse(fs.readFileSync(path.join(exportDir, 'entries.json'), 'utf8'));
+    expect(json).toHaveLength(2);
+    expect(json[0]).toHaveProperty('content');
+    expect(json[0]).toHaveProperty('tags');
+  });
+
+  test('themes.json contains theme with entries', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    await runExport(exportDir);
+    const json = JSON.parse(fs.readFileSync(path.join(exportDir, 'themes.json'), 'utf8'));
+    expect(json).toHaveLength(1);
+    expect(json[0].name).toBe('Test Theme');
+    expect(json[0].summary).toBe('A summary');
+    expect(json[0].entries).toHaveLength(2);
+  });
+
+  test('embeddings.jsonl has one line per embedding', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    await runExport(exportDir);
+    const jsonl = fs.readFileSync(path.join(exportDir, 'embeddings.jsonl'), 'utf8');
+    const lines = jsonl.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+  });
+
+  test('skips embeddings.jsonl when includeEmbeddings=false', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    await seedData();
+    const result = await runExport(exportDir, { includeEmbeddings: false });
+    expect(fs.existsSync(path.join(exportDir, 'embeddings.jsonl'))).toBe(false);
+    expect(result.embeddingCount).toBe(0);
+    expect(result.files).not.toContain(path.join(exportDir, 'embeddings.jsonl'));
+  });
+
+  test('works with no data (empty DB)', async () => {
+    const { runExport } = require('../../../src/backend/export/runner');
+    const result = await runExport(exportDir);
+    expect(result.entryCount).toBe(0);
+    expect(result.themeCount).toBe(0);
+    expect(result.embeddingCount).toBe(0);
+    expect(fs.existsSync(path.join(exportDir, 'entries.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #20

## What's included

### Export formatters
- \src/backend/export/formatters.js\ — pure functions: \entriesToJson\, \	hemesToJson\, \entriesToMarkdown\, \	hemesToMarkdown\, \embeddingsToJsonl\

### Export runner
- \src/backend/export/runner.js\ — fetches all entries (enriched with tags), themes (enriched with members), and embeddings; writes 5 files to a chosen directory

### IPC + preload
- \export:run\ handler in main.js — shows native folder picker dialog, runs export, returns counts
- \exportAll(opts)\ exposed via preload

### Library UI
- **Export…** button in the toolbar
- Native OS folder picker dialog
- Toast notification on success/failure showing entry/theme counts and destination path

### Tests
- \	ests/unit/export/formatters.test.js\ — 20 formatter tests
- \	ests/unit/export/runner.test.js\ — 7 integration tests
- 118 total tests, all passing

### Docs
- README: Phase 6 marked complete, validation section added with output file table