### PR TITLE
ci: fix release trigger for non-v tags and workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+      - '[0-9]*'
   workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a GitHub Release after building'
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # needed to upload release assets
@@ -65,7 +71,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || inputs.create_release == true
 
     steps:
       - name: Download all artifacts
@@ -74,8 +80,14 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          name: "Neurologue ${{ github.ref_name }}"
           files: artifacts/**
           generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
- add '[0-9]*' to push.tags so '0.0.2' style tags fire the workflow
  automatically on push (no manual dispatch needed)
- add create_release boolean input to workflow_dispatch so the release
  job can be explicitly triggered when running manually
- release condition: ref_type==tag (push) OR create_release input (dispatch)
- release name: 'Neurologue <tag>'
- prerelease flag auto-set for tags containing '-'
