### PR TITLE
fix: add apache-arrow as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neurologue",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "description": "A local-first cognitive system for capturing, organising, and understanding your thoughts.",
   "main": "src/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "license": "TBD",
   "dependencies": {
     "@lancedb/lancedb": "^0.17.0",
+    "apache-arrow": "^18.1.0",
     "sql.js": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
apache-arrow is a peer dependency of @lancedb/lancedb. npm installs it
locally but electron-builder only bundles explicit dependencies, so
the packaged app fails with 'Cannot find module apache-arrow'.
