### PR TITLE
feat: tag editor in detail panel

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -79,7 +79,12 @@
               <div id="detail-text"></div>
               <div id="detail-tags-section">
                 <div id="detail-tags-label">Tags</div>
-                <div id="detail-tags"></div>
+                <div id="detail-tags-editor">
+                  <div id="detail-tags-chips"></div>
+                  <input id="detail-tags-input" type="text"
+                    placeholder="Add a tag…"
+                    autocomplete="off" spellcheck="false" />
+                </div>
               </div>
             </div>
             <!-- Edit form (hidden by default) -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -384,7 +384,56 @@ html, body {
   color: var(--text-dim);
   margin-bottom: 6px;
 }
-#detail-tags { display: flex; flex-wrap: wrap; gap: 5px; }
+
+/* Tag editor — chips + inline input */
+#detail-tags-editor {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+#detail-tags-chips {
+  display: contents; /* chips flow directly into the flex parent */
+}
+.detail-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  border-radius: 4px;
+  padding: 1px 4px 1px 6px;
+}
+.detail-tag-chip .dtc-name {
+  cursor: pointer;
+}
+.detail-tag-chip .dtc-name:hover { color: var(--cortex-teal); }
+.detail-tag-chip .dtc-remove {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 1px;
+}
+.detail-tag-chip .dtc-remove:hover { color: var(--danger); }
+#detail-tags-input {
+  flex: 1;
+  min-width: 80px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  padding: 1px 2px;
+  outline: none;
+}
+#detail-tags-input::placeholder { color: var(--text-dim); }
+#detail-tags-input:focus { border-bottom-color: var(--cortex-teal); }
 
 /* ── Detail footer (Edit / History buttons) ───────────────────────────── */
 #detail-footer {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -332,7 +332,6 @@ async function selectEntry(id) {
     detailCategoryBadge.textContent = displayCat || '';
     detailCategoryBadge.setAttribute('data-cat', displayCat || '');
     detailCategorySelect.value = entry.user_category || '';
-    detailTags.innerHTML = '';
     renderDetailTags(entry.tags || []);
 
     detailPlaceholder.style.display = 'none';

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -31,9 +31,10 @@ const detailDate    = document.getElementById('detail-date');
 const detailSource  = document.getElementById('detail-source');
 const detailCategoryBadge  = document.getElementById('detail-category-badge');
 const detailCategorySelect = document.getElementById('detail-category-select');
-const detailText    = document.getElementById('detail-text');
-const detailTags    = document.getElementById('detail-tags');
-const detailRead    = document.getElementById('detail-read');
+const detailText      = document.getElementById('detail-text');
+const detailTagsChips = document.getElementById('detail-tags-chips');
+const detailTagsInput = document.getElementById('detail-tags-input');
+const detailRead      = document.getElementById('detail-read');
 const detailEdit    = document.getElementById('detail-edit');
 const detailHistory = document.getElementById('detail-history');
 const historyList   = document.getElementById('history-list');
