### PR TITLE
feat: Ollama detection, guided setup flow, model pull, and configurable models (closes #28, closes #29, closes #30, closes #31)

### DIFF
--- a/src/backend/clustering/themes.js
+++ b/src/backend/clustering/themes.js
@@ -14,6 +14,7 @@ const { kmeans, cosineSimilarity } = require('./kmeans');
 const { openDb } = require('../db/connection');
 const { upsertTheme, setThemeEntries, listThemes } = require('../db/themes');
 const { isOllamaAvailable } = require('../../worker/ollama');
+const { getSettings } = require('../settings');
 const config = require('../../config');
 const http = require('http');
 
@@ -134,7 +135,7 @@ async function runClustering() {
 function generateTextCompletion(prompt) {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({
-      model: config.ollama.llmModel,
+      model: getSettings().llmModel,
       prompt,
       stream: false,
     });

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/**
+ * User-editable runtime settings (model choices etc.).
+ *
+ * Persisted as JSON in the app's user-data directory alongside the SQLite DB.
+ * Falls back to hard-coded defaults from config.js when the file is absent.
+ *
+ * All reads are synchronous — the file is tiny and only called from the main
+ * process.  Do not require this module from the renderer.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const config = require('../config');
+
+const SETTINGS_PATH = config.settings.path;
+
+/** @type {{ embeddingModel: string, llmModel: string }} */
+const DEFAULTS = {
+  embeddingModel: config.ollama.embeddingModel,
+  llmModel:       config.ollama.llmModel,
+};
+
+/**
+ * Read persisted settings, merged over defaults.
+ * Returns defaults when the settings file does not exist or is malformed.
+ * @returns {{ embeddingModel: string, llmModel: string }}
+ */
+function getSettings() {
+  try {
+    const raw = fs.readFileSync(SETTINGS_PATH, 'utf8');
+    return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+/**
+ * Persist a partial settings update and return the merged result.
+ * @param {Partial<{embeddingModel: string, llmModel: string}>} updates
+ * @returns {{ embeddingModel: string, llmModel: string }}
+ */
+function saveSettings(updates) {
+  const next = { ...getSettings(), ...updates };
+  fs.mkdirSync(path.dirname(SETTINGS_PATH), { recursive: true });
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(next, null, 2), 'utf8');
+  return next;
+}
+
+module.exports = { getSettings, saveSettings };

--- a/src/config.js
+++ b/src/config.js
@@ -22,8 +22,13 @@ const config = {
   vectorStore: {
     path: path.join(userDataPath, 'vector-store'),
   },
+  settings: {
+    // User-editable runtime preferences (model choices etc.)
+    path: path.join(userDataPath, 'settings.json'),
+  },
   ollama: {
     baseUrl: 'http://127.0.0.1:11434',
+    // Defaults — overridden at runtime by src/backend/settings.js
     embeddingModel: 'nomic-embed-text',
     llmModel: 'phi3:mini',
   },

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -21,6 +21,7 @@
       </div>
       <span id="entry-count"></span>
       <button id="btn-export" class="mode-btn">Export…</button>
+      <button id="btn-settings" class="mode-btn" title="Model settings">⚙</button>
       <button id="btn-help" class="mode-btn">Help</button>
     </div>
 
@@ -88,6 +89,62 @@
     </div>
 
   </div><!-- /#app -->
+
+  <!-- ── Setup modal (Ollama not installed / not running / models missing) ─── -->
+  <div id="setup-modal" class="modal-overlay hidden">
+    <div class="modal-box">
+      <button class="modal-close" id="setup-close" title="Skip for now">✕</button>
+
+      <div class="setup-step" id="step-install">
+        <div class="setup-icon">⚡</div>
+        <h2>Ollama is not installed</h2>
+        <p>Neurologue uses Ollama to generate embeddings and theme summaries. Without it, semantic search and themes won’t work — but text search and capture still do.</p>
+        <button class="btn-setup-primary" id="btn-ollama-download">Download Ollama →</button>
+        <p class="setup-hint">After installing, click <strong>Check again</strong>.</p>
+        <button class="btn-setup-secondary" id="btn-recheck-install">Check again</button>
+      </div>
+
+      <div class="setup-step hidden" id="step-start">
+        <div class="setup-icon">⚡</div>
+        <h2>Ollama is not running</h2>
+        <p>Ollama is installed but not running. Start it to enable semantic search and theme generation.</p>
+        <pre class="setup-code">ollama serve</pre>
+        <p class="setup-hint">Or launch Ollama from your system tray / Start menu, then click <strong>Check again</strong>.</p>
+        <button class="btn-setup-secondary" id="btn-recheck-running">Check again</button>
+      </div>
+
+      <div class="setup-step hidden" id="step-models">
+        <div class="setup-icon">📦</div>
+        <h2>Required models not found</h2>
+        <p>Neurologue needs the following Ollama models to be pulled locally. Click <strong>Pull all</strong> to download them now.</p>
+        <div id="model-pull-list"></div>
+        <button class="btn-setup-primary" id="btn-pull-all">Pull all missing models</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Settings modal ────────────────────────────────────────────────────── -->
+  <div id="settings-modal" class="modal-overlay hidden">
+    <div class="modal-box">
+      <button class="modal-close" id="settings-close" title="Close">✕</button>
+      <h2>Model settings</h2>
+      <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
+      <div class="settings-field">
+        <label for="select-embed-model">Embedding model</label>
+        <select id="select-embed-model"></select>
+        <span class="settings-hint">Used for semantic search. Changing this will re-embed your entries over time.</span>
+      </div>
+      <div class="settings-field">
+        <label for="select-llm-model">LLM model (theme summaries)</label>
+        <select id="select-llm-model"></select>
+        <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
+      </div>
+      <div class="settings-actions">
+        <button class="btn-setup-primary" id="btn-save-settings">Save settings</button>
+        <span class="settings-saved hidden" id="settings-saved-msg">✓ Saved</span>
+      </div>
+    </div>
+  </div>
 
   <script src="library.js"></script>
 </body>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -469,3 +469,165 @@ html, body {
 }
 .status-dot.active     { background: var(--cortex-teal); }
 .status-dot.processing { background: var(--synapse-gold); }
+
+/* ── Modals (setup + settings) ───────────────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.modal-overlay.hidden { display: none; }
+
+.modal-box {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 2);
+  padding: 32px 36px;
+  max-width: 480px;
+  width: calc(100% - 48px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  color: var(--text);
+}
+.modal-box h2 {
+  margin: 0 0 10px;
+  font-size: 17px;
+  font-weight: 600;
+}
+.modal-box p {
+  margin: 0 0 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+.modal-close {
+  position: absolute;
+  top: 12px; right: 12px;
+  background: none; border: none;
+  color: var(--text-dim);
+  font-size: 16px; cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius);
+}
+.modal-close:hover { color: var(--text); background: var(--surface2); }
+
+/* ── Setup steps ────────────────────────────────────────────────────────── */
+.setup-step.hidden { display: none; }
+
+.setup-icon { font-size: 28px; margin-bottom: 12px; }
+
+.setup-hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin: 8px 0 12px;
+}
+.setup-code {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-family: monospace;
+  font-size: 13px;
+  color: var(--cortex-teal);
+  margin: 0 0 12px;
+  user-select: text;
+}
+.btn-setup-primary {
+  display: inline-block;
+  background: var(--cortex-teal);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  padding: 8px 16px;
+  font-size: 13px;
+  cursor: pointer;
+  margin-right: 8px;
+}
+.btn-setup-primary:hover { background: var(--teal-hover); }
+.btn-setup-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-setup-secondary {
+  display: inline-block;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.btn-setup-secondary:hover { border-color: var(--text-muted); color: var(--text); }
+
+/* ── Model pull list ────────────────────────────────────────────────────── */
+.model-row {
+  padding: 10px 12px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.model-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.model-name  { font-family: monospace; font-size: 13px; color: var(--cortex-teal); }
+.model-status { font-size: 11px; color: var(--text-dim); }
+.progress-bar-outer {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.progress-bar-outer.hidden { display: none; }
+.progress-bar-inner {
+  height: 100%;
+  background: var(--cortex-teal);
+  border-radius: 2px;
+  transition: width 0.15s;
+  width: 0%;
+}
+
+/* ── Settings modal fields ──────────────────────────────────────────────── */
+.settings-field {
+  margin-bottom: 20px;
+}
+.settings-field label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+.settings-field select {
+  width: 100%;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 7px 10px;
+  font-size: 13px;
+}
+.settings-field select:focus { outline: none; border-color: var(--cortex-teal); }
+.settings-hint {
+  display: block;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 5px;
+}
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+}
+.settings-saved          { font-size: 12px; color: var(--cortex-teal); }
+.settings-saved.hidden   { display: none; }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -403,12 +403,207 @@ window.neurologue.onWorkerStatus(updateStatus);
 window.neurologue.onEntriesUpdated(() => { loadEntries(); loadTags(); });
 window.neurologue.onThemesUpdated(() => loadThemes());
 
+// ── Setup + settings modals ────────────────────────────────────────
+
+const setupModal    = document.getElementById('setup-modal');
+const settingsModal = document.getElementById('settings-modal');
+const btnSettings   = document.getElementById('btn-settings');
+
+function showSetupStep(stepId) {
+  document.querySelectorAll('.setup-step').forEach((el) => el.classList.add('hidden'));
+  document.getElementById(stepId).classList.remove('hidden');
+}
+
+function showSetupModal(step, data = {}) {
+  if (step === 'install') showSetupStep('step-install');
+  if (step === 'start')   showSetupStep('step-start');
+  if (step === 'models') {
+    showSetupStep('step-models');
+    renderModelPullList(data.missing || []);
+  }
+  setupModal.classList.remove('hidden');
+}
+
+function hideSetupModal() { setupModal.classList.add('hidden'); }
+
+// Build the per-model rows in the pull step
+function renderModelPullList(missing) {
+  const list = document.getElementById('model-pull-list');
+  list.innerHTML = '';
+  missing.forEach((name) => {
+    const safeId = name.replace(/[^a-z0-9]/gi, '-');
+    const row = document.createElement('div');
+    row.className = 'model-row';
+    row.innerHTML =
+      `<div class="model-row-header">` +
+      `<span class="model-name">${name}</span>` +
+      `<span class="model-status" id="mstatus-${safeId}">Not pulled</span>` +
+      `</div>` +
+      `<div class="progress-bar-outer hidden" id="mbar-outer-${safeId}">` +
+      `<div class="progress-bar-inner" id="mbar-${safeId}"></div>` +
+      `</div>`;
+    list.appendChild(row);
+  });
+}
+
+// Stream progress from ollama:pull-progress IPC events
+window.neurologue.onPullProgress((progress) => {
+  const safeId    = (progress.name || '').replace(/[^a-z0-9]/gi, '-');
+  const statusEl  = document.getElementById(`mstatus-${safeId}`);
+  const barOuter  = document.getElementById(`mbar-outer-${safeId}`);
+  const barInner  = document.getElementById(`mbar-${safeId}`);
+  if (!statusEl) return;
+
+  if (progress.total && progress.completed !== undefined) {
+    barOuter && barOuter.classList.remove('hidden');
+    const pct = Math.round((progress.completed / progress.total) * 100);
+    if (barInner) barInner.style.width = pct + '%';
+    statusEl.textContent = `Downloading… ${pct}%`;
+  } else if (progress.status === 'success') {
+    barOuter && barOuter.classList.add('hidden');
+    statusEl.textContent = '✓ Ready';
+  } else {
+    statusEl.textContent = progress.status || 'Working…';
+  }
+});
+
+async function pullAllMissing() {
+  const pullAllBtn = document.getElementById('btn-pull-all');
+  const missing = Array.from(
+    document.querySelectorAll('#model-pull-list .model-name')
+  ).map((el) => el.textContent);
+
+  pullAllBtn.disabled    = true;
+  pullAllBtn.textContent = 'Pulling…';
+
+  for (const name of missing) {
+    const result = await window.neurologue.pullModel(name);
+    if (!result.ok) {
+      const safeId = name.replace(/[^a-z0-9]/gi, '-');
+      const statusEl = document.getElementById(`mstatus-${safeId}`);
+      if (statusEl) statusEl.textContent = `Error: ${result.error}`;
+    }
+  }
+
+  pullAllBtn.disabled    = false;
+  pullAllBtn.textContent = 'Pull all missing models';
+
+  const newStatus = await window.neurologue.getStatus();
+  updateStatus(newStatus);
+  hideSetupModal();
+}
+
+document.getElementById('setup-close').addEventListener('click', hideSetupModal);
+
+document.getElementById('btn-ollama-download').addEventListener('click', () => {
+  window.neurologue.openOllamaDownload();
+});
+
+document.getElementById('btn-recheck-install').addEventListener('click', async () => {
+  const result = await window.neurologue.checkOllamaInstalled();
+  if (result.installed) {
+    const status = await window.neurologue.getStatus();
+    updateStatus(status);
+    if (!status.ollama.running) {
+      showSetupModal('start');
+    } else {
+      await runModelCheck(status);
+    }
+  }
+});
+
+document.getElementById('btn-recheck-running').addEventListener('click', async () => {
+  const status = await window.neurologue.getStatus();
+  updateStatus(status);
+  if (status.ollama.running) {
+    await runModelCheck(status);
+  }
+});
+
+document.getElementById('btn-pull-all').addEventListener('click', pullAllMissing);
+
+// ── Settings modal ─────────────────────────────────────────────────
+
+btnSettings.addEventListener('click', async () => {
+  const [settings, status] = await Promise.all([
+    window.neurologue.getSettings(),
+    window.neurologue.getStatus(),
+  ]);
+  const available = status.ollama.availableModels;
+
+  function buildOptions(selectId, models, current) {
+    const select = document.getElementById(selectId);
+    select.innerHTML = '';
+    // Always include the currently configured model even if Ollama is offline
+    const allModels = [...new Set([current, ...models])].filter(Boolean);
+    allModels.forEach((m) => {
+      const opt = document.createElement('option');
+      opt.value = m;
+      opt.textContent = m;
+      opt.selected = (m === current);
+      select.appendChild(opt);
+    });
+  }
+
+  buildOptions('select-embed-model', available, settings.embeddingModel);
+  buildOptions('select-llm-model',   available, settings.llmModel);
+  settingsModal.classList.remove('hidden');
+});
+
+document.getElementById('settings-close').addEventListener('click', () => {
+  settingsModal.classList.add('hidden');
+});
+
+document.getElementById('btn-save-settings').addEventListener('click', async () => {
+  const embedModel = document.getElementById('select-embed-model').value;
+  const llmModel   = document.getElementById('select-llm-model').value;
+  await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel });
+  const msg = document.getElementById('settings-saved-msg');
+  msg.classList.remove('hidden');
+  setTimeout(() => msg.classList.add('hidden'), 2000);
+});
+
+// ── Startup setup check ────────────────────────────────────────────
+
+// True if a model name from settings matches one of the available model strings
+function modelAvailable(model, available) {
+  const base = model.split(':')[0];
+  return available.some((a) => a === model || a.split(':')[0] === base);
+}
+
+async function runModelCheck(status) {
+  const settings = await window.neurologue.getSettings();
+  const required = [settings.embeddingModel, settings.llmModel];
+  const missing  = required.filter((m) => !modelAvailable(m, status.ollama.availableModels));
+  if (missing.length > 0) {
+    showSetupModal('models', { missing });
+  } else {
+    hideSetupModal();
+  }
+}
+
+async function runSetupCheck() {
+  try {
+    const status = await window.neurologue.getStatus();
+    updateStatus(status);
+
+    if (!status.ollama.running) {
+      const installed = await window.neurologue.checkOllamaInstalled();
+      showSetupModal(installed.installed ? 'start' : 'install');
+      return;
+    }
+
+    await runModelCheck(status);
+  } catch (err) {
+    console.error('[library] setup check failed:', err);
+  }
+}
+
 // ── Init ────────────────────────────────────────────────────────────
 
 (async () => {
   await loadTags();
   await loadThemes();
   await loadEntries();
-  // Fetch initial status (worker + Ollama) before first push event arrives
-  window.neurologue.getStatus().then(updateStatus).catch(() => {});
+  runSetupCheck(); // checks Ollama install + models, shows modal if needed
 })();

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -26,5 +26,15 @@ contextBridge.exposeInMainWorld('neurologue', {
   onWorkerStatus:     (cb) => { ipcRenderer.on('worker:status',           (_e, d) => cb(d)); },
   onEntriesUpdated:   (cb) => { ipcRenderer.on('worker:entries-updated',  (_e, d) => cb(d)); },
   onThemesUpdated:    (cb) => { ipcRenderer.on('worker:themes-updated',   (_e, d) => cb(d)); },
+
+  // ── Settings ─────────────────────────────────────────────────────────────
+  getSettings:  ()        => ipcRenderer.invoke('settings:get'),
+  saveSettings: (updates) => ipcRenderer.invoke('settings:save', updates),
+
+  // ── Ollama setup ─────────────────────────────────────────────────────────
+  openOllamaDownload:  ()     => ipcRenderer.invoke('ollama:open-download'),
+  checkOllamaInstalled: ()    => ipcRenderer.invoke('ollama:check-installed'),
+  pullModel:           (name) => ipcRenderer.invoke('ollama:pull-model', { name }),
+  onPullProgress:      (cb)   => { ipcRenderer.on('ollama:pull-progress', (_e, d) => cb(d)); },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -10,13 +10,14 @@ const { listTags } = require('./backend/db/tags');
 const { listEntries } = require('./backend/db/entries');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
-const { generateEmbedding, isOllamaAvailable } = require('./worker/ollama');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel } = require('./worker/ollama');
+const { getSettings, saveSettings } = require('./backend/settings');
 const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus } = require('./worker/index');
-const { getOllamaStatus } = require('./worker/ollama');
+// getOllamaStatus and getSettings imported above
 
 async function initialise() {
   await runMigrations();
@@ -127,7 +128,10 @@ ipcMain.handle('themes:cluster', async () => {
 ipcMain.handle('help:open', () => {
   shell.openExternal('https://codebureau.github.io/neurologue');
 });
-
+// Open the Ollama download page in the system browser
+ipcMain.handle('ollama:open-download', () => {
+  shell.openExternal('https://ollama.ai');
+});
 // ── Export IPC ───────────────────────────────────────────────────────────────
 
 // Show native folder picker and run export to chosen directory
@@ -168,6 +172,29 @@ app.whenReady().then(async () => {
 ipcMain.handle('status:get', async () => {
   const ollama = await getOllamaStatus();
   return { worker: workerStatus(), ollama };
+});
+
+// ── Settings IPC ──────────────────────────────────────────────────────────
+
+ipcMain.handle('settings:get', () => getSettings());
+ipcMain.handle('settings:save', (_e, updates) => saveSettings(updates));
+
+// ── Ollama setup IPC ───────────────────────────────────────────────────────
+
+ipcMain.handle('ollama:check-installed', () => checkOllamaInstalled());
+
+// Pull a model — long-running; streams NDJSON progress back to renderer
+ipcMain.handle('ollama:pull-model', async (event, { name }) => {
+  try {
+    await pullModel(name, (progress) => {
+      if (!event.sender.isDestroyed()) {
+        event.sender.send('ollama:pull-progress', { name, ...progress });
+      }
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -15,6 +15,7 @@ const { getEntryById } = require('../backend/db/entries');
 const { upsertVector } = require('../backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus } = require('./ollama');
 const { runClustering } = require('../backend/clustering/themes');
+const { getSettings } = require('../backend/settings');
 const config = require('../config');
 
 const POLL_INTERVAL_MS = 10_000; // check every 10 seconds
@@ -66,8 +67,8 @@ async function processBatch() {
       const entry = await getEntryById(id);
       if (!entry) continue;
 
-      const vector = await generateEmbedding(entry.content);
-      const modelName = config.ollama.embeddingModel;
+      const vector    = await generateEmbedding(entry.content);
+      const modelName = getSettings().embeddingModel;
 
       // Store in SQLite (compact BLOB backup)
       await upsertEmbedding(id, vector, modelName);

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -7,8 +7,10 @@
  * All requests go to the base URL defined in src/config.js.
  */
 
-const http = require('http');
+const http   = require('http');
+const { exec } = require('child_process');
 const config = require('../config');
+const { getSettings } = require('../backend/settings');
 
 /**
  * Send a JSON request to the Ollama API.
@@ -66,8 +68,9 @@ function ollamaRequest(path, body) {
  * @returns {Promise<Float32Array>}
  */
 async function generateEmbedding(text) {
+  const model = getSettings().embeddingModel;
   const response = await ollamaRequest('/api/embeddings', {
-    model: config.ollama.embeddingModel,
+    model,
     prompt: text,
   });
 
@@ -150,4 +153,79 @@ async function getOllamaStatus() {
   return { running: true, availableModels, loadedModels };
 }
 
-module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus };
+/**
+ * Check whether the `ollama` CLI is installed on this machine.
+ * @returns {Promise<{installed: boolean, version: string|null}>}
+ */
+function checkOllamaInstalled() {
+  return new Promise((resolve) => {
+    exec('ollama --version', { timeout: 5000 }, (err, stdout) => {
+      if (err) {
+        resolve({ installed: false, version: null });
+      } else {
+        const match = stdout.match(/(\d+\.\d+\.\d+)/);
+        resolve({ installed: true, version: match ? match[1] : stdout.trim() });
+      }
+    });
+  });
+}
+
+/**
+ * Pull an Ollama model, streaming progress events to the caller.
+ * @param {string} name  e.g. 'nomic-embed-text'
+ * @param {function} [onProgress]  called with each NDJSON progress object
+ * @returns {Promise<void>}
+ */
+function pullModel(name, onProgress) {
+  return new Promise((resolve, reject) => {
+    const url     = new URL(config.ollama.baseUrl);
+    const payload = JSON.stringify({ name, stream: true });
+
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port || 11434,
+        path: '/api/pull',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (chunk) => {
+          buf += chunk.toString('utf8');
+          // NDJSON: split on newlines, keep any incomplete tail
+          const lines = buf.split('\n');
+          buf = lines.pop();
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const obj = JSON.parse(line);
+              if (onProgress) onProgress(obj);
+            } catch { /* ignore malformed line */ }
+          }
+        });
+        res.on('end', () => {
+          // Flush any remaining buffer
+          if (buf.trim()) {
+            try {
+              const obj = JSON.parse(buf);
+              if (onProgress) onProgress(obj);
+            } catch { /* ignore */ }
+          }
+          resolve();
+        });
+      }
+    );
+
+    // 5-minute hard cap for large model downloads
+    req.setTimeout(300_000, () => req.destroy(new Error('pullModel timed out after 5 min')));
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel };

--- a/tests/unit/settings.test.js
+++ b/tests/unit/settings.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Tests for src/backend/settings.js
+ *
+ * NEUROLOGUE_DATA_PATH is set before requiring any modules so that
+ * config.js (and therefore settings.js) uses the test temp directory.
+ */
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+const TEST_DIR = path.join(os.tmpdir(), `neurologue-settings-test-${process.pid}`);
+process.env.NEUROLOGUE_DATA_PATH = TEST_DIR;
+
+// Must be required AFTER setting env
+const { getSettings, saveSettings } = require('../../src/backend/settings');
+
+const SETTINGS_FILE = path.join(TEST_DIR, 'settings.json');
+
+beforeEach(() => {
+  // Start each test with a clean slate
+  if (fs.existsSync(SETTINGS_FILE)) fs.unlinkSync(SETTINGS_FILE);
+});
+
+afterAll(() => {
+  // Clean up temp dir
+  try { fs.rmSync(TEST_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('getSettings', () => {
+  test('returns defaults when settings file does not exist', () => {
+    const s = getSettings();
+    expect(s.embeddingModel).toBe('nomic-embed-text');
+    expect(s.llmModel).toBe('phi3:mini');
+  });
+
+  test('returns defaults merged with saved values', () => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    fs.writeFileSync(SETTINGS_FILE, JSON.stringify({ embeddingModel: 'mxbai-embed-large' }), 'utf8');
+    const s = getSettings();
+    expect(s.embeddingModel).toBe('mxbai-embed-large');
+    expect(s.llmModel).toBe('phi3:mini'); // default preserved
+  });
+
+  test('returns defaults when settings file is malformed JSON', () => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+    fs.writeFileSync(SETTINGS_FILE, 'not json {{', 'utf8');
+    const s = getSettings();
+    expect(s.embeddingModel).toBe('nomic-embed-text');
+  });
+});
+
+describe('saveSettings', () => {
+  test('persists changes and returns merged result', () => {
+    const result = saveSettings({ embeddingModel: 'mxbai-embed-large' });
+    expect(result.embeddingModel).toBe('mxbai-embed-large');
+    expect(result.llmModel).toBe('phi3:mini');
+  });
+
+  test('written file is valid JSON', () => {
+    saveSettings({ llmModel: 'llama3:8b' });
+    const raw = fs.readFileSync(SETTINGS_FILE, 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+    expect(JSON.parse(raw).llmModel).toBe('llama3:8b');
+  });
+
+  test('merges successive partial updates', () => {
+    saveSettings({ embeddingModel: 'custom-embed' });
+    saveSettings({ llmModel: 'custom-llm' });
+    const s = getSettings();
+    expect(s.embeddingModel).toBe('custom-embed');
+    expect(s.llmModel).toBe('custom-llm');
+  });
+
+  test('creates the directory if it does not exist', () => {
+    const deepDir = path.join(TEST_DIR, 'nested', 'dir');
+    // Temporarily override SETTINGS_PATH by pointing to nested path
+    // (we test indirectly via the directory creation in saveSettings)
+    saveSettings({ embeddingModel: 'test' });
+    expect(fs.existsSync(SETTINGS_FILE)).toBe(true);
+  });
+});

--- a/tests/unit/worker/ollama.test.js
+++ b/tests/unit/worker/ollama.test.js
@@ -7,8 +7,10 @@
  */
 
 jest.mock('http', () => ({ request: jest.fn() }));
+jest.mock('child_process', () => ({ exec: jest.fn() }));
 const http = require('http');
-const { generateEmbedding, isOllamaAvailable, getOllamaStatus } = require('../../../src/worker/ollama');
+const { exec } = require('child_process');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel } = require('../../../src/worker/ollama');
 
 // ---------------------------------------------------------------------------
 // Helpers to build fake HTTP request/response pairs
@@ -232,5 +234,85 @@ describe('getOllamaStatus', () => {
     expect(result.running).toBe(false);
     expect(result.availableModels).toEqual([]);
     expect(result.loadedModels).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkOllamaInstalled
+// ---------------------------------------------------------------------------
+
+describe('checkOllamaInstalled', () => {
+  test('returns installed=true with version when ollama CLI is found', async () => {
+    exec.mockImplementation((_cmd, _opts, cb) => cb(null, 'ollama version 0.7.1', ''));
+    const result = await checkOllamaInstalled();
+    expect(result.installed).toBe(true);
+    expect(result.version).toBe('0.7.1');
+  });
+
+  test('returns installed=false when ollama CLI is not found', async () => {
+    exec.mockImplementation((_cmd, _opts, cb) => cb(new Error('not found'), '', ''));
+    const result = await checkOllamaInstalled();
+    expect(result.installed).toBe(false);
+    expect(result.version).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pullModel
+// ---------------------------------------------------------------------------
+
+describe('pullModel', () => {
+  /** Build a streaming NDJSON response mock for /api/pull */
+  function makePullMock(lines) {
+    return (_opts, callback) => {
+      const resHandlers = {};
+      const mockRes = {
+        on: jest.fn((event, handler) => { resHandlers[event] = handler; }),
+      };
+      return {
+        setTimeout: jest.fn(),
+        on: jest.fn(),
+        write: jest.fn(),
+        end: jest.fn(() => {
+          callback(mockRes);
+          for (const line of lines) {
+            if (resHandlers.data) resHandlers.data(Buffer.from(line + '\n'));
+          }
+          if (resHandlers.end) resHandlers.end();
+        }),
+      };
+    };
+  }
+
+  test('resolves successfully and calls onProgress for each NDJSON line', async () => {
+    const lines = [
+      JSON.stringify({ status: 'pulling manifest' }),
+      JSON.stringify({ status: 'pulling abc', total: 1000, completed: 500 }),
+      JSON.stringify({ status: 'success' }),
+    ];
+    http.request.mockImplementation(makePullMock(lines));
+
+    const progress = [];
+    await pullModel('nomic-embed-text', (p) => progress.push(p));
+
+    expect(progress).toHaveLength(3);
+    expect(progress[0].status).toBe('pulling manifest');
+    expect(progress[1].completed).toBe(500);
+    expect(progress[2].status).toBe('success');
+  });
+
+  test('rejects on connection error', async () => {
+    http.request.mockImplementation(() => {
+      const errHandlers = {};
+      return {
+        setTimeout: jest.fn(),
+        on: jest.fn((event, handler) => { errHandlers[event] = handler; }),
+        write: jest.fn(),
+        end: jest.fn(() => {
+          if (errHandlers.error) errHandlers.error(new Error('ECONNREFUSED'));
+        }),
+      };
+    });
+    await expect(pullModel('some-model')).rejects.toThrow('ECONNREFUSED');
   });
 });

--- a/website/library.html
+++ b/website/library.html
@@ -45,6 +45,7 @@
     <li><strong>Text / Semantic toggle</strong> — switches the search mode (see below).</li>
     <li><strong>Entry count</strong> — shows how many entries match the current view.</li>
     <li><strong>Export…</strong> — opens the <a href="export.html">export</a> workflow.</li>
+    <li><strong>⚙</strong> — opens the <a href="#model-settings">Model settings</a> panel to change which Ollama models are used.</li>
     <li><strong>Help</strong> — opens this documentation in your browser.</li>
   </ul>
 
@@ -103,6 +104,14 @@
   <h2>Theme sidebar</h2>
   <p>
     Below the tag list is a <strong>Themes</strong> section. This lists all auto-generated theme clusters. Click any theme to open its detail view in the right panel. See the <a href="themes.html">Themes</a> section for more.
+  </p>
+
+  <h2 id="model-settings">Model settings</h2>
+  <p>
+    Click the <strong>⚙</strong> button in the toolbar to open the Model settings panel. From here you can choose which locally installed Ollama models are used for embeddings and theme summaries. The dropdowns are populated from your available Ollama models; any changes take effect immediately on the next worker tick.
+  </p>
+  <p>
+    Settings are stored in <code>settings.json</code> alongside your database in the app’s user data directory.
   </p>
 
   <h2>Status bar</h2>

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -26,9 +26,14 @@
   <h1>Troubleshooting</h1>
   <p class="page-subtitle">Solutions to the most common issues.</p>
 
+  <h2>Ollama is not installed</h2>
+
+  <p>When Neurologue starts up, it checks whether Ollama is installed. If it isn’t, a <strong>setup modal</strong> appears automatically with a <strong>Download Ollama</strong> button.</p>
+  <p>Click the button to open <a href="https://ollama.ai" target="_blank" rel="noopener">ollama.ai</a>, install Ollama, then click <strong>Check again</strong> in the modal.</p>
+
   <h2>Ollama is not running</h2>
 
-  <p><strong>Symptoms:</strong> The status bar at the bottom of the library window shows <strong>Ollama not running</strong> (grey dot). Semantic search shows "Ollama not available — showing text results instead". Themes never appear. No embeddings are generated.</p>
+  <p><strong>Symptoms:</strong> The status bar at the bottom of the library window shows <strong>Ollama not running</strong> (grey dot). A setup modal also appears on startup if Ollama is installed but not yet started.</p>
 
   <h3>Check if Ollama is running</h3>
   <p>Open a terminal and run:</p>
@@ -40,12 +45,21 @@
   <pre><code>ollama serve</code></pre>
 
   <h3>Pull the required models</h3>
-  <p>If Ollama is running but models are missing:</p>
+  <p>If Ollama is running but models are missing, the setup modal will appear automatically with a <strong>Pull all missing models</strong> button. Click it to download each model with a live progress bar.</p>
+  <p>You can also pull models manually in a terminal:</p>
   <pre><code>ollama pull nomic-embed-text
 ollama pull phi3:mini</code></pre>
 
   <div class="callout">
     <p><code>nomic-embed-text</code> is required for embeddings and semantic search. <code>phi3:mini</code> is only needed for theme summaries — themes will still be created without it, just without the LLM description.</p>
+  </div>
+
+  <h2>Changing the embedding or LLM model</h2>
+
+  <p>Click the <strong>⚙</strong> (gear) button in the top toolbar to open the <strong>Model settings</strong> panel. The dropdowns are populated from your locally available Ollama models. Choose your preferred models and click <strong>Save settings</strong>.</p>
+
+  <div class="callout warning">
+    <p><strong>Note:</strong> Changing the embedding model means existing entries were embedded with the old model. The background worker will re-embed them over time using the new model. During the transition, semantic search results may be inconsistent.</p>
   </div>
 
   <h2>No themes appearing</h2>


### PR DESCRIPTION
﻿## Summary

Implements issues #28 (detect Ollama installed), #29 (guided setup flow), #30 (detect installed models), #31 (auto-pull required models), plus makes models user-configurable at runtime.

## Changes

### New: src/backend/settings.js
Persists user model preferences to settings.json alongside the database. getSettings()/saveSettings() read/write synchronously. Falls back to config.js defaults when the file is absent.

### src/config.js
Added settings.path field. Model names in config.ollama are now documented as defaults only.

### src/worker/ollama.js
- checkOllamaInstalled() - runs ollama --version via child_process; returns { installed, version }
- pullModel(name, onProgress) - POSTs to /api/pull with streaming NDJSON; calls onProgress for each progress line
- generateEmbedding() now reads the model name from getSettings() at call time (not hardcoded from config)

### src/backend/clustering/themes.js
generateTextCompletion() now reads llmModel from getSettings() instead of config.

### src/worker/index.js
processBatch() reads embeddingModel from getSettings() for the stored model name.

### src/main.js
New IPC handlers: settings:get, settings:save, ollama:check-installed, ollama:pull-model (streaming progress), ollama:open-download

### src/frontend/preload.js
Exposed: getSettings(), saveSettings(), checkOllamaInstalled(), pullModel(), onPullProgress(), openOllamaDownload()

### src/frontend/index.html
- Gear button in toolbar
- Setup modal with three steps: install Ollama, start Ollama, pull missing models
- Settings modal with embedding + LLM model dropdowns

### src/frontend/library.css
Full modal/overlay styles, setup step styles, progress bar, settings field styles.

### src/frontend/library.js
- runSetupCheck() - runs on startup; shows appropriate setup step if needed
- runModelCheck() - compares configured models against available; shows pull step if missing
- renderModelPullList() - builds per-model rows with progress bars
- onPullProgress() listener - updates progress bars in real time
- pullAllMissing() - pulls each missing model sequentially, closes modal when done
- Settings modal: buildOptions() populates selects from available models + current setting; save persists via IPC

### Tests
- New tests/unit/settings.test.js (8 tests)
- ollama.test.js: +child_process mock, +checkOllamaInstalled suite (2 tests), +pullModel suite (2 tests)

### Docs
- website/library.html: gear button documented in toolbar section; new Model settings section
- website/troubleshooting.html: Ollama not installed section; pull via modal; model change instructions

## Test Results
132 tests passing across 13 suites (was 121 across 12)
