### PR TITLE
fix: electron-builder CI failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -46,8 +46,9 @@ jobs:
       - name: Build (${{ matrix.platform }})
         run: npm run build:${{ matrix.platform }}
         env:
-          # Suppress electron-builder's auto-update publish check
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          DEBUG: electron-builder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -19,13 +19,16 @@
     "copyright": "Copyright © 2025 Codebureau",
     "icon": "build/icon.png",
     "files": [
-      "src/**/*",
-      "package.json",
-      "!**/*.test.js",
-      "!**/__tests__/**",
-      "!**/tests/**"
+      "**/*",
+      "!tests/**",
+      "!docs/**",
+      "!website/**",
+      "!dist/**",
+      "!.github/**",
+      "!build/**",
+      "!**/*.test.js"
     ],
-    "asar": true,
+    "npmRebuild": false,
     "asarUnpack": [
       "**/@lancedb/**",
       "**/*.node"


### PR DESCRIPTION
- files: switch from 'src/**/*' to '**/*' with exclusions so node_modules
  is included in the bundle (was missing, causing silent build failure)
- npmRebuild: false — @lancedb/lancedb ships NAPI-RS prebuilts that must
  not be rebuilt against Electron headers on CI
- CSC_IDENTITY_AUTO_DISCOVERY=false in workflow — prevents macOS/Windows
  from trying to code-sign without a certificate
- DEBUG: electron-builder — verbose output for future diagnosis
- Node 22 (was 20, deprecated on Actions runners)
