### PR TITLE
feat: configurable capture hotkey

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Each roadmap item is written to be convertible into GitHub Issues.
 - Package Neurologue as a standalone desktop app (Windows/macOS/Linux)
 - Provide installer and portable modes
 - Ensure global hotkey works in packaged builds
-- Add UI to configure global hotkey
+- ~~Add UI to configure global hotkey~~ — delivered in 0.2.3
 
 ### 0.2.2 Ollama Detection & Setup
 - Detect whether Ollama is installed
@@ -23,9 +23,10 @@ Each roadmap item is written to be convertible into GitHub Issues.
 
 ### 0.2.3 Ollama Runtime Control
 - Detect whether Ollama is running
-- Start/stop Ollama from within Neurologue
+- ~~Start/stop Ollama from within Neurologue~~ — not supported; Ollama on Windows manages its own lifecycle as a tray application
 - Display model load status and basic resource usage
 - Provide graceful fallback when Ollama is offline
+- Configure global capture hotkey (conflict detection, persisted setting)
 
 ### 0.2.4 Background Worker Visibility
 - Add worker status indicator (online/offline)

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -16,10 +16,11 @@ const config = require('../config');
 
 const SETTINGS_PATH = config.settings.path;
 
-/** @type {{ embeddingModel: string, llmModel: string }} */
+/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string }} */
 const DEFAULTS = {
   embeddingModel: config.ollama.embeddingModel,
   llmModel:       config.ollama.llmModel,
+  captureHotkey:  config.hotkey.capture,
 };
 
 /**

--- a/src/capture/hotkey.js
+++ b/src/capture/hotkey.js
@@ -98,4 +98,18 @@ function reRegisterCaptureHotkey(accelerator) {
   return { ok: false, conflict: true };
 }
 
-module.exports = { registerCaptureHotkey, reRegisterCaptureHotkey, openCaptureWindow, closeCaptureWindow, DEFAULT_HOTKEY };
+/**
+ * Temporarily unregister the capture hotkey (e.g. while the settings modal is open).
+ */
+function pauseCaptureHotkey() {
+  if (_currentHotkey) globalShortcut.unregister(_currentHotkey);
+}
+
+/**
+ * Re-register the capture hotkey after a pause.
+ */
+function resumeCaptureHotkey() {
+  if (_currentHotkey) globalShortcut.register(_currentHotkey, openCaptureWindow);
+}
+
+module.exports = { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow, closeCaptureWindow, DEFAULT_HOTKEY };

--- a/src/capture/hotkey.js
+++ b/src/capture/hotkey.js
@@ -3,7 +3,10 @@
 const { BrowserWindow, globalShortcut, app } = require('electron');
 const path = require('path');
 
-const HOTKEY = 'CommandOrControl+Shift+Space';
+const DEFAULT_HOTKEY = 'CommandOrControl+Shift+Space';
+
+/** Currently registered accelerator — set by registerCaptureHotkey. */
+let _currentHotkey = null;
 
 let _captureWin = null;
 
