### PR TITLE
feat: Ollama + worker status bar and auto-refresh UI (closes #33, closes #34, closes #35)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -80,6 +80,13 @@
       </div>
 
     </div><!-- /#body -->
+
+    <!-- ── Status bar ───────────────────────────────────────────────── -->
+    <div id="status-bar">
+      <span id="status-ollama"></span>
+      <span id="status-worker"></span>
+    </div>
+
   </div><!-- /#app -->
 
   <script src="library.js"></script>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -443,3 +443,29 @@ html, body {
 }
 #export-toast.success { border-color: var(--cortex-teal); color: var(--cortex-teal); }
 #export-toast.error   { border-color: var(--danger);      color: var(--danger); }
+
+/* ── Status bar ───────────────────────────────────────────────────────── */
+#status-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 16px;
+  height: 28px;
+  flex-shrink: 0;
+  background: var(--neuro-blue);
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+  background: var(--text-dim);
+}
+.status-dot.active     { background: var(--cortex-teal); }
+.status-dot.processing { background: var(--synapse-gold); }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -35,6 +35,8 @@ const exportBtn     = document.getElementById('btn-export');
 const exportToast   = document.getElementById('export-toast');
 const helpBtn       = document.getElementById('btn-help');
 const semanticNotice = document.getElementById('semantic-notice');
+const statusOllama  = document.getElementById('status-ollama');
+const statusWorker  = document.getElementById('status-worker');
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 
@@ -368,10 +370,45 @@ helpBtn.addEventListener('click', () => {
   window.neurologue.openHelp();
 });
 
