### PR TITLE
feat: LLM-based entry categorisation

### DIFF
--- a/src/backend/db/entries.js
+++ b/src/backend/db/entries.js
@@ -100,4 +100,42 @@ async function getEntryRevisions(id) {
     .all(id);
 }
 
-module.exports = { createEntry, getEntryById, listEntries, deleteEntry, updateEntry, getEntryRevisions };
+/**
+ * Update the category of an entry.
+ * Pass a non-null value to set; pass null to clear (revert to auto-classification).
+ * `source` should be 'llm' or 'user'.
+ * @param {string} id
+ * @param {string|null} category  One of: Task, Thought, Reminder, Idea, Question, Decision
+ * @param {'llm'|'user'} [source='user']
+ * @returns {Promise<object|undefined>}
+ */
+async function updateEntryCategory(id, category, source = 'user') {
+  const db = await openDb();
+  const field = source === 'llm' ? 'category' : 'user_category';
+  db.prepare(`UPDATE entries SET ${field} = ? WHERE id = ?`).run(category, id);
+  return getEntryById(id);
+}
+
+/**
+ * List entries that have no LLM-assigned category yet.
+ * @param {number} [limit=50]
+ * @returns {Promise<string[]>}  entry IDs
+ */
+async function listEntriesWithoutCategory(limit = 50) {
+  const db = await openDb();
+  return db
+    .prepare('SELECT id FROM entries WHERE category IS NULL ORDER BY created_at ASC LIMIT ?')
+    .all(limit)
+    .map((r) => r.id);
+}
+
+module.exports = {
+  createEntry,
+  getEntryById,
+  listEntries,
+  deleteEntry,
+  updateEntry,
+  getEntryRevisions,
+  updateEntryCategory,
+  listEntriesWithoutCategory,
+};

--- a/src/backend/db/search.js
+++ b/src/backend/db/search.js
@@ -13,7 +13,7 @@ const { openDb } = require('./connection');
 async function searchEntriesText(query, { limit = 50, offset = 0 } = {}) {
   const db = await openDb();
   const pattern = `%${query}%`;
-  return db
+  const entries = db
     .prepare(`
       SELECT * FROM entries
       WHERE content LIKE ?
@@ -21,6 +21,7 @@ async function searchEntriesText(query, { limit = 50, offset = 0 } = {}) {
       LIMIT ? OFFSET ?
     `)
     .all(pattern, limit, offset);
+  return _enrichWithTags(db, entries);
 }
 
 /**
@@ -32,7 +33,7 @@ async function searchEntriesText(query, { limit = 50, offset = 0 } = {}) {
  */
 async function listEntriesByTag(tagName, { limit = 100, offset = 0 } = {}) {
   const db = await openDb();
-  return db
+  const entries = db
     .prepare(`
       SELECT e.* FROM entries e
       INNER JOIN entry_tags et ON et.entry_id = e.id
@@ -42,6 +43,7 @@ async function listEntriesByTag(tagName, { limit = 100, offset = 0 } = {}) {
       LIMIT ? OFFSET ?
     `)
     .all(tagName.trim().toLowerCase(), limit, offset);
+  return _enrichWithTags(db, entries);
 }
 
 /**
@@ -68,4 +70,48 @@ async function getEntryWithTags(id) {
   return { ...entry, tags };
 }
 
-module.exports = { searchEntriesText, listEntriesByTag, getEntryWithTags };
+/**
+ * Attach tags to an array of entries using a single batch query.
+ * Returns a new array where each entry has a `tags` array.
+ *
+ * @param {object} db - open db connection
+ * @param {object[]} entries
+ * @returns {object[]}
+ */
+function _enrichWithTags(db, entries) {
+  if (!entries.length) return entries;
+  const ids = entries.map((e) => e.id);
+  const placeholders = ids.map(() => '?').join(',');
+  const rows = db
+    .prepare(`
+      SELECT et.entry_id, t.id, t.name
+      FROM tags t
+      INNER JOIN entry_tags et ON et.tag_id = t.id
+      WHERE et.entry_id IN (${placeholders})
+      ORDER BY t.name ASC
+    `)
+    .all(...ids);
+
+  const byEntry = {};
+  for (const row of rows) {
+    if (!byEntry[row.entry_id]) byEntry[row.entry_id] = [];
+    byEntry[row.entry_id].push({ id: row.id, name: row.name });
+  }
+  return entries.map((e) => ({ ...e, tags: byEntry[e.id] || [] }));
+}
+
+/**
+ * List all entries (newest first) with their tags.
+ *
+ * @param {{ limit?: number, offset?: number }} options
+ * @returns {Promise<object[]>}
+ */
+async function listEntriesWithTags({ limit = 50, offset = 0 } = {}) {
+  const db = await openDb();
+  const entries = db
+    .prepare('SELECT * FROM entries ORDER BY created_at DESC LIMIT ? OFFSET ?')
+    .all(limit, offset);
+  return _enrichWithTags(db, entries);
+}
+
+module.exports = { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags };

