### PR TITLE
feat: LLM tag suggestions in capture and detail panel

### DIFF
--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -16,11 +16,12 @@ const config = require('../config');
 
 const SETTINGS_PATH = config.settings.path;
 
-/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string }} */
+/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string, tagSuggestionFormat: string }} */
 const DEFAULTS = {
-  embeddingModel: config.ollama.embeddingModel,
-  llmModel:       config.ollama.llmModel,
-  captureHotkey:  config.hotkey.capture,
+  embeddingModel:      config.ollama.embeddingModel,
+  llmModel:            config.ollama.llmModel,
+  captureHotkey:       config.hotkey.capture,
+  tagSuggestionFormat: 'hyphenated', // 'hyphenated' = two-words, 'concatenated' = twowords
 };
 
 /**

--- a/src/frontend/capture-preload.js
+++ b/src/frontend/capture-preload.js
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld('capture', {
    */
   save: (data) => ipcRenderer.invoke('capture:save', data),
 
+  /** Suggest tags for a piece of text. */
+  suggestTags: (text) => ipcRenderer.invoke('library:suggest-tags', { text }),
+
   /** Close the popup without saving. */
   close: () => ipcRenderer.send('capture:close'),
 });

--- a/src/frontend/capture.html
+++ b/src/frontend/capture.html
@@ -298,6 +298,35 @@
     .btn-save:hover    { background: var(--insight-cyan); }
     .btn-save:disabled { opacity: 0.45; cursor: default; }
 
+    /* ── Tag suggestions ── */
+    #tag-suggestions {
+      display: none;
+      flex-wrap: wrap;
+      gap: 5px;
+      padding: 0 2px;
+      -webkit-app-region: no-drag;
+    }
+    #tag-suggestions.visible { display: flex; }
+    .tag-suggestion {
+      font-size: 11px;
+      background: transparent;
+      border: 1px solid var(--cortex-teal);
+      color: var(--cortex-teal);
+      border-radius: 4px;
+      padding: 1px 8px;
+      cursor: pointer;
+      font-family: var(--font);
+      transition: background 0.1s, color 0.1s;
+      user-select: none;
+    }
+    .tag-suggestion:hover { background: var(--cortex-teal); color: var(--white); }
+    .tag-suggestions-label {
+      font-size: 11px;
+      color: var(--slate);
+      opacity: 0.6;
+      align-self: center;
+    }
+
     /* ── Error banner ── */
     .error {
       display: none;
@@ -344,6 +373,7 @@
         spellcheck="false"
         autocomplete="off"
       />
+      <div id="tag-suggestions" role="list" aria-label="Suggested tags"></div>
     </div>
 
     <p class="error" id="error-msg"></p>

--- a/src/frontend/capture.js
+++ b/src/frontend/capture.js
@@ -5,6 +5,7 @@
 
 const contentEl    = document.getElementById('content');
 const tagsEl       = document.getElementById('tags');
+const tagSuggestions = document.getElementById('tag-suggestions');
 const saveBtn      = document.getElementById('btn-save');
 const errorMsg     = document.getElementById('error-msg');
 const toolbar      = document.getElementById('toolbar');
@@ -18,6 +19,58 @@ const btnPastePlain = document.getElementById('btn-paste-plain');
 let _mdMode       = false;
 let _previewMode  = false;
 let _pastePlain   = false;
+let _suggestTimer = null;
+
+// ── Tag suggestions ───────────────────────────────────────────────────────
+
+function _currentTagSet() {
+  return new Set(
+    tagsEl.value.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)
+  );
+}
+
+function _renderSuggestions(tags) {
+  tagSuggestions.innerHTML = '';
+  const current = _currentTagSet();
+  const fresh = tags.filter((t) => !current.has(t));
+  if (!fresh.length) { tagSuggestions.classList.remove('visible'); return; }
+
+  const label = document.createElement('span');
+  label.className = 'tag-suggestions-label';
+  label.textContent = 'Suggestions:';
+  tagSuggestions.appendChild(label);
+
+  fresh.forEach((tag) => {
+    const pill = document.createElement('button');
+    pill.className = 'tag-suggestion';
+    pill.type = 'button';
+    pill.textContent = `#${tag}`;
+    pill.addEventListener('click', () => {
+      const existing = tagsEl.value.trim();
+      tagsEl.value = existing ? `${existing}, ${tag}` : tag;
+      // Remove from suggestions
+      pill.remove();
+      if (tagSuggestions.querySelectorAll('.tag-suggestion').length === 0) {
+        tagSuggestions.classList.remove('visible');
+      }
+    });
+    tagSuggestions.appendChild(pill);
+  });
+  tagSuggestions.classList.add('visible');
+}
+
+async function _fetchSuggestions() {
+  const text = contentEl.value.trim();
+  if (text.length < 20) return; // too short to bother
+  try {
+    const result = await window.capture.suggestTags(text);
+    if (result.ok && result.suggestions.length > 0) {
+      _renderSuggestions(result.suggestions);
+    }
+  } catch {
+    // suggestions are best-effort — silently ignore errors
+  }
+}
 
 // ── Enable/disable Save based on content ──────────────────────────────────
 