-// ── Init ───────────────────────────────────────────────────────────────────
+// ── Status bar ──────────────────────────────────────────────────────
+
+function updateStatus({ worker, ollama } = {}) {
+  if (ollama) {
+    const dot = ollama.running ? 'active' : '';
+    const label = ollama.running
+      ? `Ollama — ${ollama.availableModels.join(', ') || 'no models'}`
+      : 'Ollama not running';
+    statusOllama.innerHTML = `<span class="status-dot ${dot}"></span>${label}`;
+  }
+  if (worker) {
+    const processing = worker.queueLength > 0;
+    const dot = processing ? 'processing' : (worker.running ? 'active' : '');
+    let label;
+    if (!worker.running) {
+      label = 'Worker stopped';
+    } else if (processing) {
+      label = `Processing (${worker.queueLength} queued)`;
+    } else if (worker.lastProcessed) {
+      const d = new Date(worker.lastProcessed);
+      const ts = d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+      label = `Worker idle — last: ${ts}`;
+    } else {
+      label = 'Worker idle';
+    }
+    statusWorker.innerHTML = `<span class="status-dot ${dot}"></span>${label}`;
+  }
+}
+
+window.neurologue.onWorkerStatus(updateStatus);
+window.neurologue.onEntriesUpdated(() => { loadEntries(); loadTags(); });
+window.neurologue.onThemesUpdated(() => loadThemes());
+
+// ── Init ────────────────────────────────────────────────────────────
 
 (async () => {
   await loadTags();
   await loadThemes();
   await loadEntries();
+  // Fetch initial status (worker + Ollama) before first push event arrives
+  window.neurologue.getStatus().then(updateStatus).catch(() => {});
 })();

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -20,5 +20,11 @@ contextBridge.exposeInMainWorld('neurologue', {
 
   // ── Help ─────────────────────────────────────────────────────────────────
   openHelp: () => ipcRenderer.invoke('help:open'),
+
+  // ── Status ───────────────────────────────────────────────────────────────
+  getStatus: () => ipcRenderer.invoke('status:get'),
+  onWorkerStatus:     (cb) => { ipcRenderer.on('worker:status',           (_e, d) => cb(d)); },
+  onEntriesUpdated:   (cb) => { ipcRenderer.on('worker:entries-updated',  (_e, d) => cb(d)); },
+  onThemesUpdated:    (cb) => { ipcRenderer.on('worker:themes-updated',   (_e, d) => cb(d)); },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,15 +15,18 @@ const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/t
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey } = require('./capture/hotkey');
-const { startWorker, stopWorker } = require('./worker/index');
+const { startWorker, stopWorker, setMainWindow, workerStatus } = require('./worker/index');
+const { getOllamaStatus } = require('./worker/ollama');
 
 async function initialise() {
   await runMigrations();
   await initVectorStore();
 }
 
+let _mainWindow = null;
+
 function createMainWindow() {
-  const win = new BrowserWindow({
+  _mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
     webPreferences: {
@@ -33,7 +36,8 @@ function createMainWindow() {
     },
   });
 
-  win.loadFile(path.join(__dirname, 'frontend', 'index.html'));
+  _mainWindow.loadFile(path.join(__dirname, 'frontend', 'index.html'));
+  _mainWindow.on('closed', () => { _mainWindow = null; });
 }
 
 // IPC: renderer sends { content, tags } → main writes to DB
@@ -146,12 +150,24 @@ app.whenReady().then(async () => {
   createMainWindow();
   registerCaptureHotkey();
   startWorker();
+  // Wire the worker to push IPC events to the library window once it is ready
+  _mainWindow.webContents.on('did-finish-load', () => {
+    setMainWindow(_mainWindow.webContents);
+  });
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createMainWindow();
     }
   });
+});
+
+// ── Status IPC ────────────────────────────────────────────────────────────
+
+// Renderer calls this on startup to get initial status before the first push
+ipcMain.handle('status:get', async () => {
+  const ollama = await getOllamaStatus();
+  return { worker: workerStatus(), ollama };
 });
 
 app.on('window-all-closed', () => {

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -13,7 +13,7 @@
 const { listEntriesWithoutEmbedding, upsertEmbedding } = require('../backend/db/embeddings');
 const { getEntryById } = require('../backend/db/entries');
 const { upsertVector } = require('../backend/vector/store');
-const { generateEmbedding, isOllamaAvailable } = require('./ollama');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus } = require('./ollama');
 const { runClustering } = require('../backend/clustering/themes');
 const config = require('../config');
 
@@ -26,6 +26,16 @@ let _timer = null;
 let _running = false;
 let _paused = false;
 let _embeddedSinceCluster = 0;
+let _queueLength = 0;
+let _lastProcessed = null; // ISO timestamp of last successfully embedded entry
+let _webContents = null;  // set by setMainWindow() once the library window opens
+
+// Push a channel + payload to the renderer (silently no-ops if window not ready)
+function _push(channel, payload) {
+  if (_webContents && !_webContents.isDestroyed()) {
+    _webContents.send(channel, payload);
+  }
+}
 
 // ── Core processing ───────────────────────────────────────────────────────
 
@@ -35,15 +45,22 @@ async function processBatch() {
   const available = await isOllamaAvailable();
   if (!available) {
     console.log('[worker] Ollama not available — skipping tick');
+    _push('worker:status', await _buildStatus(false));
     return;
   }
 
   const entryIds = await listEntriesWithoutEmbedding();
-  if (entryIds.length === 0) return;
+  _queueLength = entryIds.length;
+  if (entryIds.length === 0) {
+    _push('worker:status', await _buildStatus(true));
+    return;
+  }
 
   const batch = entryIds.slice(0, BATCH_SIZE);
   console.log(`[worker] Processing ${batch.length} of ${entryIds.length} pending entries`);
+  _push('worker:status', await _buildStatus(true));
 
+  let newEmbeddings = 0;
   for (const id of batch) {
     try {
       const entry = await getEntryById(id);
@@ -60,10 +77,17 @@ async function processBatch() {
 
       console.log(`[worker] Embedded entry ${id.slice(0, 8)}…`);
       _embeddedSinceCluster++;
+      _lastProcessed = new Date().toISOString();
+      _queueLength = Math.max(0, _queueLength - 1);
+      newEmbeddings++;
     } catch (err) {
       // Log and continue — a single failure must not stop the batch
       console.error(`[worker] Failed to embed entry ${id.slice(0, 8)}…: ${err.message}`);
     }
+  }
+
+  if (newEmbeddings > 0) {
+    _push('worker:entries-updated', {});
   }
 
   // Trigger clustering after enough new embeddings
@@ -75,11 +99,14 @@ async function processBatch() {
         console.log(`[worker] Clustering skipped: ${result.reason}`);
       } else {
         console.log(`[worker] Clustering complete — ${result.themes} themes`);
+        _push('worker:themes-updated', {});
       }
     } catch (err) {
       console.error('[worker] Clustering error:', err.message);
     }
   }
+
+  _push('worker:status', await _buildStatus(true));
 }
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -126,7 +153,30 @@ function resumeWorker() { _paused = false; console.log('[worker] Resumed'); }
  * Returns current worker state — useful for a status UI.
  */
 function workerStatus() {
-  return { running: _running, paused: _paused };
+  return {
+    running: _running,
+    paused: _paused,
+    queueLength: _queueLength,
+    lastProcessed: _lastProcessed,
+  };
 }
 