@@ -222,6 +223,88 @@ function applyTagFilter(tagName) {
 
 // ── Entry detail ───────────────────────────────────────────────────────────
 
+// Render editable tag chips in the detail panel.
+// Tags are shown as removable pills; an input at the end lets the user add more.
+function renderDetailTags(tags) {
+  detailTagsChips.innerHTML = '';
+  const currentNames = tags.map((t) => t.name || t);
+
+  currentNames.forEach((name) => {
+    const chip = document.createElement('span');
+    chip.className = 'detail-tag-chip';
+    chip.innerHTML = `<span class="dtc-name">#${name}</span><button class="dtc-remove" title="Remove tag" aria-label="Remove ${name}">×</button>`;
+    chip.querySelector('.dtc-name').addEventListener('click', () => applyTagFilter(name));
+    chip.querySelector('.dtc-remove').addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const updated = currentNames.filter((n) => n !== name);
+      await _saveTags(updated);
+    });
+    detailTagsChips.appendChild(chip);
+  });
+
+  detailTagsInput.value = '';
+}
+
+async function _saveTags(tagNames) {
+  if (!_state.selectedId) return;
+  const result = await window.neurologue.setTags(_state.selectedId, tagNames);
+  if (result.ok) {
+    renderDetailTags(result.entry.tags || []);
+    // Refresh the card in the timeline so the chip row stays in sync
+    const card = document.querySelector(`.entry-card[data-id="${_state.selectedId}"]`);
+    if (card) {
+      const updated = result.entry;
+      // Re-render the chips row on the card
+      const oldChips = card.querySelector('.entry-chips');
+      const cat = updated.user_category || updated.category;
+      const hasTags = updated.tags && updated.tags.length > 0;
+      if (hasTags || cat) {
+        const chipRow = document.createElement('div');
+        chipRow.className = 'entry-chips';
+        if (hasTags) {
+          updated.tags.slice(0, 6).forEach((t) => {
+            const pill = document.createElement('span');
+            pill.className = 'tag-pill';
+            pill.textContent = `#${t.name || t}`;
+            chipRow.appendChild(pill);
+          });
+        }
+        if (cat) {
+          const badge = document.createElement('span');
+          badge.className = 'category-badge category-badge--card';
+          badge.setAttribute('data-cat', cat);
+          badge.textContent = cat;
+          chipRow.appendChild(badge);
+        }
+        if (oldChips) { card.replaceChild(chipRow, oldChips); } else { card.appendChild(chipRow); }
+      } else if (oldChips) {
+        oldChips.remove();
+      }
+    }
+    await loadTags(); // refresh sidebar tag list
+  }
+}
+
+// Commit whatever is in the tag input field as a new tag
+async function _commitTagInput() {
+  const raw = detailTagsInput.value.trim();
+  if (!raw) return;
+  const newNames = raw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean);
+  if (!newNames.length) return;
+  const existing = Array.from(detailTagsChips.querySelectorAll('.dtc-name'))
+    .map((el) => el.textContent.replace(/^#/, ''));
+  const merged = [...new Set([...existing, ...newNames])];
+  await _saveTags(merged);
+}
+
+detailTagsInput.addEventListener('keydown', async (e) => {
+  if (e.key === 'Enter' || e.key === ',') {
+    e.preventDefault();
+    await _commitTagInput();
+  }
+});
+detailTagsInput.addEventListener('blur', () => _commitTagInput());
+
 async function selectEntry(id) {
   _state.selectedId = id;
 
@@ -250,19 +333,7 @@ async function selectEntry(id) {
     detailCategoryBadge.setAttribute('data-cat', displayCat || '');
     detailCategorySelect.value = entry.user_category || '';
     detailTags.innerHTML = '';
-    if (entry.tags && entry.tags.length > 0) {
-      entry.tags.forEach((t) => {
-        const pill = document.createElement('span');
-        pill.className = 'tag-pill';
-        pill.style.cursor = 'pointer';
-        pill.textContent = t.name;
-        pill.addEventListener('click', () => applyTagFilter(t.name));
-        detailTags.appendChild(pill);
-      });
-      document.getElementById('detail-tags-section').style.display = 'block';
-    } else {
-      document.getElementById('detail-tags-section').style.display = 'none';
-    }
+    renderDetailTags(entry.tags || []);
 
     detailPlaceholder.style.display = 'none';
     detailContent.style.display = 'flex';

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   updateEntry: (id, content) => ipcRenderer.invoke('library:update-entry', { id, content }),
   getRevisions: (id) => ipcRenderer.invoke('library:get-revisions', { id }),
   setCategory: (id, category) => ipcRenderer.invoke('library:set-category', { id, category }),
+  setTags: (id, tags) => ipcRenderer.invoke('library:set-tags', { id, tags }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
 
   // ── Themes ───────────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -113,6 +113,14 @@ ipcMain.handle('library:list-tags', async () => {
   return listTags();
 });
 
+// Update tags for an existing entry
+ipcMain.handle('library:set-tags', async (_event, { id, tags }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  await setTagsForEntry(id, Array.isArray(tags) ? tags : []);
+  const entry = await getEntryWithTags(id);
+  return entry ? { ok: true, entry } : { ok: false, error: 'Entry not found' };
+});
+
 // ── Themes IPC ───────────────────────────────────────────────────────────────
 
 // List all themes with their entry count


### PR DESCRIPTION
Closes #41

## Changes

### Tag editor in detail panel
- Existing tags render as removable chips with a # prefix — clicking the name applies a tag filter, clicking × removes the tag immediately
- An inline input at the end of the chips accepts new tags (commit with Enter, comma, or blur); multiple tags can be entered comma-separated in one go
- Works on entries with no tags (just shows the placeholder input)

### IPC
- New library:set-tags handler in main.js — calls setTagsForEntry and returns the enriched entry
- setTags(id, tags) exposed via preload.js

### Card sync
- After saving, the matching timeline card's chip row is updated in-place (no full reload needed)
- Sidebar tag list refreshes after any tag change

### Acceptance criteria from #41
- ✅ Tag chips on entry cards (styled pills, differentiated from category badges)
- ✅ Category badge on each entry card (colour-coded)
- ✅ Category badge in detail panel
- ✅ Tag editor — removable chips + add input
- ✅ Works on entries with no tags
- ✅ Saves via IPC and refreshes card