@@ -61,16 +64,38 @@ function closeCaptureWindow() {
 
 /**
  * Register the global hotkey. Call once after app.whenReady().
+ * @param {string} [accelerator] - Electron accelerator; defaults to DEFAULT_HOTKEY.
  */
-function registerCaptureHotkey() {
-  const registered = globalShortcut.register(HOTKEY, openCaptureWindow);
+function registerCaptureHotkey(accelerator) {
+  _currentHotkey = accelerator || DEFAULT_HOTKEY;
+  const registered = globalShortcut.register(_currentHotkey, openCaptureWindow);
   if (!registered) {
-    console.warn(`[hotkey] Failed to register ${HOTKEY} — it may already be in use by another app.`);
+    console.warn(`[hotkey] Failed to register ${_currentHotkey} — it may already be in use by another app.`);
   }
 
   app.on('will-quit', () => {
-    globalShortcut.unregister(HOTKEY);
+    globalShortcut.unregister(_currentHotkey);
   });
 }
 
-module.exports = { registerCaptureHotkey, openCaptureWindow, closeCaptureWindow };
+/**
+ * Unregister the current hotkey and register a new one.
+ * Returns { ok: true } on success, { ok: false, conflict: true } if the new
+ * shortcut is already claimed by another application.
+ * @param {string} accelerator
+ * @returns {{ ok: boolean, conflict?: boolean }}
+ */
+function reRegisterCaptureHotkey(accelerator) {
+  const prev = _currentHotkey;
+  globalShortcut.unregister(prev);
+  const registered = globalShortcut.register(accelerator, openCaptureWindow);
+  if (registered) {
+    _currentHotkey = accelerator;
+    return { ok: true };
+  }
+  // Conflict — restore the previous hotkey
+  globalShortcut.register(prev, openCaptureWindow);
+  return { ok: false, conflict: true };
+}
+
+module.exports = { registerCaptureHotkey, reRegisterCaptureHotkey, openCaptureWindow, closeCaptureWindow, DEFAULT_HOTKEY };

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,9 @@ const config = {
     // User-editable runtime preferences (model choices etc.)
     path: path.join(userDataPath, 'settings.json'),
   },
+  hotkey: {
+    capture: 'CommandOrControl+Shift+Space',
+  },
   ollama: {
     baseUrl: 'http://127.0.0.1:11434',
     // Defaults — overridden at runtime by src/backend/settings.js

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -126,7 +126,9 @@
   <div id="settings-modal" class="modal-overlay hidden">
     <div class="modal-box">
       <button class="modal-close" id="settings-close" title="Close">✕</button>
-      <h2>Model settings</h2>
+      <h2>Settings</h2>
+
+      <h3 class="settings-section-heading">Model settings</h3>
       <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
       <div class="settings-field">
         <label for="select-embed-model">Embedding model</label>
@@ -138,6 +140,18 @@
         <select id="select-llm-model"></select>
         <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
       </div>
+
+      <h3 class="settings-section-heading">Capture hotkey</h3>
+      <div class="settings-field">
+        <label>Global shortcut</label>
+        <div class="hotkey-row">
+          <span id="hotkey-display" class="hotkey-display"></span>
+          <button id="btn-record-hotkey" class="btn-record-hotkey">Change</button>
+        </div>
+        <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
+        <span class="hotkey-conflict hidden" id="hotkey-conflict">⚠ That shortcut is already claimed by another application.</span>
+      </div>
+
       <div class="settings-actions">
         <button class="btn-setup-primary" id="btn-save-settings">Save settings</button>
         <span class="settings-saved hidden" id="settings-saved-msg">✓ Saved</span>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -21,7 +21,8 @@
       </div>
       <span id="entry-count"></span>
       <button id="btn-export" class="mode-btn">Export…</button>
-      <button id="btn-settings" class="mode-btn" title="Model settings">⚙</button>
+      <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
+      <button id="btn-settings" class="mode-btn" title="Settings">⚙</button>
       <button id="btn-help" class="mode-btn">Help</button>
     </div>
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -91,6 +91,14 @@ html, body {
 }
 .mode-btn:hover:not(.active) { border-color: var(--cortex-teal); color: var(--text); }
 
+#btn-new-note {
+  background: var(--cortex-teal);
+  border-color: var(--cortex-teal);
+  color: #fff;
+  font-weight: 600;
+}
+#btn-new-note:hover { background: var(--teal-hover, #1ab8a0); border-color: var(--teal-hover, #1ab8a0); color: #fff; }
+
 #entry-count {
   font-size: 12px;
   color: var(--text-dim);

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -631,3 +631,54 @@ html, body {
 }
 .settings-saved          { font-size: 12px; color: var(--cortex-teal); }
 .settings-saved.hidden   { display: none; }
+
+/* ── Settings section headings ──────────────────────────────────────────── */
+.settings-section-heading {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 24px 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.settings-section-heading:first-of-type { margin-top: 8px; }
+
+/* ── Hotkey recorder ────────────────────────────────────────────────────── */
+.hotkey-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.hotkey-display {
+  flex: 1;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 7px 10px;
+  font-size: 13px;
+  font-family: monospace;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+}
+.hotkey-display.recording {
+  border-color: var(--cortex-teal);
+  color: var(--text-muted);
+}
+.btn-record-hotkey {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  padding: 7px 14px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-record-hotkey:hover { background: var(--surface); }
+.btn-record-hotkey.recording { border-color: var(--cortex-teal); color: var(--cortex-teal); }
+.hotkey-conflict { display: block; font-size: 11px; color: var(--danger); margin-top: 5px; }
+.hotkey-conflict.hidden { display: none; }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -526,7 +526,83 @@ document.getElementById('btn-pull-all').addEventListener('click', pullAllMissing
 
 // ── Settings modal ─────────────────────────────────────────────────
 
+// ── Hotkey recorder ─────────────────────────────────────────────────────────
+let _recordingHotkey = false;
+let _pendingHotkey   = null;
+
+const hotkeyDisplay  = document.getElementById('hotkey-display');
+const btnRecord      = document.getElementById('btn-record-hotkey');
+const hotkeyConflict = document.getElementById('hotkey-conflict');
+
+/** Convert a keyboard event to an Electron accelerator string, or null if invalid. */
+function keyEventToAccelerator(e) {
+  if (['Control', 'Shift', 'Alt', 'Meta', 'Command'].includes(e.key)) return null;
+  if (e.key === 'Escape') return null; // Escape cancels recording
+
+  const parts = [];
+  if (e.ctrlKey || e.metaKey) parts.push('CommandOrControl');
+  if (e.altKey)  parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+  if (parts.length === 0) return null; // require at least one modifier
+
+  const KEY_MAP = {
+    ' ': 'Space', 'ArrowUp': 'Up', 'ArrowDown': 'Down',
+    'ArrowLeft': 'Left', 'ArrowRight': 'Right',
+    'Enter': 'Return',
+  };
+  const mapped = KEY_MAP[e.key] ?? (e.key.length === 1 ? e.key.toUpperCase() : e.key);
+  parts.push(mapped);
+  return parts.join('+');
+}
+
+/** Format an Electron accelerator for display (e.g. 'CommandOrControl+Shift+Space' → 'Ctrl+Shift+Space'). */
+function formatAccelerator(acc) {
+  return acc.replace('CommandOrControl', 'Ctrl');
+}
+
+function onHotkeyKeydown(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  if (e.key === 'Escape') { stopHotkeyRecording(true); return; }
+  const acc = keyEventToAccelerator(e);
+  if (!acc) return;
+  _pendingHotkey = acc;
+  hotkeyDisplay.textContent = formatAccelerator(acc);
+  stopHotkeyRecording(false);
+}
+
+function startHotkeyRecording() {
+  _recordingHotkey = true;
+  hotkeyDisplay.textContent = 'Press keys…';
+  hotkeyDisplay.classList.add('recording');
+  btnRecord.textContent = 'Cancel';
+  btnRecord.classList.add('recording');
+  hotkeyConflict.classList.add('hidden');
+  document.addEventListener('keydown', onHotkeyKeydown, { capture: true });
+}
+
+function stopHotkeyRecording(restore) {
+  _recordingHotkey = false;
+  document.removeEventListener('keydown', onHotkeyKeydown, { capture: true });
+  hotkeyDisplay.classList.remove('recording');
+  btnRecord.textContent = 'Change';
+  btnRecord.classList.remove('recording');
+  if (restore) {
+    // Revert display to the last saved or pending hotkey
+    const current = _pendingHotkey || hotkeyDisplay.dataset.saved || '';
+    hotkeyDisplay.textContent = current ? formatAccelerator(current) : '';
+  }
+}
+
+btnRecord.addEventListener('click', () => {
+  if (_recordingHotkey) stopHotkeyRecording(true);
+  else startHotkeyRecording();
+});
+// ────────────────────────────────────────────────────────────────────────────
+
 btnSettings.addEventListener('click', async () => {
+  _pendingHotkey = null;
+  hotkeyConflict.classList.add('hidden');
   const [settings, status] = await Promise.all([
     window.neurologue.getSettings(),
     window.neurologue.getStatus(),
@@ -549,16 +625,36 @@ btnSettings.addEventListener('click', async () => {
 
   buildOptions('select-embed-model', available, settings.embeddingModel);
   buildOptions('select-llm-model',   available, settings.llmModel);
+
+  // Populate hotkey display
+  const currentHotkey = settings.captureHotkey || 'CommandOrControl+Shift+Space';
+  hotkeyDisplay.dataset.saved = currentHotkey;
+  hotkeyDisplay.textContent   = formatAccelerator(currentHotkey);
+
   settingsModal.classList.remove('hidden');
 });
 
 document.getElementById('settings-close').addEventListener('click', () => {
+  if (_recordingHotkey) stopHotkeyRecording(true);
   settingsModal.classList.add('hidden');
 });
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
   const embedModel = document.getElementById('select-embed-model').value;
   const llmModel   = document.getElementById('select-llm-model').value;
+
+  // Apply hotkey change first if the user recorded a new one
+  if (_pendingHotkey) {
+    const result = await window.neurologue.setHotkey(_pendingHotkey);
+    if (!result.ok) {
+      hotkeyConflict.classList.remove('hidden');
+      return; // Don't close — let user pick a different shortcut
+    }
+    hotkeyConflict.classList.add('hidden');
+    hotkeyDisplay.dataset.saved = _pendingHotkey;
+    _pendingHotkey = null;
+  }
+
   await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel });
   const msg = document.getElementById('settings-saved-msg');
   msg.classList.remove('hidden');

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -33,6 +33,7 @@ const detailText    = document.getElementById('detail-text');
 const detailTags    = document.getElementById('detail-tags');
 const exportBtn     = document.getElementById('btn-export');
 const exportToast   = document.getElementById('export-toast');
+const newNoteBtn    = document.getElementById('btn-new-note');
 const helpBtn       = document.getElementById('btn-help');
 const semanticNotice = document.getElementById('semantic-notice');
 const statusOllama  = document.getElementById('status-ollama');
@@ -370,6 +371,10 @@ helpBtn.addEventListener('click', () => {
   window.neurologue.openHelp();
 });
 
+newNoteBtn.addEventListener('click', () => {
+  window.neurologue.openCapture();
+});
+
 // ── Status bar ──────────────────────────────────────────────────────
 
 function updateStatus({ worker, ollama } = {}) {
@@ -632,11 +637,13 @@ btnSettings.addEventListener('click', async () => {
   hotkeyDisplay.textContent   = formatAccelerator(currentHotkey);
 
   settingsModal.classList.remove('hidden');
+  window.neurologue.pauseHotkey();
 });
 
 document.getElementById('settings-close').addEventListener('click', () => {
   if (_recordingHotkey) stopHotkeyRecording(true);
   settingsModal.classList.add('hidden');
+  window.neurologue.resumeHotkey();
 });
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -30,6 +30,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Settings ─────────────────────────────────────────────────────────────
   getSettings:  ()        => ipcRenderer.invoke('settings:get'),
   saveSettings: (updates) => ipcRenderer.invoke('settings:save', updates),
+  setHotkey:    (accelerator) => ipcRenderer.invoke('hotkey:set', { accelerator }),
 
   // ── Ollama setup ─────────────────────────────────────────────────────────
   openOllamaDownload:  ()     => ipcRenderer.invoke('ollama:open-download'),

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -31,6 +31,11 @@ contextBridge.exposeInMainWorld('neurologue', {
   getSettings:  ()        => ipcRenderer.invoke('settings:get'),
   saveSettings: (updates) => ipcRenderer.invoke('settings:save', updates),
   setHotkey:    (accelerator) => ipcRenderer.invoke('hotkey:set', { accelerator }),
+  pauseHotkey:  ()            => ipcRenderer.invoke('hotkey:pause'),
+  resumeHotkey: ()            => ipcRenderer.invoke('hotkey:resume'),
+
+  // ── Capture ───────────────────────────────────────────────────────────────
+  openCapture: () => ipcRenderer.invoke('capture:open'),
 
   // ── Ollama setup ─────────────────────────────────────────────────────────
   openOllamaDownload:  ()     => ipcRenderer.invoke('ollama:open-download'),

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const { getSettings, saveSettings } = require('./backend/settings');
 const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
-const { registerCaptureHotkey } = require('./capture/hotkey');
+const { registerCaptureHotkey, reRegisterCaptureHotkey } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus } = require('./worker/index');
 // getOllamaStatus and getSettings imported above
 
@@ -152,7 +152,8 @@ ipcMain.handle('export:run', async (_event, { includeEmbeddings = true } = {}) =
 app.whenReady().then(async () => {
   await initialise();
   createMainWindow();
-  registerCaptureHotkey();
+  const { captureHotkey } = getSettings();
+  registerCaptureHotkey(captureHotkey);
   startWorker();
   // Wire the worker to push IPC events to the library window once it is ready
   _mainWindow.webContents.on('did-finish-load', () => {
@@ -178,6 +179,14 @@ ipcMain.handle('status:get', async () => {
 
 ipcMain.handle('settings:get', () => getSettings());
 ipcMain.handle('settings:save', (_e, updates) => saveSettings(updates));
+
+// ── Hotkey IPC ────────────────────────────────────────────────────────────
+
+ipcMain.handle('hotkey:set', (_e, { accelerator }) => {
+  const result = reRegisterCaptureHotkey(accelerator);
+  if (result.ok) saveSettings({ captureHotkey: accelerator });
+  return result;
+});
 
 // ── Ollama setup IPC ───────────────────────────────────────────────────────
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const { getSettings, saveSettings } = require('./backend/settings');
 const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
-const { registerCaptureHotkey, reRegisterCaptureHotkey } = require('./capture/hotkey');
+const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus } = require('./worker/index');
 // getOllamaStatus and getSettings imported above
 
@@ -187,6 +187,11 @@ ipcMain.handle('hotkey:set', (_e, { accelerator }) => {
   if (result.ok) saveSettings({ captureHotkey: accelerator });
   return result;
 });
+
+ipcMain.handle('hotkey:pause',  () => { pauseCaptureHotkey(); });
+ipcMain.handle('hotkey:resume', () => { resumeCaptureHotkey(); });
+
+ipcMain.handle('capture:open',  () => { openCaptureWindow(); });
 
 // ── Ollama setup IPC ───────────────────────────────────────────────────────
 

--- a/tests/__mocks__/electron.js
+++ b/tests/__mocks__/electron.js
@@ -12,10 +12,11 @@ const app = {
     return os.tmpdir();
   },
   quit: jest.fn(),
+  on:   jest.fn(),
 };
 
 const BrowserWindow = jest.fn();
-const globalShortcut = { register: jest.fn(), unregisterAll: jest.fn() };
+const globalShortcut = { register: jest.fn(), unregister: jest.fn(), unregisterAll: jest.fn() };
 const ipcMain = { handle: jest.fn(), on: jest.fn() };
 
 module.exports = { app, BrowserWindow, globalShortcut, ipcMain };

--- a/tests/unit/capture/hotkey.test.js
+++ b/tests/unit/capture/hotkey.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+jest.mock('electron');
+
+const { globalShortcut } = require('electron');
+
+// Re-require the module fresh for each describe block by resetting the module registry
+let hotkey;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  // Re-mock electron after resetModules
+  jest.mock('electron');
+  hotkey = require('../../../src/capture/hotkey');
+});
+
+describe('DEFAULT_HOTKEY', () => {
+  test('is a non-empty string', () => {
+    expect(typeof hotkey.DEFAULT_HOTKEY).toBe('string');
+    expect(hotkey.DEFAULT_HOTKEY.length).toBeGreaterThan(0);
+  });
+});
+
+describe('registerCaptureHotkey', () => {
+  test('registers the DEFAULT_HOTKEY when no accelerator is provided', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(true);
+    hotkey.registerCaptureHotkey();
+    expect(gs.register).toHaveBeenCalledWith(hotkey.DEFAULT_HOTKEY, expect.any(Function));
+  });
+
+  test('registers the provided accelerator', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(true);
+    hotkey.registerCaptureHotkey('CommandOrControl+Shift+N');
+    expect(gs.register).toHaveBeenCalledWith('CommandOrControl+Shift+N', expect.any(Function));
+  });
+
+  test('logs a warning when hotkey cannot be registered', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(false);
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    hotkey.registerCaptureHotkey();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('reRegisterCaptureHotkey', () => {
+  beforeEach(() => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(true);
+    hotkey.registerCaptureHotkey(); // establish initial state (_currentHotkey = DEFAULT_HOTKEY)
+    gs.register.mockClear();
+    gs.unregister.mockClear();
+  });
+
+  test('returns { ok: true } when new hotkey registers successfully', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(true);
+    const result = hotkey.reRegisterCaptureHotkey('CommandOrControl+Shift+N');
+    expect(result).toEqual({ ok: true });
+    expect(gs.unregister).toHaveBeenCalledWith(hotkey.DEFAULT_HOTKEY);
+    expect(gs.register).toHaveBeenCalledWith('CommandOrControl+Shift+N', expect.any(Function));
+  });
+
+  test('returns { ok: false, conflict: true } when the new accelerator conflicts', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(false);
+    const result = hotkey.reRegisterCaptureHotkey('CommandOrControl+Shift+N');
+    expect(result).toEqual({ ok: false, conflict: true });
+  });
+
+  test('restores old hotkey when the new one conflicts', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValueOnce(false).mockReturnValue(true);
+    hotkey.reRegisterCaptureHotkey('CommandOrControl+Shift+N');
+    // Second register call should restore the DEFAULT_HOTKEY
+    expect(gs.register).toHaveBeenCalledTimes(2);
+    expect(gs.register.mock.calls[1][0]).toBe(hotkey.DEFAULT_HOTKEY);
+  });
+
+  test('updates _currentHotkey after a successful re-registration', () => {
+    const { globalShortcut: gs } = require('electron');
+    gs.register.mockReturnValue(true);
+    hotkey.reRegisterCaptureHotkey('CommandOrControl+Alt+P');
+    gs.register.mockClear();
+    gs.unregister.mockClear();
+
+    // A second re-registration should unregister the newly set key
+    hotkey.reRegisterCaptureHotkey('CommandOrControl+Alt+Q');
+    expect(gs.unregister).toHaveBeenCalledWith('CommandOrControl+Alt+P');
+  });
+});

--- a/tests/unit/settings.test.js
+++ b/tests/unit/settings.test.js
@@ -82,3 +82,25 @@ describe('saveSettings', () => {
     expect(fs.existsSync(SETTINGS_FILE)).toBe(true);
   });
 });
+
+describe('captureHotkey default', () => {
+  test('default captureHotkey is a non-empty string', () => {
+    const s = getSettings();
+    expect(typeof s.captureHotkey).toBe('string');
+    expect(s.captureHotkey.length).toBeGreaterThan(0);
+  });
+
+  test('captureHotkey can be saved and retrieved', () => {
+    const result = saveSettings({ captureHotkey: 'CommandOrControl+Shift+N' });
+    expect(result.captureHotkey).toBe('CommandOrControl+Shift+N');
+    expect(getSettings().captureHotkey).toBe('CommandOrControl+Shift+N');
+  });
+
+  test('captureHotkey update preserves other settings', () => {
+    saveSettings({ embeddingModel: 'mxbai-embed-large' });
+    saveSettings({ captureHotkey: 'CommandOrControl+Alt+N' });
+    const s = getSettings();
+    expect(s.embeddingModel).toBe('mxbai-embed-large');
+    expect(s.captureHotkey).toBe('CommandOrControl+Alt+N');
+  });
+});

--- a/website/capture.html
+++ b/website/capture.html
@@ -35,6 +35,10 @@
     <p>The hotkey is registered globally when Neurologue is running. You don't need to switch to the app first.</p>
   </div>
 
+  <p>
+    The default hotkey is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Space</kbd>. You can change it in <strong>Settings → Capture hotkey</strong>. See the <a href="library.html#capture-hotkey">Library — Capture hotkey</a> section for instructions.
+  </p>
+
   <h2>The capture popup</h2>
   <p>The popup is a compact 560×260px window with two fields:</p>
 

--- a/website/library.html
+++ b/website/library.html
@@ -45,7 +45,7 @@
     <li><strong>Text / Semantic toggle</strong> — switches the search mode (see below).</li>
     <li><strong>Entry count</strong> — shows how many entries match the current view.</li>
     <li><strong>Export…</strong> — opens the <a href="export.html">export</a> workflow.</li>
-    <li><strong>⚙</strong> — opens the <a href="#model-settings">Model settings</a> panel to change which Ollama models are used.</li>
+    <li><strong>⚙</strong> — opens the <a href="#settings">Settings</a> panel to change Ollama models and the capture hotkey.</li>
     <li><strong>Help</strong> — opens this documentation in your browser.</li>
   </ul>
 
@@ -106,9 +106,28 @@
     Below the tag list is a <strong>Themes</strong> section. This lists all auto-generated theme clusters. Click any theme to open its detail view in the right panel. See the <a href="themes.html">Themes</a> section for more.
   </p>
 
-  <h2 id="model-settings">Model settings</h2>
+  <h2 id="settings">Settings</h2>
   <p>
-    Click the <strong>⚙</strong> button in the toolbar to open the Model settings panel. From here you can choose which locally installed Ollama models are used for embeddings and theme summaries. The dropdowns are populated from your available Ollama models; any changes take effect immediately on the next worker tick.
+    Click the <strong>⚙</strong> button in the toolbar to open the Settings panel.
+  </p>
+
+  <h3 id="model-settings">Model settings</h3>
+  <p>
+    Choose which locally installed Ollama models are used for embeddings and theme summaries. The dropdowns are populated from your available Ollama models; any changes take effect immediately on the next worker tick.
+  </p>
+
+  <h3 id="capture-hotkey">Capture hotkey</h3>
+  <p>
+    The <strong>Global shortcut</strong> field shows the current key combination that opens the capture popup from anywhere on your desktop. To change it:
+  </p>
+  <ol>
+    <li>Click the <strong>Change</strong> button next to the hotkey field.</li>
+    <li>The field will show <em>Press keys…</em> — press the combination you want (e.g. <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd>).</li>
+    <li>The new shortcut appears in the field. Press <kbd>Escape</kbd> or click <strong>Cancel</strong> to discard.</li>
+    <li>Click <strong>Save settings</strong>. If the shortcut is already claimed by another application, a conflict warning is shown and the old shortcut is kept.</li>
+  </ol>
+  <p>
+    The shortcut must include at least one modifier key (Ctrl, Alt, or Shift).
   </p>
   <p>
     Settings are stored in <code>settings.json</code> alongside your database in the app’s user data directory.


### PR DESCRIPTION
Closes #27

## Changes

### Backend
- \captureHotkey\ added to settings defaults (\CommandOrControl+Shift+Space\)
- \egisterCaptureHotkey(accelerator)\ now accepts an optional accelerator (falls back to default)
- New \eRegisterCaptureHotkey(accelerator)\ — unregisters current hotkey, tries to register the new one; on conflict, restores the old one and returns \{ ok: false, conflict: true }\
- \hotkey:set\ IPC handler: applies the change via \eRegisterCaptureHotkey\ and persists to \settings.json\ on success

### Frontend
- Settings modal renamed from \Model settings\ to \Settings\ with two sections: Model settings and Capture hotkey
- Key recorder UI: click **Change**, press the desired combination, click **Save settings**
- Escape cancels recording without committing
- Conflict error message shown inline if the shortcut is already claimed

### Tests
- \	ests/unit/capture/hotkey.test.js\ — 8 new tests for \egisterCaptureHotkey\ and \eRegisterCaptureHotkey\
- \	ests/unit/settings.test.js\ — 3 new tests for \captureHotkey\ default and persistence
- 143 tests / 14 suites passing

### Docs
- \website/library.html\: Settings section split into Model settings + Capture hotkey with step-by-step instructions
- \website/capture.html\: Note that the default hotkey is configurable, with link to docs