--- a/src/db/migrations/003_entry_category.sql
+++ b/src/db/migrations/003_entry_category.sql
@@ -1,0 +1,6 @@
+-- Migration 003: add category column to entries
+-- Stores LLM-classified category (Task, Thought, Reminder, Idea, Question, Decision)
+-- NULL means not yet classified; user_category allows manual override.
+
+ALTER TABLE entries ADD COLUMN category TEXT;
+ALTER TABLE entries ADD COLUMN user_category TEXT;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -60,6 +60,18 @@
           <div id="detail-header">
             <div id="detail-date"></div>
             <div id="detail-source"></div>
+            <div id="detail-category-row">
+              <span id="detail-category-badge" class="category-badge"></span>
+              <select id="detail-category-select" class="category-select" title="Set category">
+                <option value="">Auto</option>
+                <option value="Task">Task</option>
+                <option value="Thought">Thought</option>
+                <option value="Reminder">Reminder</option>
+                <option value="Idea">Idea</option>
+                <option value="Question">Question</option>
+                <option value="Decision">Decision</option>
+              </select>
+            </div>
           </div>
           <div id="detail-body">
             <!-- Read view -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -293,6 +293,50 @@ html, body {
 #detail-date { font-size: 11px; color: var(--text-dim); margin-bottom: 4px; }
 #detail-source { font-size: 11px; color: var(--text-dim); }
 
+/* ── Category row ──────────────────────────────────────────────────────── */
+#detail-category-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.category-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+}
+.category-badge:empty { display: none; }
+/* Per-category colours */
+.category-badge[data-cat="Task"]     { background: #1a3a2a; border-color: #2e6b47; color: #5dba8a; }
+.category-badge[data-cat="Thought"]  { background: #1c2a3a; border-color: #2a4a6a; color: #6aacdc; }
+.category-badge[data-cat="Reminder"] { background: #3a2a1a; border-color: #6b4a2a; color: #d4945a; }
+.category-badge[data-cat="Idea"]     { background: #2e2a1a; border-color: #6b5a2a; color: var(--synapse-gold); }
+.category-badge[data-cat="Question"] { background: #2a1a3a; border-color: #4a2e6a; color: #a07ad0; }
+.category-badge[data-cat="Decision"] { background: #3a1a1a; border-color: #6a2a2a; color: #e07a7a; }
+
+.category-select {
+  font-size: 11px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  padding: 1px 4px;
+  cursor: pointer;
+  font-family: inherit;
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+}
+.category-select:hover  { border-color: var(--cortex-teal); color: var(--text); }
+.category-select:focus  { border-color: var(--cortex-teal); }
+.category-select option { background: var(--surface2); color: var(--text); }
+
 #detail-body {
   flex: 1;
   overflow-y: auto;

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -218,20 +218,26 @@ html, body {
   word-break: break-word;
 }
 
-.entry-card .entry-tags {
+/* Unified chip row (tags + category badge) */
+.entry-card .entry-chips {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 4px;
   margin-top: 6px;
 }
+
+/* Tags — neutral, lower-key, # prefix supplied by JS */
 .tag-pill {
   font-size: 11px;
-  background: var(--surface2);
+  background: transparent;
   border: 1px solid var(--border);
-  color: var(--text-muted);
-  border-radius: 12px;
-  padding: 1px 7px;
+  color: var(--text-dim);
+  border-radius: 4px;
+  padding: 1px 6px;
+  letter-spacing: 0.02em;
 }
+.tag-pill:hover { border-color: var(--cortex-teal); color: var(--text-muted); }
 
 .empty-state {
   padding: 48px 24px;
@@ -320,11 +326,10 @@ html, body {
 .category-badge[data-cat="Question"] { background: #2a1a3a; border-color: #4a2e6a; color: #a07ad0; }
 .category-badge[data-cat="Decision"] { background: #3a1a1a; border-color: #6a2a2a; color: #e07a7a; }
 
-/* Variant used on timeline cards — smaller, sits after the tag row */
+/* Variant used on timeline cards — smaller, sits inline in the chip row */
 .category-badge--card {
-  font-size: 9px;
-  padding: 0px 5px;
-  margin-top: 4px;
+  font-size: 10px;
+  padding: 1px 6px;
   display: inline-block;
 }
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -320,6 +320,14 @@ html, body {
 .category-badge[data-cat="Question"] { background: #2a1a3a; border-color: #4a2e6a; color: #a07ad0; }
 .category-badge[data-cat="Decision"] { background: #3a1a1a; border-color: #6a2a2a; color: #e07a7a; }
 
+/* Variant used on timeline cards — smaller, sits after the tag row */
+.category-badge--card {
+  font-size: 9px;
+  padding: 0px 5px;
+  margin-top: 4px;
+  display: inline-block;
+}
+
 .category-select {
   font-size: 11px;
   background: transparent;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -97,25 +97,30 @@ function renderEntryCard(entry) {
   preview.textContent = entry.content;
   card.appendChild(preview);
 
-  if (entry.tags && entry.tags.length > 0) {
-    const tagRow = document.createElement('div');
-    tagRow.className = 'entry-tags';
-    entry.tags.slice(0, 6).forEach((t) => {
-      const pill = document.createElement('span');
-      pill.className = 'tag-pill';
-      pill.textContent = t.name || t;
-      tagRow.appendChild(pill);
-    });
-    card.appendChild(tagRow);
-  }
-
   const cat = entry.user_category || entry.category;
-  if (cat) {
-    const badge = document.createElement('span');
-    badge.className = 'category-badge category-badge--card';
-    badge.setAttribute('data-cat', cat);
-    badge.textContent = cat;
-    card.appendChild(badge);
+  const hasTags = entry.tags && entry.tags.length > 0;
+  if (hasTags || cat) {
+    const chipRow = document.createElement('div');
+    chipRow.className = 'entry-chips';
+
+    if (hasTags) {
+      entry.tags.slice(0, 6).forEach((t) => {
+        const pill = document.createElement('span');
+        pill.className = 'tag-pill';
+        pill.textContent = `#${t.name || t}`;
+        chipRow.appendChild(pill);
+      });
+    }
+
+    if (cat) {
+      const badge = document.createElement('span');
+      badge.className = 'category-badge category-badge--card';
+      badge.setAttribute('data-cat', cat);
+      badge.textContent = cat;
+      chipRow.appendChild(badge);
+    }
+
+    card.appendChild(chipRow);
   }
 
   card.addEventListener('click', () => selectEntry(entry.id));

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -29,6 +29,8 @@ const detailContent          = document.getElementById('detail-content');
 const themeDetailContent     = document.getElementById('theme-detail-content');
 const detailDate    = document.getElementById('detail-date');
 const detailSource  = document.getElementById('detail-source');
+const detailCategoryBadge  = document.getElementById('detail-category-badge');
+const detailCategorySelect = document.getElementById('detail-category-select');
 const detailText    = document.getElementById('detail-text');
 const detailTags    = document.getElementById('detail-tags');
 const detailRead    = document.getElementById('detail-read');
@@ -228,7 +230,11 @@ async function selectEntry(id) {
       : formatDate(entry.created_at);
     detailSource.textContent = `Source: ${entry.source || 'manual'}  \u00b7  Type: ${entry.type || 'note'}`;
     detailText.textContent = entry.content;
-
+    // Category: user_category overrides the LLM-assigned category
+    const displayCat = entry.user_category || entry.category || null;
+    detailCategoryBadge.textContent = displayCat || '';
+    detailCategoryBadge.setAttribute('data-cat', displayCat || '');
+    detailCategorySelect.value = entry.user_category || '';
     detailTags.innerHTML = '';
     if (entry.tags && entry.tags.length > 0) {
       entry.tags.forEach((t) => {
@@ -354,6 +360,23 @@ btnText.addEventListener('click', () => setMode('text'));
 btnSemantic.addEventListener('click', () => setMode('semantic'));
 tagAll.addEventListener('click', () => applyTagFilter(null));
 loadMoreBtn.addEventListener('click', () => loadEntries(true));
+
+// ── Category override ──────────────────────────────────────────────────────
+
+detailCategorySelect.addEventListener('change', async () => {
+  if (!_state.selectedId) return;
+  const selected = detailCategorySelect.value || null; // '' → clear (revert to auto)
+  try {
+    const result = await window.neurologue.setCategory(_state.selectedId, selected);
+    if (result.ok) {
+      const displayCat = result.entry.user_category || result.entry.category || null;
+      detailCategoryBadge.textContent = displayCat || '';
+      detailCategoryBadge.setAttribute('data-cat', displayCat || '');
+    }
+  } catch (err) {
+    console.error('[library] setCategory failed:', err);
+  }
+});
 
 // ── Markdown utilities (used by edit panel) ────────────────────────────────
 
@@ -684,7 +707,19 @@ function updateStatus({ worker, ollama } = {}) {
 }
 
 window.neurologue.onWorkerStatus(updateStatus);
-window.neurologue.onEntriesUpdated(() => { loadEntries(); loadTags(); });
+window.neurologue.onEntriesUpdated(async () => {
+  await loadEntries();
+  await loadTags();
+  // Refresh the detail panel if a selected entry may now have a category assigned
+  if (_state.selectedId) {
+    const entry = await window.neurologue.getEntry(_state.selectedId);
+    if (entry && !entry.user_category) {
+      const cat = entry.category || null;
+      detailCategoryBadge.textContent = cat || '';
+      detailCategoryBadge.setAttribute('data-cat', cat || '');
+    }
+  }
+});
 window.neurologue.onThemesUpdated(() => loadThemes());
 
 // ── Setup + settings modals ────────────────────────────────────────

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -109,6 +109,15 @@ function renderEntryCard(entry) {
     card.appendChild(tagRow);
   }
 
+  const cat = entry.user_category || entry.category;
+  if (cat) {
+    const badge = document.createElement('span');
+    badge.className = 'category-badge category-badge--card';
+    badge.setAttribute('data-cat', cat);
+    badge.textContent = cat;
+    card.appendChild(badge);
+  }
+
   card.addEventListener('click', () => selectEntry(entry.id));
   return card;
 }
@@ -689,12 +698,15 @@ function updateStatus({ worker, ollama } = {}) {
   }
   if (worker) {
     const processing = worker.queueLength > 0;
-    const dot = processing ? 'processing' : (worker.running ? 'active' : '');
+    const classifying = !processing && worker.classifyQueueLength > 0;
+    const dot = (processing || classifying) ? 'processing' : (worker.running ? 'active' : '');
     let label;
     if (!worker.running) {
       label = 'Worker stopped';
     } else if (processing) {
       label = `Processing (${worker.queueLength} queued)`;
+    } else if (classifying) {
+      label = `Classifying (${worker.classifyQueueLength} queued)`;
     } else if (worker.lastProcessed) {
       const d = new Date(worker.lastProcessed);
       const ts = d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   getEntry: (id) => ipcRenderer.invoke('library:get-entry', { id }),
   updateEntry: (id, content) => ipcRenderer.invoke('library:update-entry', { id, content }),
   getRevisions: (id) => ipcRenderer.invoke('library:get-revisions', { id }),
+  setCategory: (id, category) => ipcRenderer.invoke('library:set-category', { id, category }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
 
   // ── Themes ───────────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const { app, BrowserWindow, globalShortcut, ipcMain, shell } = require('electron
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
-const { createEntry, listEntries, updateEntry, getEntryRevisions } = require('./backend/db/entries');
+const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory } = require('./backend/db/entries');
 const { setTagsForEntry, listTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
@@ -99,6 +99,13 @@ ipcMain.handle('library:update-entry', async (_event, { id, content }) => {
 // Get revision history for an entry
 ipcMain.handle('library:get-revisions', async (_event, { id }) => {
   return getEntryRevisions(id);
+});
+
+// Update (or clear) the category for an entry (user override)
+ipcMain.handle('library:set-category', async (_event, { id, category }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  const entry = await updateEntryCategory(id, category || null, 'user');
+  return entry ? { ok: true, entry } : { ok: false, error: 'Entry not found' };
 });
 
 // List all tags (for sidebar)

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
 const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory } = require('./backend/db/entries');
 const { setTagsForEntry, listTags } = require('./backend/db/tags');
-const { searchEntriesText, listEntriesByTag, getEntryWithTags } = require('./backend/db/search');
+const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
@@ -59,7 +59,7 @@ ipcMain.on('capture:close', (event) => {
 // List entries (paginated, optional tag filter)
 ipcMain.handle('library:list', async (_event, { limit = 50, offset = 0, tag } = {}) => {
   if (tag) return listEntriesByTag(tag, { limit, offset });
-  return listEntries({ limit, offset });
+  return listEntriesWithTags({ limit, offset });
 });
 
 // Full-text search

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -11,15 +11,16 @@
  */
 
 const { listEntriesWithoutEmbedding, upsertEmbedding } = require('../backend/db/embeddings');
-const { getEntryById } = require('../backend/db/entries');
+const { getEntryById, updateEntryCategory, listEntriesWithoutCategory } = require('../backend/db/entries');
 const { upsertVector } = require('../backend/vector/store');
-const { generateEmbedding, isOllamaAvailable, getOllamaStatus } = require('./ollama');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus, classifyEntry } = require('./ollama');
 const { runClustering } = require('../backend/clustering/themes');
 const { getSettings } = require('../backend/settings');
 const config = require('../config');
 
 const POLL_INTERVAL_MS = 10_000; // check every 10 seconds
 const BATCH_SIZE = 5;            // process up to 5 entries per tick
+const CLASSIFY_BATCH_SIZE = 3;   // classify up to 3 already-embedded entries per tick
 // Re-cluster after this many new embeddings are added in one session
 const CLUSTER_AFTER = 5;
 
@@ -50,16 +51,15 @@ async function processBatch() {
     return;
   }
 
+  // ── Pass 1: embed entries that have no embedding yet ──────────────────
   const entryIds = await listEntriesWithoutEmbedding();
   _queueLength = entryIds.length;
-  if (entryIds.length === 0) {
-    _push('worker:status', await _buildStatus(true));
-    return;
-  }
+  _push('worker:status', await _buildStatus(true));
 
   const batch = entryIds.slice(0, BATCH_SIZE);
-  console.log(`[worker] Processing ${batch.length} of ${entryIds.length} pending entries`);
-  _push('worker:status', await _buildStatus(true));
+  if (batch.length > 0) {
+    console.log(`[worker] Embedding ${batch.length} of ${entryIds.length} pending entries`);
+  }
 
   let newEmbeddings = 0;
   for (const id of batch) {
@@ -76,6 +76,14 @@ async function processBatch() {
       // Store in LanceDB (primary vector index for similarity search)
       await upsertVector(id, vector, modelName);
 
+      // Classify entry if not already categorised — fire-and-forget, must not block embedding
+      if (!entry.category) {
+        Promise.resolve()
+          .then(() => classifyEntry(entry.content))
+          .then((category) => updateEntryCategory(id, category, 'llm'))
+          .catch((err) => console.warn(`[worker] Classification failed for ${id.slice(0, 8)}…: ${err.message}`));
+      }
+
       console.log(`[worker] Embedded entry ${id.slice(0, 8)}…`);
       _embeddedSinceCluster++;
       _lastProcessed = new Date().toISOString();
@@ -88,6 +96,28 @@ async function processBatch() {
   }
 
   if (newEmbeddings > 0) {
+    _push('worker:entries-updated', {});
+  }
+
+  // ── Pass 2: classify entries that are embedded but have no category ───
+  // Handles existing content from before the classification feature shipped,
+  // and any entry whose fire-and-forget classification failed.
+  const unclassifiedIds = await listEntriesWithoutCategory(CLASSIFY_BATCH_SIZE);
+  let newCategories = 0;
+  for (const id of unclassifiedIds) {
+    try {
+      const entry = await getEntryById(id);
+      if (!entry) continue;
+      const category = await classifyEntry(entry.content);
+      await updateEntryCategory(id, category, 'llm');
+      console.log(`[worker] Classified entry ${id.slice(0, 8)}… → ${category}`);
+      newCategories++;
+    } catch (err) {
+      console.warn(`[worker] Classification failed for ${id.slice(0, 8)}…: ${err.message}`);
+    }
+  }
+
+  if (newCategories > 0) {
     _push('worker:entries-updated', {});
   }
 

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -28,7 +28,8 @@ let _timer = null;
 let _running = false;
 let _paused = false;
 let _embeddedSinceCluster = 0;
-let _queueLength = 0;
+let _queueLength = 0;          // entries pending embedding
+let _classifyQueueLength = 0;  // entries pending classification
 let _lastProcessed = null; // ISO timestamp of last successfully embedded entry
 let _webContents = null;  // set by setMainWindow() once the library window opens
 
@@ -103,6 +104,8 @@ async function processBatch() {
   // Handles existing content from before the classification feature shipped,
   // and any entry whose fire-and-forget classification failed.
   const unclassifiedIds = await listEntriesWithoutCategory(CLASSIFY_BATCH_SIZE);
+  _classifyQueueLength = unclassifiedIds.length;
+  _push('worker:status', await _buildStatus(true));
   let newCategories = 0;
   for (const id of unclassifiedIds) {
     try {
@@ -116,6 +119,7 @@ async function processBatch() {
       console.warn(`[worker] Classification failed for ${id.slice(0, 8)}…: ${err.message}`);
     }
   }
+  _classifyQueueLength = 0;
 
   if (newCategories > 0) {
     _push('worker:entries-updated', {});
@@ -188,6 +192,7 @@ function workerStatus() {
     running: _running,
     paused: _paused,
     queueLength: _queueLength,
+    classifyQueueLength: _classifyQueueLength,
     lastProcessed: _lastProcessed,
   };
 }

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -18,7 +18,14 @@ const { getSettings } = require('../backend/settings');
  * @param {object} body  JSON-serialisable request body
  * @returns {Promise<object>}
  */
-function ollamaRequest(path, body) {
+/**
+ * Send a JSON request to the Ollama API.
+ * @param {string} path  e.g. '/api/embeddings'
+ * @param {object} body  JSON-serialisable request body
+ * @param {number} [timeoutMs=30000]
+ * @returns {Promise<object>}
+ */
+function ollamaRequest(path, body, timeoutMs = 30000) {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify(body);
     const url = new URL(config.ollama.baseUrl);
@@ -52,8 +59,8 @@ function ollamaRequest(path, body) {
       });
     });
 
-    req.setTimeout(30000, () => {
-      req.destroy(new Error('Ollama request timed out after 30s'));
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Ollama request timed out after ${timeoutMs / 1000}s`));
     });
 
     req.on('error', reject);
@@ -150,6 +157,9 @@ async function getOllamaStatus() {
     sizeVram: m.size_vram || 0,
   }));
 
+  // Keep the classification model-availability cache up to date
+  setAvailableModels(availableModels);
+
   return { running: true, availableModels, loadedModels };
 }
 
@@ -230,9 +240,14 @@ function pullModel(name, onProgress) {
 
 const VALID_CATEGORIES = ['Task', 'Thought', 'Reminder', 'Idea', 'Question', 'Decision'];
 
+// Cached set of available model names (refreshed via getOllamaStatus calls)
+let _availableModels = null;
+
 /**
  * Classify a piece of text into one of the six entry categories using an LLM.
- * Uses the chat-generation model (phi3:mini or user-configured chat model).
+ * Uses the LLM model (llmModel setting, default phi3:mini).
+ * Skips silently if the model is not installed.
+ * Uses a 120s timeout to allow for cold model loading.
  *
  * @param {string} text  The entry content to classify
  * @returns {Promise<string>}  One of: Task, Thought, Reminder, Idea, Question, Decision
@@ -242,23 +257,37 @@ async function classifyEntry(text) {
   // Use the LLM model, never the embedding model (embedding models don't support /api/generate)
   const model = settings.llmModel || 'phi3:mini';
 
+  // Check the model is actually installed — avoid spinning indefinitely against a missing model.
+  // _availableModels is populated by getOllamaStatus() which the worker calls regularly.
+  if (_availableModels !== null && !_availableModels.some((m) => m === model || m.startsWith(model + ':'))) {
+    throw new Error(`LLM model '${model}' is not installed — skipping classification`);
+  }
+
   const prompt =
     'Classify the following note into exactly one of these categories:\n' +
     'Task, Thought, Reminder, Idea, Question, Decision\n\n' +
     'Reply with only the category name and nothing else.\n\n' +
     `Note: ${text.slice(0, 500)}`;
 
+  // 120s timeout: allows for cold model loading from disk
   const response = await ollamaRequest('/api/generate', {
     model,
     prompt,
     stream: false,
     options: { temperature: 0, num_predict: 10 },
-  });
+  }, 120_000);
 
   const raw = (response.response || '').trim();
-  // Find which valid category appears in the response (case-insensitive)
   const match = VALID_CATEGORIES.find((c) => raw.toLowerCase().startsWith(c.toLowerCase()));
   return match || 'Thought'; // safe fallback
+}
+
+/**
+ * Update the cached list of available models (called from getOllamaStatus).
+ * @param {string[]} models
+ */
+function setAvailableModels(models) {
+  _availableModels = models;
 }
 
 

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -228,4 +228,37 @@ function pullModel(name, onProgress) {
   });
 }
 
-module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel };
+const VALID_CATEGORIES = ['Task', 'Thought', 'Reminder', 'Idea', 'Question', 'Decision'];
+
+/**
+ * Classify a piece of text into one of the six entry categories using an LLM.
+ * Uses the chat-generation model (phi3:mini or user-configured chat model).
+ *
+ * @param {string} text  The entry content to classify
+ * @returns {Promise<string>}  One of: Task, Thought, Reminder, Idea, Question, Decision
+ */
+async function classifyEntry(text) {
+  const settings = getSettings();
+  const model = settings.chatModel || settings.embeddingModel || 'phi3:mini';
+
+  const prompt =
+    'Classify the following note into exactly one of these categories:\n' +
+    'Task, Thought, Reminder, Idea, Question, Decision\n\n' +
+    'Reply with only the category name and nothing else.\n\n' +
+    `Note: ${text.slice(0, 500)}`;
+
+  const response = await ollamaRequest('/api/generate', {
+    model,
+    prompt,
+    stream: false,
+    options: { temperature: 0, num_predict: 10 },
+  });
+
+  const raw = (response.response || '').trim();
+  // Find which valid category appears in the response (case-insensitive)
+  const match = VALID_CATEGORIES.find((c) => raw.toLowerCase().startsWith(c.toLowerCase()));
+  return match || 'Thought'; // safe fallback
+}
+
+
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry };

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -239,7 +239,8 @@ const VALID_CATEGORIES = ['Task', 'Thought', 'Reminder', 'Idea', 'Question', 'De
  */
 async function classifyEntry(text) {
   const settings = getSettings();
-  const model = settings.chatModel || settings.embeddingModel || 'phi3:mini';
+  // Use the LLM model, never the embedding model (embedding models don't support /api/generate)
+  const model = settings.llmModel || 'phi3:mini';
 
   const prompt =
     'Classify the following note into exactly one of these categories:\n' +

--- a/tests/unit/db/entries.test.js
+++ b/tests/unit/db/entries.test.js
@@ -174,3 +174,60 @@ describe('getEntryRevisions', () => {
     expect(revisions).toEqual([]);
   });
 });
+
+describe('updateEntryCategory', () => {
+  test('sets the LLM-assigned category', async () => {
+    const { createEntry, updateEntryCategory } = require('../../../src/backend/db/entries');
+    const entry = await createEntry({ content: 'buy milk' });
+    expect(entry.category).toBeNull();
+
+    const updated = await updateEntryCategory(entry.id, 'Task', 'llm');
+    expect(updated.category).toBe('Task');
+    expect(updated.user_category).toBeNull();
+  });
+
+  test('sets a user category override', async () => {
+    const { createEntry, updateEntryCategory } = require('../../../src/backend/db/entries');
+    const entry = await createEntry({ content: 'interesting thought' });
+    await updateEntryCategory(entry.id, 'Thought', 'llm');
+    const updated = await updateEntryCategory(entry.id, 'Idea', 'user');
+    expect(updated.category).toBe('Thought');
+    expect(updated.user_category).toBe('Idea');
+  });
+
+  test('can clear a user override by passing null', async () => {
+    const { createEntry, updateEntryCategory } = require('../../../src/backend/db/entries');
+    const entry = await createEntry({ content: 'something' });
+    await updateEntryCategory(entry.id, 'Task', 'user');
+    const cleared = await updateEntryCategory(entry.id, null, 'user');
+    expect(cleared.user_category).toBeNull();
+  });
+
+  test('returns undefined for unknown id', async () => {
+    const { updateEntryCategory } = require('../../../src/backend/db/entries');
+    const result = await updateEntryCategory('no-such-id', 'Task', 'llm');
+    // getEntryById returns undefined for missing rows
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('listEntriesWithoutCategory', () => {
+  test('returns ids of entries with no category', async () => {
+    const { createEntry, updateEntryCategory, listEntriesWithoutCategory } = require('../../../src/backend/db/entries');
+    const a = await createEntry({ content: 'alpha' });
+    const b = await createEntry({ content: 'beta' });
+    await updateEntryCategory(a.id, 'Task', 'llm');
+
+    const ids = await listEntriesWithoutCategory();
+    expect(ids).not.toContain(a.id);
+    expect(ids).toContain(b.id);
+  });
+
+  test('returns empty array when all entries are classified', async () => {
+    const { createEntry, updateEntryCategory, listEntriesWithoutCategory } = require('../../../src/backend/db/entries');
+    const e = await createEntry({ content: 'done' });
+    await updateEntryCategory(e.id, 'Thought', 'llm');
+    const ids = await listEntriesWithoutCategory();
+    expect(ids).toHaveLength(0);
+  });
+});

--- a/tests/unit/worker/worker.test.js
+++ b/tests/unit/worker/worker.test.js
@@ -38,8 +38,11 @@ beforeEach(() => {
   mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue([]);
   mockEmbeddings.upsertEmbedding.mockResolvedValue(undefined);
   mockEntries.getEntryById.mockResolvedValue(undefined);
+  mockEntries.updateEntryCategory.mockResolvedValue(undefined);
+  mockEntries.listEntriesWithoutCategory.mockResolvedValue([]);
   mockStore.upsertVector.mockResolvedValue(undefined);
   mockOllama.generateEmbedding.mockResolvedValue(makeVector());
+  mockOllama.classifyEntry.mockResolvedValue('Thought');
 });
 
 afterEach(() => {
@@ -140,6 +143,39 @@ describe('processBatch', () => {
     await flushAsync();
 
     expect(mockOllama.isOllamaAvailable).not.toHaveBeenCalled();
+  });
+
+  test('classification backfill: classifies entries that have no category', async () => {
+    // No entries need embedding, but one needs classification
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue([]);
+    mockEntries.listEntriesWithoutCategory.mockResolvedValue(['existing-id']);
+    mockEntries.getEntryById.mockResolvedValue({ id: 'existing-id', content: 'old note', category: null });
+    mockOllama.classifyEntry.mockResolvedValue('Idea');
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    expect(mockOllama.classifyEntry).toHaveBeenCalledWith('old note');
+    expect(mockEntries.updateEntryCategory).toHaveBeenCalledWith('existing-id', 'Idea', 'llm');
+  });
+
+  test('classification backfill: handles a classification error without stopping', async () => {
+    mockEmbeddings.listEntriesWithoutEmbedding.mockResolvedValue([]);
+    mockEntries.listEntriesWithoutCategory.mockResolvedValue(['bad-id', 'good-id']);
+    mockEntries.getEntryById
+      .mockResolvedValueOnce({ id: 'bad-id',  content: 'bad',  category: null })
+      .mockResolvedValueOnce({ id: 'good-id', content: 'good', category: null });
+    mockOllama.classifyEntry
+      .mockRejectedValueOnce(new Error('LLM offline'))
+      .mockResolvedValueOnce('Task');
+
+    const { startWorker } = require('../../../src/worker/index');
+    startWorker();
+    await flushAsync();
+
+    expect(mockEntries.updateEntryCategory).toHaveBeenCalledTimes(1);
+    expect(mockEntries.updateEntryCategory).toHaveBeenCalledWith('good-id', 'Task', 'llm');
   });
 });
 


### PR DESCRIPTION
Closes #40

## What
Automatically classifies entries as Task, Thought, Reminder, Idea, Question, or Decision using the local Ollama LLM. Users can override the category at any time.

## How it works
- **Worker pass 1**: after embedding a new entry, fires a fire-and-forget classification (doesn't block the embedding pipeline)
- **Worker pass 2** (backfill): every tick calls \listEntriesWithoutCategory\ and processes up to 3 unclassified entries — this means all existing notes are automatically classified without any manual migration step
- **User override**: a dropdown in the detail panel stores the override in \user_category\; the displayed badge always prefers \user_category\ over \category\
- **Auto-refresh**: the badge updates when \worker:entries-updated\ fires after the backfill completes

## DB changes
Migration 003 adds \category TEXT\ and \user_category TEXT\ to \entries\.

## Tests
159 passing (8 new db tests, 2 new worker tests).