@@ -25,6 +78,9 @@ contentEl.addEventListener('input', () => {
   saveBtn.disabled = contentEl.value.trim().length === 0;
   hideError();
   if (_previewMode) renderPreview();
+  // Debounce tag suggestions — fire 900ms after user stops typing
+  clearTimeout(_suggestTimer);
+  _suggestTimer = setTimeout(_fetchSuggestions, 900);
 });
 
 // ── Markdown toggle ───────────────────────────────────────────────────────

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -197,6 +197,16 @@
         <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
       </div>
 
+      <h3 class="settings-section-heading">Tag suggestions</h3>
+      <div class="settings-field">
+        <label for="select-tag-format">Multi-word tag format</label>
+        <select id="select-tag-format">
+          <option value="hyphenated">Hyphenated (two-words)</option>
+          <option value="concatenated">Concatenated (twowords)</option>
+        </select>
+        <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
+      </div>
+
       <h3 class="settings-section-heading">Capture hotkey</h3>
       <div class="settings-field">
         <label>Global shortcut</label>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -85,6 +85,7 @@
                     placeholder="Add a tag…"
                     autocomplete="off" spellcheck="false" />
                 </div>
+                <div id="detail-tags-suggestions"></div>
               </div>
             </div>
             <!-- Edit form (hidden by default) -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -435,6 +435,36 @@ html, body {
 #detail-tags-input::placeholder { color: var(--text-dim); }
 #detail-tags-input:focus { border-bottom-color: var(--cortex-teal); }
 
+/* Tag suggestions in detail panel */
+#detail-tags-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  min-height: 0;
+}
+#detail-tags-suggestions:empty { display: none; }
+.detail-suggestions-label {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  align-self: center;
+}
+.detail-tag-suggestion {
+  background: transparent;
+  border: 1px solid var(--cortex-teal);
+  color: var(--cortex-teal);
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 1px 7px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.1s, color 0.1s;
+}
+.detail-tag-suggestion:hover { background: var(--cortex-teal); color: var(--text); }
+
 /* ── Detail footer (Edit / History buttons) ───────────────────────────── */
 #detail-footer {
   padding: 8px 16px 12px;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -223,6 +223,9 @@ function applyTagFilter(tagName) {
 
 // ── Entry detail ───────────────────────────────────────────────────────────
 
+const detailTagsSuggestions = document.getElementById('detail-tags-suggestions');
+let _detailSuggestTimer = null;
+
 // Render editable tag chips in the detail panel.
 // Tags are shown as removable pills; an input at the end lets the user add more.
 function renderDetailTags(tags) {
@@ -243,6 +246,50 @@ function renderDetailTags(tags) {
   });
 
   detailTagsInput.value = '';
+}
+
+function _renderDetailSuggestions(suggested) {
+  detailTagsSuggestions.innerHTML = '';
+  const current = new Set(
+    Array.from(detailTagsChips.querySelectorAll('.dtc-name'))
+      .map((el) => el.textContent.replace(/^#/, ''))
+  );
+  const fresh = suggested.filter((t) => !current.has(t));
+  if (!fresh.length) return;
+
+  const label = document.createElement('span');
+  label.className = 'detail-suggestions-label';
+  label.textContent = 'Suggestions:';
+  detailTagsSuggestions.appendChild(label);
+
+  fresh.forEach((tag) => {
+    const pill = document.createElement('button');
+    pill.className = 'detail-tag-suggestion';
+    pill.type = 'button';
+    pill.textContent = `#${tag}`;
+    pill.addEventListener('click', async () => {
+      const existing = Array.from(detailTagsChips.querySelectorAll('.dtc-name'))
+        .map((el) => el.textContent.replace(/^#/, ''));
+      await _saveTags([...new Set([...existing, tag])]);
+      pill.remove();
+      if (detailTagsSuggestions.querySelectorAll('.detail-tag-suggestion').length === 0) {
+        detailTagsSuggestions.innerHTML = '';
+      }
+    });
+    detailTagsSuggestions.appendChild(pill);
+  });
+}
+
+async function _fetchDetailSuggestions(entryContent) {
+  if (!entryContent || entryContent.length < 20) return;
+  try {
+    const result = await window.neurologue.suggestTags(entryContent);
+    if (result.ok && result.suggestions.length > 0) {
+      _renderDetailSuggestions(result.suggestions);
+    }
+  } catch {
+    // best-effort
+  }
 }
 
 async function _saveTags(tagNames) {
@@ -333,6 +380,11 @@ async function selectEntry(id) {
     detailCategoryBadge.setAttribute('data-cat', displayCat || '');
     detailCategorySelect.value = entry.user_category || '';
     renderDetailTags(entry.tags || []);
+
+    // Clear stale suggestions then fetch fresh ones (debounced to avoid hammering on quick selection)
+    detailTagsSuggestions.innerHTML = '';
+    clearTimeout(_detailSuggestTimer);
+    _detailSuggestTimer = setTimeout(() => _fetchDetailSuggestions(entry.content), 600);
 
     detailPlaceholder.style.display = 'none';
     detailContent.style.display = 'flex';

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1082,6 +1082,10 @@ btnSettings.addEventListener('click', async () => {
   buildOptions('select-embed-model', available, settings.embeddingModel);
   buildOptions('select-llm-model',   available, settings.llmModel);
 
+  // Tag suggestion format
+  const tagFmtSelect = document.getElementById('select-tag-format');
+  if (tagFmtSelect) tagFmtSelect.value = settings.tagSuggestionFormat || 'hyphenated';
+
   // Populate hotkey display
   const currentHotkey = settings.captureHotkey || 'CommandOrControl+Shift+Space';
   hotkeyDisplay.dataset.saved = currentHotkey;
@@ -1100,6 +1104,7 @@ document.getElementById('settings-close').addEventListener('click', () => {
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
   const embedModel = document.getElementById('select-embed-model').value;
   const llmModel   = document.getElementById('select-llm-model').value;
+  const tagFmt     = (document.getElementById('select-tag-format') || {}).value || 'hyphenated';
 
   // Apply hotkey change first if the user recorded a new one
   if (_pendingHotkey) {
@@ -1113,7 +1118,7 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
     _pendingHotkey = null;
   }
 
-  await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel });
+  await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel, tagSuggestionFormat: tagFmt });
   const msg = document.getElementById('settings-saved-msg');
   msg.classList.remove('hidden');
   setTimeout(() => msg.classList.add('hidden'), 2000);

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   getRevisions: (id) => ipcRenderer.invoke('library:get-revisions', { id }),
   setCategory: (id, category) => ipcRenderer.invoke('library:set-category', { id, category }),
   setTags: (id, tags) => ipcRenderer.invoke('library:set-tags', { id, tags }),
+  suggestTags: (text) => ipcRenderer.invoke('library:suggest-tags', { text }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
 
   // ── Themes ───────────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCat
 const { setTagsForEntry, listTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
-const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel } = require('./worker/ollama');
+const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
 const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
@@ -119,6 +119,18 @@ ipcMain.handle('library:set-tags', async (_event, { id, tags }) => {
   await setTagsForEntry(id, Array.isArray(tags) ? tags : []);
   const entry = await getEntryWithTags(id);
   return entry ? { ok: true, entry } : { ok: false, error: 'Entry not found' };
+});
+
+// Suggest tags for a piece of text (used by capture + detail panel)
+ipcMain.handle('library:suggest-tags', async (_event, { text }) => {
+  if (!text || !text.trim()) return { ok: true, suggestions: [] };
+  try {
+    const known = (await listTags()).map((t) => t.name);
+    const suggestions = await suggestTags(text.trim(), known);
+    return { ok: true, suggestions };
+  } catch (err) {
+    return { ok: false, suggestions: [], error: err.message };
+  }
 });
 
 // ── Themes IPC ───────────────────────────────────────────────────────────────

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -294,6 +294,7 @@ async function classifyEntry(text) {
 async function suggestTags(text, knownTags = []) {
   const settings = getSettings();
   const model = settings.llmModel || 'phi3:mini';
+  const useHyphens = (settings.tagSuggestionFormat || 'hyphenated') === 'hyphenated';
 
   if (_availableModels !== null && !_availableModels.some((m) => m === model || m.startsWith(model + ':'))) {
     throw new Error(`LLM model '${model}' is not installed — skipping tag suggestions`);
@@ -320,7 +321,12 @@ async function suggestTags(text, knownTags = []) {
   const raw = (response.response || '').trim();
   return raw
     .split(',')
-    .map((t) => t.trim().toLowerCase().replace(/[^a-z0-9-]/g, ''))
+    .map((t) => {
+      const clean = t.trim().toLowerCase().replace(/[^a-z0-9\s-]/g, '').trim();
+      return useHyphens
+        ? clean.replace(/\s+/g, '-')   // two words → two-words
+        : clean.replace(/[\s-]+/g, ''); // two words / two-words → twowords
+    })
     .filter(Boolean)
     .slice(0, 5);
 }

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -283,6 +283,49 @@ async function classifyEntry(text) {
 }
 
 /**
+ * Suggest up to 5 relevant tags for a piece of text using an LLM.
+ * Receives the existing tag corpus so it can reuse known tags where appropriate,
+ * but may also suggest new ones.
+ *
+ * @param {string}   text         The entry content to tag
+ * @param {string[]} [knownTags]  Existing tags in the library (for reuse hints)
+ * @returns {Promise<string[]>}   Up to 5 lowercase tag names
+ */
+async function suggestTags(text, knownTags = []) {
+  const settings = getSettings();
+  const model = settings.llmModel || 'phi3:mini';
+
+  if (_availableModels !== null && !_availableModels.some((m) => m === model || m.startsWith(model + ':'))) {
+    throw new Error(`LLM model '${model}' is not installed — skipping tag suggestions`);
+  }
+
+  const knownHint = knownTags.length > 0
+    ? `Existing tags you may reuse if relevant: ${knownTags.slice(0, 30).join(', ')}.\n`
+    : '';
+
+  const prompt =
+    'Suggest up to 5 short, lowercase tags for the following note.\n' +
+    knownHint +
+    'Reply with only a comma-separated list of tags and nothing else. ' +
+    'Tags should be single words or short hyphenated phrases.\n\n' +
+    `Note: ${text.slice(0, 500)}`;
+
+  const response = await ollamaRequest('/api/generate', {
+    model,
+    prompt,
+    stream: false,
+    options: { temperature: 0.2, num_predict: 40 },
+  }, 120_000);
+
+  const raw = (response.response || '').trim();
+  return raw
+    .split(',')
+    .map((t) => t.trim().toLowerCase().replace(/[^a-z0-9-]/g, ''))
+    .filter(Boolean)
+    .slice(0, 5);
+}
+
+/**
  * Update the cached list of available models (called from getOllamaStatus).
  * @param {string[]} models
  */
@@ -291,4 +334,4 @@ function setAvailableModels(models) {
 }
 
 
-module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry };
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry, suggestTags, setAvailableModels };


### PR DESCRIPTION
Closes #42

## What this does
Uses the configured LLM model (same one used for entry classification) to suggest relevant tags as the user types.

## Capture window
- After the user pauses typing for 900ms, the content is sent to \library:suggest-tags\
- Suggestions appear as teal-bordered clickable pills labelled \#tagname\ below the tags input
- Clicking a pill appends the tag to the tags field and removes that pill
- Already-typed tags are filtered out of suggestions
- Requires ≥20 characters of content before triggering

## Detail panel (existing entries)
- When an entry is selected, suggestions are fetched after a 600ms debounce
- Appear as clickable pills below the tag editor chips
- Clicking a suggestion immediately saves it via \library:set-tags\ IPC and updates the card
- Stale suggestions are cleared when selecting a different entry

## LLM behaviour
- \suggestTags(text, knownTags)\ in \ollama.js\ passes existing library tags as a hint so the model reuses known tags where appropriate, but can also suggest new ones
- Uses \	emperature: 0.2\ for slight variety
- 120s timeout (same as classification) to handle cold model loading
- Gracefully skips if LLM model is not installed (same guard as classification)
- All errors are silently swallowed in the UI — suggestions are best-effort