-module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus };
+/**
+ * Build the full status payload (worker + ollama) for pushing to renderer.
+ * @param {boolean} ollamaReachable - whether the current tick found Ollama up
+ */
+async function _buildStatus(ollamaReachable) {
+  const ollama = ollamaReachable ? await getOllamaStatus() : { running: false, availableModels: [], loadedModels: [] };
+  return { worker: workerStatus(), ollama };
+}
+
+/**
+ * Register the renderer's webContents so the worker can push IPC events.
+ * Call this once from main.js after the library window is created.
+ * @param {Electron.WebContents} webContents
+ */
+function setMainWindow(webContents) {
+  _webContents = webContents;
+}
+
+module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus, setMainWindow, getOllamaStatus };

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -98,4 +98,56 @@ function isOllamaAvailable() {
   });
 }
 
-module.exports = { generateEmbedding, isOllamaAvailable };
+/**
+ * GET helper for Ollama (no request body).
+ * @param {string} path
+ * @param {number} timeoutMs
+ * @returns {Promise<object|null>} parsed JSON or null on error/timeout
+ */
+function ollamaGet(path, timeoutMs = 3000) {
+  return new Promise((resolve) => {
+    const url = new URL(config.ollama.baseUrl);
+    const req = http.request(
+      { hostname: url.hostname, port: url.port || 11434, path, method: 'GET' },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.setTimeout(timeoutMs, () => { req.destroy(); resolve(null); });
+    req.on('error', () => resolve(null));
+    req.end();
+  });
+}
+
+/**
+ * Get detailed Ollama runtime status.
+ * @returns {Promise<{running: boolean, availableModels: string[], loadedModels: Array<{name:string,sizeVram:number}>}>}
+ */
+async function getOllamaStatus() {
+  const [tags, ps] = await Promise.all([
+    ollamaGet('/api/tags'),
+    ollamaGet('/api/ps'),
+  ]);
+
+  if (!tags) {
+    return { running: false, availableModels: [], loadedModels: [] };
+  }
+
+  const availableModels = (tags.models || []).map((m) => m.name);
+  const loadedModels = (ps && ps.models ? ps.models : []).map((m) => ({
+    name: m.name,
+    sizeVram: m.size_vram || 0,
+  }));
+
+  return { running: true, availableModels, loadedModels };
+}
+
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus };

--- a/tests/unit/worker/ollama.test.js
+++ b/tests/unit/worker/ollama.test.js
@@ -8,7 +8,7 @@
 
 jest.mock('http', () => ({ request: jest.fn() }));
 const http = require('http');
-const { generateEmbedding, isOllamaAvailable } = require('../../../src/worker/ollama');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus } = require('../../../src/worker/ollama');
 
 // ---------------------------------------------------------------------------
 // Helpers to build fake HTTP request/response pairs
