### PR TITLE
fix: move electron to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
   "license": "TBD",
   "dependencies": {
     "@lancedb/lancedb": "^0.17.0",
-    "electron": "^35.0.0",
     "sql.js": "^1.12.0"
   },
   "devDependencies": {
+    "electron": "^35.0.0",
     "electron-builder": "^25.1.8",
     "jest": "^30.3.0"
   }


### PR DESCRIPTION
electron-builder requires electron to be in devDependencies, not
dependencies. Having it in dependencies causes electron-builder to
exit immediately with: 'Package electron is only allowed in devDependencies'
