### PR TITLE
feat: user documentation website + in-app Help link

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,41 @@
+name: Deploy documentation to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; cancel in-progress runs on new push
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./website
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -21,6 +21,7 @@
       </div>
       <span id="entry-count"></span>
       <button id="btn-export" class="mode-btn">Export…</button>
+      <button id="btn-help" class="mode-btn">Help</button>
     </div>
 
     <!-- ── Export toast ─────────────────────────────────────────── -->

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -33,6 +33,7 @@ const detailText    = document.getElementById('detail-text');
 const detailTags    = document.getElementById('detail-tags');
 const exportBtn     = document.getElementById('btn-export');
 const exportToast   = document.getElementById('export-toast');
+const helpBtn       = document.getElementById('btn-help');
 const semanticNotice = document.getElementById('semantic-notice');
 
 // ── Utilities ──────────────────────────────────────────────────────────────
@@ -361,6 +362,10 @@ exportBtn.addEventListener('click', async () => {
     exportBtn.disabled = false;
     exportBtn.textContent = 'Export…';
   }
+});
+
+helpBtn.addEventListener('click', () => {
+  window.neurologue.openHelp();
 });
 
 // ── Init ───────────────────────────────────────────────────────────────────

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -16,5 +16,9 @@ contextBridge.exposeInMainWorld('neurologue', {
   getTheme: (id) => ipcRenderer.invoke('themes:get', { id }),
   triggerClustering: () => ipcRenderer.invoke('themes:cluster'),
   // ── Export ───────────────────────────────────────────────────────────────
-  exportAll: (opts) => ipcRenderer.invoke('export:run', opts),});
+  exportAll: (opts) => ipcRenderer.invoke('export:run', opts),
+
+  // ── Help ─────────────────────────────────────────────────────────────────
+  openHelp: () => ipcRenderer.invoke('help:open'),
+});
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow, globalShortcut, ipcMain } = require('electron');
+const { app, BrowserWindow, globalShortcut, ipcMain, shell } = require('electron');
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
@@ -116,6 +116,12 @@ ipcMain.handle('themes:get', async (_event, { id }) => {
 // Manually trigger clustering (for dev/debug)
 ipcMain.handle('themes:cluster', async () => {
   return runClustering();
+});
+
+// ── Help IPC ─────────────────────────────────────────────────────────────────
+
+ipcMain.handle('help:open', () => {
+  shell.openExternal('https://codebureau.github.io/neurologue');
 });
 
 // ── Export IPC ───────────────────────────────────────────────────────────────

--- a/website/capture.html
+++ b/website/capture.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Capture — Neurologue Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html">Overview</a>
+      <a href="capture.html" class="active">Capture</a>
+      <a href="library.html">Library</a>
+      <a href="themes.html">Themes</a>
+      <a href="export.html">Export</a>
+      <a href="troubleshooting.html">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Capture</h1>
+  <p class="page-subtitle">Capture any thought in under two seconds, without leaving what you're doing.</p>
+
+  <h2>Global hotkey</h2>
+  <p>
+    Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd> from anywhere on your desktop — even when Neurologue is in the background or minimised. A small floating popup appears instantly on top of your current window.
+  </p>
+
+  <div class="callout">
+    <p>The hotkey is registered globally when Neurologue is running. You don't need to switch to the app first.</p>
+  </div>
+
+  <h2>The capture popup</h2>
+  <p>The popup is a compact 560×260px window with two fields:</p>
+
+  <table>
+    <thead><tr><th>Field</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Content</strong></td>
+        <td>The main text area. Accepts multi-line input. Spellcheck is enabled. This field is automatically focused when the popup opens.</td>
+      </tr>
+      <tr>
+        <td><strong>Tags</strong></td>
+        <td>Optional comma-separated tags, e.g. <code>work, ideas, todo</code>. Whitespace around each tag is trimmed automatically.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Keyboard shortcuts</h2>
+
+  <table>
+    <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+    <tbody>
+      <tr><td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd></td><td>Open the capture popup (global)</td></tr>
+      <tr><td><kbd>Ctrl</kbd>+<kbd>Enter</kbd></td><td>Save the entry and close the popup</td></tr>
+      <tr><td><kbd>Escape</kbd></td><td>Dismiss the popup without saving</td></tr>
+    </tbody>
+  </table>
+
+  <p>The popup also closes automatically if you click anywhere outside it.</p>
+
+  <h2>What gets saved</h2>
+  <p>Each captured entry is stored with the following metadata automatically:</p>
+
+  <table>
+    <thead><tr><th>Field</th><th>Value</th></tr></thead>
+    <tbody>
+      <tr><td><code>content</code></td><td>Your text</td></tr>
+      <tr><td><code>tags</code></td><td>Parsed from the tags field</td></tr>
+      <tr><td><code>source</code></td><td><code>manual</code></td></tr>
+      <tr><td><code>type</code></td><td><code>note</code></td></tr>
+      <tr><td><code>created_at</code></td><td>Current timestamp (UTC)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>After capture</h2>
+  <p>
+    Once saved, the entry appears immediately in your <a href="library.html">Library</a>. The background worker will pick it up within 10 seconds and generate a vector embedding. You don't need to do anything — this happens silently.
+  </p>
+
+  <div class="callout warning">
+    <p><strong>Ollama must be running</strong> for embeddings to be generated. If Ollama isn't available, the entry is still saved and will be embedded the next time Ollama is running and the worker picks it up.</p>
+  </div>
+
+  <h3>Tips for good entries</h3>
+  <ul>
+    <li>Write naturally — semantic search works on meaning, not keywords, so there's no need to craft perfectly worded entries.</li>
+    <li>Tags are optional but useful for quick filtering. Use them for categories (<code>work</code>, <code>health</code>) or status (<code>todo</code>, <code>idea</code>).</li>
+    <li>Short fragments and half-formed thoughts are fine. The system clusters similar entries into themes, so even brief notes contribute to patterns over time.</li>
+  </ul>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/website/export.html
+++ b/website/export.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Export — Neurologue Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html">Overview</a>
+      <a href="capture.html">Capture</a>
+      <a href="library.html">Library</a>
+      <a href="themes.html">Themes</a>
+      <a href="export.html" class="active">Export</a>
+      <a href="troubleshooting.html">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Export</h1>
+  <p class="page-subtitle">Export your entire knowledge base to portable files for use with external AI tools.</p>
+
+  <h2>Running an export</h2>
+
+  <ol class="steps">
+    <li>
+      <div><p>Click the <strong>Export…</strong> button in the top-right of the library toolbar.</p></div>
+    </li>
+    <li>
+      <div><p>A native folder picker opens. Choose an existing folder or create a new one.</p></div>
+    </li>
+    <li>
+      <div><p>Neurologue writes all five output files to that folder. A <strong>toast notification</strong> at the bottom-right of the window confirms success, showing the entry and theme counts and the destination path.</p></div>
+    </li>
+  </ol>
+
+  <div class="callout">
+    <p>Exports are non-destructive — they copy data out of Neurologue's database. Nothing in the app is modified or deleted.</p>
+  </div>
+
+  <h2>Output files</h2>
+
+  <table>
+    <thead><tr><th>File</th><th>Format</th><th>Contents</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code>entries.json</code></td>
+        <td>JSON array</td>
+        <td>All entries with <code>id</code>, <code>content</code>, <code>source</code>, <code>type</code>, <code>created_at</code>, and <code>tags</code> (array of strings)</td>
+      </tr>
+      <tr>
+        <td><code>entries.md</code></td>
+        <td>Markdown</td>
+        <td>All entries formatted as a single Markdown document — H2 per entry with content, tags, and metadata</td>
+      </tr>
+      <tr>
+        <td><code>themes.json</code></td>
+        <td>JSON array</td>
+        <td>All themes with <code>id</code>, <code>name</code>, <code>summary</code>, and <code>entries</code> (array of <code>{ entry_id, score }</code>)</td>
+      </tr>
+      <tr>
+        <td><code>themes.md</code></td>
+        <td>Markdown</td>
+        <td>All themes formatted as a Markdown document — H2 per theme with summary and member entries</td>
+      </tr>
+      <tr>
+        <td><code>embeddings.jsonl</code></td>
+        <td>JSONL (one object per line)</td>
+        <td>All entry embeddings: <code>{ entry_id, model_name, vector: [768 floats] }</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Using the export with external AI tools</h2>
+
+  <h3>NotebookLM (Google)</h3>
+  <p>
+    Upload <code>entries.md</code> and/or <code>themes.md</code> as sources in a new notebook. NotebookLM can then answer questions about your captured thoughts, generate summaries, and find connections — with citations back to the original entries.
+  </p>
+
+  <h3>Claude (Anthropic)</h3>
+  <p>
+    Paste or upload <code>entries.md</code> directly into a conversation. Claude handles large documents well. Ask it to find patterns, summarise by theme, or identify contradictions or open questions in your notes.
+  </p>
+
+  <h3>GitHub Copilot / ChatGPT</h3>
+  <p>
+    Upload <code>entries.json</code> for structured analysis, or <code>entries.md</code> for readability. Useful for asking "what are the recurring ideas in this?" or "what have I been thinking about work lately?".
+  </p>
+
+  <h3>Custom pipelines</h3>
+  <p>
+    <code>embeddings.jsonl</code> contains the raw vectors in a standard format. You can import these directly into other vector stores (Chroma, Pinecone, Weaviate, etc.) to build your own retrieval pipelines on top of your Neurologue data.
+  </p>
+  <p>Example entry from <code>embeddings.jsonl</code>:</p>
+  <pre><code>{"entry_id": "abc123...", "model_name": "nomic-embed-text", "vector": [0.021, -0.014, ...]}</code></pre>
+
+  <h2>Export scope</h2>
+  <p>
+    Each export captures a <strong>full snapshot</strong> of all entries, themes, and embeddings at the time of export. There is currently no incremental or scheduled export — run it manually whenever you want a fresh copy.
+  </p>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neurologue — Documentation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html" class="active">Overview</a>
+      <a href="capture.html">Capture</a>
+      <a href="library.html">Library</a>
+      <a href="themes.html">Themes</a>
+      <a href="export.html">Export</a>
+      <a href="troubleshooting.html">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Neurologue</h1>
+  <p class="page-subtitle">A local-first personal cognitive system — capture thoughts instantly, rediscover them intelligently.</p>
+
+  <h2>What is Neurologue?</h2>
+  <p>
+    Neurologue is a desktop application that lets you capture thoughts, notes, and ideas in under two seconds — no context switching required. In the background it generates vector embeddings of everything you write, clusters related entries into <strong>Themes</strong>, and gives you semantic search so you can find ideas by meaning rather than exact words.
+  </p>
+  <p>
+    Everything runs <strong>locally</strong>. No accounts, no cloud sync, no telemetry. Your data stays on your machine.
+  </p>
+
+  <h2>How it works</h2>
+
+  <div class="flow">
+    <div class="flow-step"><strong>Capture</strong><span>Press <kbd>Ctrl+Shift+Space</kbd></span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><strong>Store</strong><span>SQLite + tags</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><strong>Embed</strong><span>Background worker</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><strong>Cluster</strong><span>k-means → Themes</span></div>
+    <div class="flow-arrow">→</div>
+    <div class="flow-step"><strong>Retrieve</strong><span>Search + Browse</span></div>
+  </div>
+
+  <p>
+    After capture, the <strong>background worker</strong> picks up your entry within 10 seconds, generates a semantic embedding via Ollama, and after every 5 new embeddings automatically re-clusters everything into themes. This happens silently — you don't need to trigger it.
+  </p>
+
+  <h2>Requirements</h2>
+
+  <table>
+    <thead><tr><th>Requirement</th><th>Details</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Operating System</strong></td>
+        <td>Windows 10/11, macOS 12+, or Linux</td>
+      </tr>
+      <tr>
+        <td><strong>Ollama</strong></td>
+        <td>Required for embeddings and theme summaries. <a href="https://ollama.com/download" target="_blank" rel="noopener">Download from ollama.com</a></td>
+      </tr>
+      <tr>
+        <td><strong>nomic-embed-text</strong></td>
+        <td>Embedding model (~274 MB). Run: <code>ollama pull nomic-embed-text</code></td>
+      </tr>
+      <tr>
+        <td><strong>phi3:mini</strong></td>
+        <td>LLM for theme summaries (~2.3 GB). Run: <code>ollama pull phi3:mini</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout warning">
+    <p><strong>Ollama must be running</strong> for embeddings and theme summaries to work. The app functions without it (capture and text search still work), but semantic search will fall back to text mode and themes won't be generated.</p>
+  </div>
+
+  <h2>Quick start</h2>
+
+  <ol class="steps">
+    <li>
+      <div>
+        <p><strong>Install Ollama</strong> and pull both models:</p>
+        <pre><code>ollama pull nomic-embed-text
+ollama pull phi3:mini</code></pre>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>Start Neurologue</strong> with <code>npm start</code> from the project folder.</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>Capture your first thought</strong> — press <kbd>Ctrl+Shift+Space</kbd> from anywhere, type something, press <kbd>Ctrl+Enter</kbd> to save.</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>Open the library</strong> — the main window shows your entry. Wait ~10 seconds for the background worker to embed it. After 4+ entries are embedded, themes will start appearing in the sidebar.</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>Try semantic search</strong> — click <strong>Semantic</strong> in the toolbar and type a concept. Results are ranked by meaning, not keywords.</p>
+      </div>
+    </li>
+  </ol>
+
+  <h2>Sections in this guide</h2>
+
+  <table>
+    <thead><tr><th>Section</th><th>What it covers</th></tr></thead>
+    <tbody>
+      <tr><td><a href="capture.html">Capture</a></td><td>Global hotkey, popup UI, keyboard shortcuts, tags</td></tr>
+      <tr><td><a href="library.html">Library</a></td><td>Timeline, text &amp; semantic search, tag filtering, entry detail</td></tr>
+      <tr><td><a href="themes.html">Themes</a></td><td>How themes are generated, timing, viewing and understanding them</td></tr>
+      <tr><td><a href="export.html">Export</a></td><td>Export output files and using them with external AI tools</td></tr>
+      <tr><td><a href="troubleshooting.html">Troubleshooting</a></td><td>Ollama issues, no themes appearing, semantic search fallback</td></tr>
+    </tbody>
+  </table>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/website/library.html
+++ b/website/library.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Library — Neurologue Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html">Overview</a>
+      <a href="capture.html">Capture</a>
+      <a href="library.html" class="active">Library</a>
+      <a href="themes.html">Themes</a>
+      <a href="export.html">Export</a>
+      <a href="troubleshooting.html">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Library</h1>
+  <p class="page-subtitle">Browse, search, and explore everything you've captured.</p>
+
+  <h2>Layout overview</h2>
+  <p>The main library window has three panels side by side:</p>
+
+  <table>
+    <thead><tr><th>Panel</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Left sidebar</strong></td><td>Tags and Themes for filtering and navigation</td></tr>
+      <tr><td><strong>Timeline (centre)</strong></td><td>Chronological list of entries matching the current filter or search</td></tr>
+      <tr><td><strong>Detail (right)</strong></td><td>Full content of the selected entry, or details of the selected theme</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Toolbar</h2>
+  <p>The toolbar at the top contains:</p>
+  <ul>
+    <li><strong>Search bar</strong> — type to search; results update as you type (300 ms debounce). Press <kbd>Escape</kbd> to clear.</li>
+    <li><strong>Text / Semantic toggle</strong> — switches the search mode (see below).</li>
+    <li><strong>Entry count</strong> — shows how many entries match the current view.</li>
+    <li><strong>Export…</strong> — opens the <a href="export.html">export</a> workflow.</li>
+    <li><strong>Help</strong> — opens this documentation in your browser.</li>
+  </ul>
+
+  <h2>Search modes</h2>
+
+  <h3>Text search</h3>
+  <p>
+    The default mode. Uses SQLite full-text search to match entries whose content contains the words you type. Fast and works entirely offline. Results are paginated — 50 per page, with a <strong>Load more</strong> button at the bottom.
+  </p>
+
+  <h3>Semantic search</h3>
+  <p>
+    Click the <strong>Semantic</strong> button to switch modes. Instead of matching keywords, Neurologue embeds your query using <code>nomic-embed-text</code> and finds the 10 entries most similar in <em>meaning</em> — even if they share no words with your query.
+  </p>
+  <p>Each result shows a <strong>match score</strong> from 0.00 to 1.00 — the cosine similarity between your query embedding and the entry embedding. Higher is more similar.</p>
+
+  <div class="callout warning">
+    <p><strong>Requires Ollama.</strong> If Ollama is not running when you switch to Semantic mode, a notice appears and results fall back to text search automatically.</p>
+  </div>
+
+  <div class="callout">
+    <p><strong>Tip:</strong> Semantic search only returns the top 10 results. If you need to browse more, use Text mode.</p>
+  </div>
+
+  <h2>Tag filtering</h2>
+  <p>
+    The left sidebar lists all tags across all entries. Click any tag to filter the timeline to only entries with that tag. The active tag is highlighted.
+  </p>
+  <ul>
+    <li>Click <strong>All entries</strong> at the top of the tag list to clear the filter.</li>
+    <li>Click the <strong>✕</strong> next to an active tag to deselect it.</li>
+    <li>You can only have one tag filter active at a time.</li>
+    <li>Applying a tag filter clears any active search query.</li>
+    <li>Clicking a tag in the entry detail panel also applies that tag filter.</li>
+  </ul>
+
+  <h2>Entry timeline</h2>
+  <p>Each card in the timeline shows:</p>
+  <ul>
+    <li><strong>Date/time</strong> — when the entry was captured</li>
+    <li><strong>Match score</strong> — only in semantic search mode</li>
+    <li><strong>Preview</strong> — first ~50 characters of content</li>
+    <li><strong>Tag pills</strong> — up to 6 tags shown as small badges</li>
+  </ul>
+  <p>Click any card to open the full entry in the detail panel. The selected card is highlighted.</p>
+  <p>In text search and tag filter views, entries are paginated at 50 per page. A <strong>Load more</strong> button appears at the bottom when more results exist.</p>
+
+  <h2>Entry detail</h2>
+  <p>Clicking an entry opens its full detail in the right panel, showing:</p>
+  <ul>
+    <li>Full content text</li>
+    <li>Source and type metadata</li>
+    <li>All tags as clickable pills — clicking a tag applies that tag filter to the timeline</li>
+  </ul>
+
+  <h2>Theme sidebar</h2>
+  <p>
+    Below the tag list is a <strong>Themes</strong> section. This lists all auto-generated theme clusters. Click any theme to open its detail view in the right panel. See the <a href="themes.html">Themes</a> section for more.
+  </p>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,322 @@
+/* Neurologue Docs — shared styles */
+:root {
+  --neuro-blue:   #1C2A3A;
+  --cortex-teal:  #2AA6A1;
+  --teal-hover:   #238c88;
+  --synapse-gold: #C9A84C;
+  --bg:           #0F1923;
+  --surface:      #192534;
+  --surface2:     #1f2f40;
+  --border:       #2a3d52;
+  --text:         #E8EFF5;
+  --text-muted:   #7a9ab5;
+  --text-dim:     #4a6a85;
+  --danger:       #e05c5c;
+  --radius:       6px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 16px; }
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+  min-height: 100vh;
+}
+
+/* ── Layout ── */
+
+.site-header {
+  background: var(--neuro-blue);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  height: 52px;
+}
+
+.site-logo {
+  font-weight: 700;
+  font-size: 15px;
+  color: var(--cortex-teal);
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.site-nav {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 13px;
+  padding: 4px 10px;
+  border-radius: var(--radius);
+  transition: color 0.15s, background 0.15s;
+}
+
+.site-nav a:hover {
+  color: var(--text);
+  background: var(--surface2);
+}
+
+.site-nav a.active {
+  color: var(--cortex-teal);
+  background: var(--surface2);
+}
+
+.page-content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+/* ── Typography ── */
+
+h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+
+.page-subtitle {
+  font-size: 16px;
+  color: var(--text-muted);
+  margin-bottom: 40px;
+}
+
+h2 {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 48px;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--cortex-teal);
+  margin-top: 28px;
+  margin-bottom: 8px;
+}
+
+p { margin-bottom: 16px; color: var(--text); }
+p:last-child { margin-bottom: 0; }
+
+a { color: var(--cortex-teal); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+ul, ol {
+  padding-left: 24px;
+  margin-bottom: 16px;
+}
+
+li { margin-bottom: 6px; }
+li:last-child { margin-bottom: 0; }
+
+strong { color: var(--text); font-weight: 600; }
+
+code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85em;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: var(--cortex-teal);
+}
+
+pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  overflow-x: auto;
+  margin-bottom: 16px;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+kbd {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8em;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 7px;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+/* ── Components ── */
+
+.callout {
+  background: var(--surface);
+  border-left: 3px solid var(--cortex-teal);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.callout.warning {
+  border-color: var(--synapse-gold);
+}
+
+.callout.danger {
+  border-color: var(--danger);
+}
+
+.callout p:last-child { margin-bottom: 0; }
+
+/* ── Steps ── */
+
+.steps {
+  list-style: none;
+  padding: 0;
+  counter-reset: steps;
+}
+
+.steps li {
+  counter-increment: steps;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.steps li::before {
+  content: counter(steps);
+  min-width: 28px;
+  height: 28px;
+  background: var(--cortex-teal);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.steps li > div { flex: 1; }
+.steps li > div p { margin-bottom: 6px; }
+
+/* ── Flow diagram ── */
+
+.flow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  margin: 24px 0;
+}
+
+.flow-step {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 18px;
+  font-size: 13px;
+  text-align: center;
+}
+
+.flow-step strong {
+  display: block;
+  color: var(--cortex-teal);
+  font-size: 14px;
+  margin-bottom: 2px;
+}
+
+.flow-arrow {
+  color: var(--text-dim);
+  font-size: 18px;
+  padding: 0 8px;
+}
+
+/* ── Table ── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin-bottom: 20px;
+}
+
+th {
+  text-align: left;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-bottom: 2px solid var(--border);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+tr:last-child td { border-bottom: none; }
+tr:hover td { background: var(--surface); }
+
+/* ── Badge ── */
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 20px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.badge.teal { background: rgba(42,166,161,0.15); border-color: var(--cortex-teal); color: var(--cortex-teal); }
+.badge.gold { background: rgba(201,168,76,0.15); border-color: var(--synapse-gold); color: var(--synapse-gold); }
+
+/* ── Footer ── */
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 24px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.site-footer a { color: var(--text-dim); }
+.site-footer a:hover { color: var(--cortex-teal); text-decoration: none; }

--- a/website/themes.html
+++ b/website/themes.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Themes — Neurologue Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html">Overview</a>
+      <a href="capture.html">Capture</a>
+      <a href="library.html">Library</a>
+      <a href="themes.html" class="active">Themes</a>
+      <a href="export.html">Export</a>
+      <a href="troubleshooting.html">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Themes</h1>
+  <p class="page-subtitle">Automatically discovered clusters of related entries, summarised by a local AI.</p>
+
+  <h2>What are themes?</h2>
+  <p>
+    A <strong>theme</strong> is a group of entries that are semantically similar — they're about the same subject, even if you never labelled them that way. Neurologue discovers themes automatically by running k-means clustering on your entry embeddings.
+  </p>
+  <p>
+    Once clusters are found, Neurologue sends the top entries from each cluster to a local LLM (Phi-3 Mini via Ollama) and asks it to write a short natural-language summary. That summary becomes the theme's description.
+  </p>
+
+  <div class="callout">
+    <p><strong>Themes are not fixed.</strong> Every time 5 new entries are embedded, the entire entry set is re-clustered and themes are replaced. A theme that existed yesterday might merge with another, split, or disappear as your collection grows.</p>
+  </div>
+
+  <h2>How themes are generated</h2>
+
+  <ol class="steps">
+    <li>
+      <div>
+        <p><strong>Embeddings are generated</strong> — the background worker picks up newly captured entries (batches of 5, every 10 seconds) and calls Ollama (<code>nomic-embed-text</code>) to produce a 768-dimensional vector for each entry.</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>Clustering triggers</strong> — after every 5 new embeddings in a session, clustering runs automatically. It requires at least 4 entries with embeddings.</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>k-means++ clustering</strong> — the number of clusters is chosen automatically: <code>k = round(√(n/2))</code>, clamped between 2 and 20 (where <em>n</em> is the number of embedded entries).</p>
+      </div>
+    </li>
+    <li>
+      <div>
+        <p><strong>LLM summaries</strong> — Neurologue sends the top 5 entries from each cluster to Phi-3 Mini and asks for a short summary. This becomes the theme description. If Ollama is unavailable, themes are still created but show "No summary yet" until Ollama comes back.</p>
+      </div>
+    </li>
+  </ol>
+
+  <h2>Timing expectations</h2>
+
+  <table>
+    <thead><tr><th>Event</th><th>When it happens</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Entry saved</td>
+        <td>Immediately after pressing <kbd>Ctrl</kbd>+<kbd>Enter</kbd> in the popup</td>
+      </tr>
+      <tr>
+        <td>Embedding generated</td>
+        <td>Within ~10 seconds of saving (next worker poll cycle)</td>
+      </tr>
+      <tr>
+        <td>Themes generated</td>
+        <td>After 5 new embeddings in the current session AND at least 4 total embedded entries</td>
+      </tr>
+      <tr>
+        <td>Theme summaries</td>
+        <td>Shortly after clustering, if Ollama is running and <code>phi3:mini</code> is pulled</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout warning">
+    <p><strong>There is currently no visible indicator</strong> that the background worker is running or that clustering is in progress. If themes don't appear, check that Ollama is running and you have at least 4 captured entries. See <a href="troubleshooting.html">Troubleshooting</a>.</p>
+  </div>
+
+  <h2>Viewing themes</h2>
+  <p>
+    Themes appear in the <strong>Themes</strong> section of the left sidebar in the library. Each theme is listed by name (e.g. "Theme 1", "Theme 2").
+  </p>
+  <p>Click a theme to open the theme detail panel on the right, which shows:</p>
+  <ul>
+    <li><strong>Theme name</strong></li>
+    <li><strong>Summary</strong> — the LLM-generated description, or a placeholder if not yet generated</li>
+    <li><strong>Member entries</strong> — up to 20 entries from the cluster, sorted by similarity score (how close each entry is to the cluster centre). Click any entry to jump to its full detail view.</li>
+  </ul>
+
+  <h2>Understanding the similarity score</h2>
+  <p>
+    Each entry in a theme has a <strong>score</strong> — the cosine similarity between that entry's embedding and the cluster centroid. A score of <code>1.00</code> would mean the entry is the perfect centre of the theme. Scores closer to <code>0</code> mean the entry is a weaker match but still closest to that cluster compared to all others.
+  </p>
+
+  <h3>Cluster count heuristic</h3>
+  <p>
+    The number of themes is set automatically using the formula <code>k = round(√(n/2))</code> where <em>n</em> is the total number of embedded entries. This means:
+  </p>
+  <table>
+    <thead><tr><th>Embedded entries</th><th>Themes created</th></tr></thead>
+    <tbody>
+      <tr><td>4–7</td><td>2</td></tr>
+      <tr><td>8–17</td><td>2–3</td></tr>
+      <tr><td>18–31</td><td>3–4</td></tr>
+      <tr><td>50</td><td>5</td></tr>
+      <tr><td>200</td><td>10</td></tr>
+      <tr><td>800+</td><td>20 (maximum)</td></tr>
+    </tbody>
+  </table>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Troubleshooting — Neurologue Docs</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header class="site-header">
+  <div class="header-inner">
+    <a href="index.html" class="site-logo">Neurologue</a>
+    <nav class="site-nav">
+      <a href="index.html">Overview</a>
+      <a href="capture.html">Capture</a>
+      <a href="library.html">Library</a>
+      <a href="themes.html">Themes</a>
+      <a href="export.html">Export</a>
+      <a href="troubleshooting.html" class="active">Troubleshooting</a>
+    </nav>
+  </div>
+</header>
+
+<main class="page-content">
+  <h1>Troubleshooting</h1>
+  <p class="page-subtitle">Solutions to the most common issues.</p>
+
+  <h2>Ollama is not running</h2>
+
+  <p><strong>Symptoms:</strong> Semantic search shows "Ollama not available — showing text results instead". Themes never appear. No embeddings are generated.</p>
+
+  <h3>Check if Ollama is running</h3>
+  <p>Open a terminal and run:</p>
+  <pre><code>curl http://127.0.0.1:11434/api/tags</code></pre>
+  <p>If you get a JSON response listing your models, Ollama is running. If you get a connection error, it's not.</p>
+
+  <h3>Start Ollama</h3>
+  <p>On Windows, Ollama runs as a system tray application. Look for it in the system tray near the clock. If it's not there, launch it from the Start menu or run:</p>
+  <pre><code>ollama serve</code></pre>
+
+  <h3>Pull the required models</h3>
+  <p>If Ollama is running but models are missing:</p>
+  <pre><code>ollama pull nomic-embed-text
+ollama pull phi3:mini</code></pre>
+
+  <div class="callout">
+    <p><code>nomic-embed-text</code> is required for embeddings and semantic search. <code>phi3:mini</code> is only needed for theme summaries — themes will still be created without it, just without the LLM description.</p>
+  </div>
+
+  <h2>No themes appearing</h2>
+
+  <p><strong>Cause:</strong> Themes require at least 4 entries to have been embedded, and clustering only runs after every 5 new embeddings in the current session.</p>
+
+  <h3>Check your entry count</h3>
+  <p>The entry count is shown in the top toolbar. You need at least 4 entries captured.</p>
+
+  <h3>Wait for embeddings</h3>
+  <p>
+    The background worker runs every 10 seconds and processes entries in batches of 5. If you've just started the app with many unembedded entries, it may take a minute or two to embed them all. Embeddings require Ollama to be running.
+  </p>
+
+  <h3>Trigger clustering manually (developer option)</h3>
+  <p>If you have 4+ embedded entries but no themes, open the DevTools console (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> in the library window) and run:</p>
+  <pre><code>await window.neurologue.triggerClustering()</code></pre>
+
+  <h2>Semantic search not working</h2>
+
+  <p><strong>Symptom:</strong> A yellow notice appears: "Ollama not available — showing text results instead."</p>
+  <p>This means Ollama was not reachable when you ran the search. The app falls back to text search automatically.</p>
+  <ul>
+    <li>Ensure Ollama is running (see above).</li>
+    <li>Ensure the <code>nomic-embed-text</code> model is pulled: <code>ollama list</code> should show it.</li>
+    <li>Try the search again — if Ollama just started, it may need a moment to be ready.</li>
+  </ul>
+
+  <h2>Theme summaries show "No summary yet"</h2>
+
+  <p>This means clustering ran successfully but the LLM summary step couldn't complete. This happens when:</p>
+  <ul>
+    <li><code>phi3:mini</code> is not pulled yet — run <code>ollama pull phi3:mini</code></li>
+    <li>Ollama was unavailable or slow at the time clustering ran — summaries will be generated the next time clustering runs</li>
+  </ul>
+
+  <h2>Entries saved but not appearing in library</h2>
+
+  <p>The library loads entries when the window opens. If you captured an entry while the library was already open, it should appear immediately. If it doesn't:</p>
+  <ul>
+    <li>Check the entry count in the toolbar — it updates in real time.</li>
+    <li>If you have an active tag filter or search query, the new entry may be filtered out. Click <strong>All entries</strong> in the sidebar to clear filters.</li>
+  </ul>
+
+  <h2>Hotkey not working</h2>
+
+  <ul>
+    <li>Ensure Neurologue is running (check the taskbar or system tray).</li>
+    <li>The hotkey is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd>. Another application may have registered the same combination — check for conflicts in your OS keyboard settings or other running apps.</li>
+  </ul>
+
+  <h2>Data location</h2>
+  <p>Neurologue stores all data under your OS user data directory:</p>
+  <table>
+    <thead><tr><th>OS</th><th>Path</th></tr></thead>
+    <tbody>
+      <tr><td>Windows</td><td><code>%APPDATA%\Neurologue\</code></td></tr>
+      <tr><td>macOS</td><td><code>~/Library/Application Support/Neurologue/</code></td></tr>
+      <tr><td>Linux</td><td><code>~/.config/Neurologue/</code></td></tr>
+    </tbody>
+  </table>
+  <p>Inside you'll find <code>neurologue.db</code> (SQLite) and <code>vector-store/</code> (LanceDB).</p>
+
+  <div class="callout danger">
+    <p><strong>Do not delete the data folder</strong> unless you want to start fresh. There is currently no built-in backup — use <a href="export.html">Export</a> to take snapshots of your data.</p>
+  </div>
+</main>
+
+<footer class="site-footer">
+  <p>Neurologue &mdash; local-first &mdash; <a href="https://github.com/codebureau/neurologue" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #23

## What's included

### Documentation website (\website/\)
Static multi-page site matching the app's dark theme — zero build tools, zero dependencies.

| Page | Contents |
|---|---|
| \index.html\ | Overview, how it works (flow diagram), requirements, quick start |
| \capture.html\ | Global hotkey, popup UI, keyboard shortcuts, what gets saved |
| \library.html\ | Three-panel layout, text vs semantic search, tag filtering, entry/theme detail |
| \	hemes.html\ | Theme generation, timing table, cluster count heuristic, similarity scores |
| \export.html\ | Output files, using with NotebookLM / Claude / Copilot / custom pipelines |
| \	roubleshooting.html\ | Ollama issues, no themes, semantic fallback, data location |

### GitHub Actions (\.github/workflows/deploy-docs.yml\)
- Triggers on push to \main\ touching \website/**\, and on \workflow_dispatch\
- Deploys \website/\ to GitHub Pages → \https://codebureau.github.io/neurologue\
- Uses \ctions/configure-pages\, \upload-pages-artifact\, \deploy-pages\

### In-app Help button
- \src/main.js\: \help:open\ IPC handler using \shell.openExternal\
- \src/frontend/preload.js\: \openHelp()\ exposed to renderer
- \src/frontend/index.html\: **Help** button in toolbar (after Export…)
- \src/frontend/library.js\: click handler wired

## Setup required
After merge, go to **Settings → Pages → Source** and set to **GitHub Actions**. The workflow will then deploy automatically on every push that touches \website/\.

## Tests
118 passing, no regressions.