@@ -147,5 +147,90 @@ describe('isOllamaAvailable', () => {
     mockHttpTimeout();
     const result = await isOllamaAvailable();
     expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOllamaStatus
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock for a single GET request that returns the given body.
+ * Returns the mock implementation function (for use with mockImplementationOnce).
+ */
+function makeGetMock(statusCode, body) {
+  return (_opts, callback) => {
+    const resHandlers = {};
+    const mockRes = {
+      statusCode,
+      on: jest.fn((event, handler) => { resHandlers[event] = handler; }),
+    };
+    return {
+      setTimeout: jest.fn(),
+      on: jest.fn(),
+      end: jest.fn(() => {
+        callback(mockRes);
+        if (resHandlers.data) {
+          resHandlers.data(Buffer.from(typeof body === 'string' ? body : JSON.stringify(body)));
+        }
+        if (resHandlers.end) resHandlers.end();
+      }),
+    };
+  };
+}
+
+/** Build a connection-error mock for a GET (no callback). */
+function makeGetErrorMock(message) {
+  return () => {
+    const errHandlers = {};
+    return {
+      setTimeout: jest.fn(),
+      on: jest.fn((event, handler) => { errHandlers[event] = handler; }),
+      end: jest.fn(() => {
+        if (errHandlers.error) errHandlers.error(new Error(message));
+      }),
+    };
+  };
+}
+
+describe('getOllamaStatus', () => {
+  test('returns running=true with model lists when Ollama responds', async () => {
+    const tagBody = { models: [{ name: 'nomic-embed-text:latest' }, { name: 'phi3:mini' }] };
+    const psBody  = { models: [{ name: 'phi3:mini', size_vram: 1234567 }] };
+    http.request
+      .mockImplementationOnce(makeGetMock(200, tagBody))
+      .mockImplementationOnce(makeGetMock(200, psBody));
+
+    const result = await getOllamaStatus();
+
+    expect(result.running).toBe(true);
+    expect(result.availableModels).toEqual(['nomic-embed-text:latest', 'phi3:mini']);
+    expect(result.loadedModels).toEqual([{ name: 'phi3:mini', sizeVram: 1234567 }]);
+  });
+
+  test('returns running=true with empty loadedModels when /api/ps returns empty list', async () => {
+    const tagBody = { models: [{ name: 'nomic-embed-text:latest' }] };
+    const psBody  = { models: [] };
+    http.request
+      .mockImplementationOnce(makeGetMock(200, tagBody))
+      .mockImplementationOnce(makeGetMock(200, psBody));
+
+    const result = await getOllamaStatus();
+
+    expect(result.running).toBe(true);
+    expect(result.availableModels).toEqual(['nomic-embed-text:latest']);
+    expect(result.loadedModels).toEqual([]);
+  });
+
+  test('returns running=false when Ollama is not reachable', async () => {
+    http.request
+      .mockImplementationOnce(makeGetErrorMock('connect ECONNREFUSED'))
+      .mockImplementationOnce(makeGetErrorMock('connect ECONNREFUSED'));
+
+    const result = await getOllamaStatus();
+
+    expect(result.running).toBe(false);
+    expect(result.availableModels).toEqual([]);
+    expect(result.loadedModels).toEqual([]);
   });
 });

--- a/website/library.html
+++ b/website/library.html
@@ -104,6 +104,44 @@
   <p>
     Below the tag list is a <strong>Themes</strong> section. This lists all auto-generated theme clusters. Click any theme to open its detail view in the right panel. See the <a href="themes.html">Themes</a> section for more.
   </p>
+
+  <h2>Status bar</h2>
+  <p>
+    A thin bar at the bottom of the window shows live status for Ollama and the background worker. It updates automatically — you never need to refresh or restart the app to see current state.
+  </p>
+
+  <h3>Indicators</h3>
+  <p>Each indicator has a coloured dot followed by a short description:</p>
+  <table>
+    <thead><tr><th>Dot colour</th><th>Meaning</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Teal</strong></td><td>Running / active — Ollama is reachable, or the worker is running and idle</td></tr>
+      <tr><td><strong>Gold</strong></td><td>Processing — the worker is currently embedding entries</td></tr>
+      <tr><td><strong>Dim grey</strong></td><td>Stopped / not reachable — Ollama is not running, or the worker has stopped</td></tr>
+    </tbody>
+  </table>
+
+  <h3>Ollama indicator</h3>
+  <p>Shows one of:</p>
+  <ul>
+    <li><strong>Ollama — nomic-embed-text:latest, phi3:mini</strong> (teal dot) — Ollama is running and those models are available</li>
+    <li><strong>Ollama not running</strong> (grey dot) — Ollama is not reachable; semantic search and embedding will not work</li>
+  </ul>
+
+  <h3>Worker indicator</h3>
+  <p>Shows one of:</p>
+  <ul>
+    <li><strong>Processing (N queued)</strong> (gold dot) — the background worker is actively embedding entries; N is how many remain</li>
+    <li><strong>Worker idle — last: Mon DD HH:MM</strong> (teal dot) — all entries are embedded; shows when the last one was processed</li>
+    <li><strong>Worker idle</strong> (teal dot) — running but no entries have been embedded yet in this session</li>
+    <li><strong>Worker stopped</strong> (grey dot) — the worker is not running</li>
+  </ul>
+
+  <h3>Auto-refresh</h3>
+  <p>
+    When the worker finishes embedding new entries, the timeline and tag list refresh automatically — you will see newly captured entries appear without any manual action.
+    When clustering completes and new themes are generated, the themes sidebar also refreshes automatically.
+  </p>
 </main>
 
 <footer class="site-footer">

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -28,7 +28,7 @@
 
   <h2>Ollama is not running</h2>
 
-  <p><strong>Symptoms:</strong> Semantic search shows "Ollama not available — showing text results instead". Themes never appear. No embeddings are generated.</p>
+  <p><strong>Symptoms:</strong> The status bar at the bottom of the library window shows <strong>Ollama not running</strong> (grey dot). Semantic search shows "Ollama not available — showing text results instead". Themes never appear. No embeddings are generated.</p>
 
   <h3>Check if Ollama is running</h3>
   <p>Open a terminal and run:</p>
@@ -59,6 +59,9 @@ ollama pull phi3:mini</code></pre>
   <p>
     The background worker runs every 10 seconds and processes entries in batches of 5. If you've just started the app with many unembedded entries, it may take a minute or two to embed them all. Embeddings require Ollama to be running.
   </p>
+  <p>
+    Watch the <strong>Worker indicator</strong> in the status bar at the bottom of the window — a gold dot labelled <strong>Processing (N queued)</strong> means embeddings are in progress. Once it turns teal and the themes sidebar auto-refreshes, clustering has completed.
+  </p>
 
   <h3>Trigger clustering manually (developer option)</h3>
   <p>If you have 4+ embedded entries but no themes, open the DevTools console (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> in the library window) and run:</p>
@@ -84,9 +87,10 @@ ollama pull phi3:mini</code></pre>
 
   <h2>Entries saved but not appearing in library</h2>
 
-  <p>The library loads entries when the window opens. If you captured an entry while the library was already open, it should appear immediately. If it doesn't:</p>
+  <p>The timeline refreshes automatically once the background worker has embedded a new entry. If a captured entry is not appearing:</p>
   <ul>
-    <li>Check the entry count in the toolbar — it updates in real time.</li>
+    <li>Check the <strong>Worker indicator</strong> in the status bar — if it shows <strong>Processing</strong>, the worker is still running; wait a moment and the timeline will update on its own.</li>
+    <li>Check the entry count in the toolbar — it updates whenever the timeline refreshes.</li>
     <li>If you have an active tag filter or search query, the new entry may be filtered out. Click <strong>All entries</strong> in the sidebar to clear filters.</li>
   </ul>
 


### PR DESCRIPTION
﻿## Summary

Implements issues #33, #34, and #35 in a single PR since they share the same IPC infrastructure.

### Changes

**`src/worker/ollama.js`**
- Added `ollamaGet()` helper — lightweight GET request with configurable timeout
- Added `getOllamaStatus()` — queries `/api/tags` and `/api/ps` in parallel; returns `{ running, availableModels, loadedModels }`; gracefully returns `running: false` on any error

**`src/worker/index.js`**
- Added `_webContents` reference and `setMainWindow(wc)` export
- Added `_push(channel, payload)` helper (no-ops if window not ready/destroyed)
- Added `queueLength` and `lastProcessed` fields to `workerStatus()`
- Worker now pushes `worker:entries-updated` after new embeddings, `worker:themes-updated` after clustering, and `worker:status` on each tick
- Exports `setMainWindow` and re-exports `getOllamaStatus`

**`src/main.js`**
- `_mainWindow` is now saved at module-level (was a local variable)
- After `did-finish-load`, calls `setMainWindow(_mainWindow.webContents)` to wire the push channel
- Added `ipcMain.handle('status:get', ...)` returning `{ worker, ollama }` for initial load

**`src/frontend/preload.js`**
- Exposed `getStatus()`, `onWorkerStatus(cb)`, `onEntriesUpdated(cb)`, `onThemesUpdated(cb)`

**`src/frontend/index.html`**
- Added `<div id="status-bar">` with `#status-ollama` and `#status-worker` spans, below `#body`

**`src/frontend/library.css`**
- Added `#status-bar` styles (28px height, neuro-blue bg, border-top)
- Added `.status-dot`, `.status-dot.active` (teal), `.status-dot.processing` (gold)

**`src/frontend/library.js`**
- Added `updateStatus({ worker, ollama })` rendering coloured dot + descriptive label
- Registered `onWorkerStatus`, `onEntriesUpdated`, `onThemesUpdated` listeners
- Init calls `getStatus().then(updateStatus)` for immediate display before first push

**`tests/unit/worker/ollama.test.js`**
- Added 3 tests for `getOllamaStatus`: running with models, running with empty loadedModels, not reachable

### Test Results
121 tests passing across 12 suites (was 118)
