### PR TITLE
ci: fix release job condition for workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref_type == 'tag'
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
startsWith(github.ref, 'refs/tags/') fails for workflow_dispatch
runs where github.ref resolves to refs/heads/main regardless of
which tag was selected. ref_type is set correctly in both cases.
