### PR TITLE
feat: tag management panel (rename, delete, merge, duplicate detection) [#43/#86]

### DIFF
--- a/src/backend/db/tags.js
+++ b/src/backend/db/tags.js
@@ -190,9 +190,23 @@ async function findSimilarTags() {
         continue;
       }
 
+      // Prefix/abbreviation variant: one tag is a prefix of the other,
+      // or becomes one after stripping a trailing plural 's'.
+      // e.g. dev ↔ development, devs ↔ development
+      const [shorter, longer] = a.name.length <= b.name.length
+        ? [a.name, b.name] : [b.name, a.name];
+      if (shorter.length >= 3 && shorter !== longer) {
+        const stem = (shorter.endsWith('s') && shorter.length >= 4)
+          ? shorter.slice(0, -1) : shorter;
+        if (longer.startsWith(shorter) || longer.startsWith(stem)) {
+          pairs.push({ a, b, reason: 'prefix-variant' });
+          continue;
+        }
+      }
+
       // Spelling variant: small edit distance relative to tag length
       const minLen = Math.min(a.name.length, b.name.length);
-      if (minLen >= 4) {
+      if (minLen >= 3) {
         const threshold = minLen >= 7 ? 2 : 1;
         if (_levenshtein(a.name, b.name) <= threshold) {
           pairs.push({ a, b, reason: 'similar-spelling' });

--- a/src/backend/db/tags.js
+++ b/src/backend/db/tags.js
@@ -72,4 +72,137 @@ async function setTagsForEntry(entryId, tagNames) {
   setAll(tagNames.filter(Boolean));
 }
 
-module.exports = { upsertTag, listTags, getTagsForEntry, setTagsForEntry };
+/**
+ * List all tags with entry counts, sorted by count desc then name asc.
+ * @returns {Promise<{ id: string, name: string, count: number }[]>}
+ */
+async function listTagsWithCounts() {
+  const db = await openDb();
+  return db.prepare(`
+    SELECT t.id, t.name, COUNT(et.entry_id) AS count
+    FROM tags t
+    LEFT JOIN entry_tags et ON et.tag_id = t.id
+    GROUP BY t.id
+    ORDER BY count DESC, t.name ASC
+  `).all();
+}
+
+/**
+ * Rename a tag. Fails if the normalised new name already exists on a different tag.
+ * @param {string} id
+ * @param {string} newName
+ * @returns {Promise<{ ok: boolean, error?: string }>}
+ */
+async function renameTag(id, newName) {
+  const db = await openDb();
+  const normalised = newName.trim().toLowerCase();
+  if (!normalised) return { ok: false, error: 'Name cannot be empty' };
+
+  const collision = db.prepare('SELECT id FROM tags WHERE name = ? AND id != ?').get(normalised, id);
+  if (collision) return { ok: false, error: `Tag "${normalised}" already exists` };
+
+  db.prepare('UPDATE tags SET name = ? WHERE id = ?').run(normalised, id);
+  return { ok: true };
+}
+
+/**
+ * Delete a tag and all its entry associations.
+ * @param {string} id
+ * @returns {Promise<{ ok: boolean }>}
+ */
+async function deleteTag(id) {
+  const db = await openDb();
+  const doDelete = db.transaction(() => {
+    db.prepare('DELETE FROM entry_tags WHERE tag_id = ?').run(id);
+    db.prepare('DELETE FROM tags WHERE id = ?').run(id);
+  });
+  doDelete();
+  return { ok: true };
+}
+
+/**
+ * Merge two tags: all entries with `removeId` get `keepId` applied, then `removeId` is deleted.
+ * @param {string} removeId
+ * @param {string} keepId
+ * @returns {Promise<{ ok: boolean, affected: number }>}
+ */
+async function mergeTag(removeId, keepId) {
+  const db = await openDb();
+  const doMerge = db.transaction(() => {
+    // Find all entries that have the tag being removed
+    const affected = db.prepare('SELECT entry_id FROM entry_tags WHERE tag_id = ?').all(removeId);
+    let count = 0;
+    for (const { entry_id } of affected) {
+      // Add keepId to the entry if not already present
+      db.prepare('INSERT OR IGNORE INTO entry_tags (entry_id, tag_id) VALUES (?, ?)').run(entry_id, keepId);
+      count++;
+    }
+    // Remove the source tag entirely
+    db.prepare('DELETE FROM entry_tags WHERE tag_id = ?').run(removeId);
+    db.prepare('DELETE FROM tags WHERE id = ?').run(removeId);
+    return count;
+  });
+  const affected = doMerge();
+  return { ok: true, affected };
+}
+
+// ── Similarity helpers (pure JS, no external deps) ─────────────────────────
+
+function _normTagKey(name) {
+  return name.replace(/[-_\s]+/g, '').toLowerCase();
+}
+
+function _levenshtein(a, b) {
+  const m = a.length, n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const prev = Array.from({ length: n + 1 }, (_, i) => i);
+  const curr = new Array(n + 1);
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      curr[j] = a[i - 1] === b[j - 1]
+        ? prev[j - 1]
+        : 1 + Math.min(prev[j], curr[j - 1], prev[j - 1]);
+    }
+    prev.splice(0, prev.length, ...curr);
+  }
+  return curr[n];
+}
+
+/**
+ * Return pairs of tags that are likely duplicates/variants.
+ * Each pair: { a: tag, b: tag, reason: 'format-variant'|'similar-spelling' }
+ * Sorted by combined entry count desc.
+ * @returns {Promise<{ a: object, b: object, reason: string }[]>}
+ */
+async function findSimilarTags() {
+  const tags = await listTagsWithCounts();
+  const pairs = [];
+
+  for (let i = 0; i < tags.length; i++) {
+    for (let j = i + 1; j < tags.length; j++) {
+      const a = tags[i], b = tags[j];
+
+      // Format variant: same after stripping separators
+      if (_normTagKey(a.name) === _normTagKey(b.name)) {
+        pairs.push({ a, b, reason: 'format-variant' });
+        continue;
+      }
+
+      // Spelling variant: small edit distance relative to tag length
+      const minLen = Math.min(a.name.length, b.name.length);
+      if (minLen >= 4) {
+        const threshold = minLen >= 7 ? 2 : 1;
+        if (_levenshtein(a.name, b.name) <= threshold) {
+          pairs.push({ a, b, reason: 'similar-spelling' });
+        }
+      }
+    }
+  }
+
+  // Sort: most-used pairs first
+  return pairs.sort((x, y) => (y.a.count + y.b.count) - (x.a.count + x.b.count));
+}
+
+module.exports = { upsertTag, listTags, listTagsWithCounts, getTagsForEntry, setTagsForEntry, renameTag, deleteTag, mergeTag, findSimilarTags };

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -16,12 +16,13 @@ const config = require('../config');
 
 const SETTINGS_PATH = config.settings.path;
 
-/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string, tagSuggestionFormat: string }} */
+/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string, tagSuggestionFormat: string, tagSimilarityThreshold: number }} */
 const DEFAULTS = {
-  embeddingModel:      config.ollama.embeddingModel,
-  llmModel:            config.ollama.llmModel,
-  captureHotkey:       config.hotkey.capture,
-  tagSuggestionFormat: 'hyphenated', // 'hyphenated' = two-words, 'concatenated' = twowords
+  embeddingModel:         config.ollama.embeddingModel,
+  llmModel:               config.ollama.llmModel,
+  captureHotkey:          config.hotkey.capture,
+  tagSuggestionFormat:    'hyphenated', // 'hyphenated' = two-words, 'concatenated' = twowords
+  tagSimilarityThreshold: 0.88,         // cosine similarity cutoff for semantic tag dedup
 };
 
 /**

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -229,6 +229,15 @@
         </select>
         <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
       </div>
+      <div class="settings-field">
+        <label for="select-similarity-threshold">Duplicate detection sensitivity</label>
+        <select id="select-similarity-threshold">
+          <option value="0.93">Strict — near-identical meanings only</option>
+          <option value="0.88">Balanced — recommended</option>
+          <option value="0.82">Broad — more suggestions, more noise</option>
+        </select>
+        <span class="settings-hint">How closely two tags must be related (semantically) to appear as possible duplicates. Requires Ollama.</span>
+      </div>
 
       <h3 class="settings-section-heading">Capture hotkey</h3>
       <div class="settings-field">

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -22,6 +22,7 @@
       <span id="entry-count"></span>
       <button id="btn-export" class="mode-btn">Export…</button>
       <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
+      <button id="btn-maintenance" class="mode-btn" title="Tag management">Maintenance</button>
       <button id="btn-settings" class="mode-btn" title="Settings">⚙</button>
       <button id="btn-help" class="mode-btn">Help</button>
     </div>
@@ -177,7 +178,29 @@
       </div>
     </div>
   </div>
+  <!-- ── Tag Management modal ────────────────────────────────────────────────────────── -->
+  <div id="tag-management-modal" class="modal-overlay hidden">
+    <div class="modal-box modal-box--wide">
+      <button class="modal-close" id="tag-management-close" title="Close">✕</button>
+      <h2>Tag Management</h2>
+      <p>Rename or delete tags, and consolidate near-duplicates across your library.</p>
 
+      <!-- Similar tags section -->
+      <div id="tag-similar-section" class="hidden">
+        <h3 class="settings-section-heading">Possible duplicates</h3>
+        <p class="tag-mgmt-hint">These tag pairs look similar. Pick which to keep — entries will be re-tagged automatically.</p>
+        <div id="tag-similar-list"></div>
+      </div>
+
+      <!-- All tags list -->
+      <h3 class="settings-section-heading" id="tag-all-heading">All tags</h3>
+      <div id="tag-all-list"></div>
+
+      <div class="tag-mgmt-empty hidden" id="tag-mgmt-empty">
+        No tags yet. Tags are added when you capture or edit notes.
+      </div>
+    </div>
+  </div>
   <!-- ── Settings modal ────────────────────────────────────────────────────── -->
   <div id="settings-modal" class="modal-overlay hidden">
     <div class="modal-box">

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1050,3 +1050,140 @@ html, body {
 .btn-record-hotkey.recording { border-color: var(--cortex-teal); color: var(--cortex-teal); }
 .hotkey-conflict { display: block; font-size: 11px; color: var(--danger); margin-top: 5px; }
 .hotkey-conflict.hidden { display: none; }
+
+/* ── Tag Management modal ─────────────────────────────────────────────────── */
+.modal-box--wide { max-width: 640px; max-height: 80vh; overflow-y: auto; }
+
+.tag-mgmt-hint { font-size: 12px; color: var(--text-muted); margin: 0 0 10px; }
+
+/* Similar pairs */
+.tag-similar-pair {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 6px;
+}
+.tag-similar-tag {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.tag-similar-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--cortex-teal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tag-similar-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.tag-similar-sep { font-size: 14px; color: var(--text-dim); flex-shrink: 0; }
+.tag-similar-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.btn-keep-tag {
+  background: transparent;
+  border: 1px solid var(--cortex-teal);
+  color: var(--cortex-teal);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.btn-keep-tag:hover { background: var(--cortex-teal); color: var(--bg); }
+.btn-skip-pair {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.btn-skip-pair:hover { color: var(--text-muted); border-color: var(--text-muted); }
+
+/* All-tags list */
+.tag-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.tag-row:last-child { border-bottom: none; }
+.tag-row-name { flex: 1; font-size: 13px; color: var(--text); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tag-row-count { font-size: 11px; color: var(--text-muted); white-space: nowrap; }
+.tag-row-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.btn-rename-tag, .btn-delete-tag {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+.btn-rename-tag:hover { border-color: var(--cortex-teal); color: var(--cortex-teal); }
+.btn-delete-tag:hover { border-color: var(--danger); color: var(--danger); }
+
+/* Inline rename form */
+.tag-row-rename {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.tag-row-rename input {
+  flex: 1;
+  background: var(--surface2);
+  border: 1px solid var(--cortex-teal);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 12px;
+  padding: 3px 7px;
+  outline: none;
+  min-width: 0;
+}
+.btn-rename-save, .btn-rename-cancel {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+.btn-rename-save { border-color: var(--cortex-teal); color: var(--cortex-teal); }
+.btn-rename-save:hover { background: var(--cortex-teal); color: var(--bg); }
+.btn-rename-cancel:hover { color: var(--text); }
+
+/* Confirm-delete state */
+.tag-row--confirm-delete .tag-row-name { color: var(--danger); text-decoration: line-through; }
+.tag-row--confirm-delete .btn-confirm-delete {
+  background: var(--danger);
+  border: 1px solid var(--danger);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  color: #fff;
+}
+.tag-row--confirm-delete .btn-cancel-delete {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+.tag-mgmt-empty { font-size: 13px; color: var(--text-muted); padding: 16px 0; text-align: center; }

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1187,3 +1187,5 @@ html, body {
   color: var(--text-muted);
 }
 .tag-mgmt-empty { font-size: 13px; color: var(--text-muted); padding: 16px 0; text-align: center; }
+.tag-mgmt-empty.hidden { display: none; }
+#tag-similar-section.hidden { display: none; }

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1110,6 +1110,25 @@ html, body {
 }
 .btn-skip-pair:hover { color: var(--text-muted); border-color: var(--text-muted); }
 
+/* Reason badge on similar pairs */
+.tag-similar-reason {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.tag-similar-reason--structural {
+  background: var(--surface);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+}
+.tag-similar-reason--semantic {
+  background: rgba(42, 166, 161, 0.12);
+  color: var(--cortex-teal);
+  border: 1px solid rgba(42, 166, 161, 0.35);
+}
+
 /* All-tags list */
 .tag-row {
   display: flex;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1124,6 +1124,206 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
   setTimeout(() => msg.classList.add('hidden'), 2000);
 });
 
+// ── Tag Management modal ─────────────────────────────────────────────────────
+
+const tagMgmtModal    = document.getElementById('tag-management-modal');
+const tagMgmtClose    = document.getElementById('tag-management-close');
+const tagSimilarSec   = document.getElementById('tag-similar-section');
+const tagSimilarList  = document.getElementById('tag-similar-list');
+const tagAllList      = document.getElementById('tag-all-list');
+const tagMgmtEmpty    = document.getElementById('tag-mgmt-empty');
+
+document.getElementById('btn-maintenance').addEventListener('click', openTagManagement);
+tagMgmtClose.addEventListener('click', () => tagMgmtModal.classList.add('hidden'));
+tagMgmtModal.addEventListener('click', (e) => {
+  if (e.target === tagMgmtModal) tagMgmtModal.classList.add('hidden');
+});
+
+async function openTagManagement() {
+  tagSimilarSec.classList.add('hidden');
+  tagSimilarList.innerHTML = '';
+  tagAllList.innerHTML = '';
+  tagMgmtEmpty.classList.add('hidden');
+  tagMgmtModal.classList.remove('hidden');
+  await refreshTagManagement();
+}
+
+async function refreshTagManagement() {
+  const [tags, similar] = await Promise.all([
+    window.neurologue.listTagsWithCounts(),
+    window.neurologue.similarTags(),
+  ]);
+
+  // Similar pairs
+  if (similar.length > 0) {
+    tagSimilarSec.classList.remove('hidden');
+    tagSimilarList.innerHTML = '';
+    similar.forEach((pair) => renderSimilarPair(pair));
+  } else {
+    tagSimilarSec.classList.add('hidden');
+  }
+
+  // All tags
+  tagAllList.innerHTML = '';
+  if (tags.length === 0) {
+    tagMgmtEmpty.classList.remove('hidden');
+  } else {
+    tagMgmtEmpty.classList.add('hidden');
+    tags.forEach((tag) => tagAllList.appendChild(buildTagRow(tag)));
+  }
+}
+
+function renderSimilarPair(pair) {
+  // Sort so highest count is first
+  const [first, second] = pair.a.count >= pair.b.count ? [pair.a, pair.b] : [pair.b, pair.a];
+
+  const row = document.createElement('div');
+  row.className = 'tag-similar-pair';
+  row.dataset.pairA = pair.a.id;
+  row.dataset.pairB = pair.b.id;
+
+  const noteWord = (n) => n === 1 ? '1 note' : `${n} notes`;
+
+  row.innerHTML = `
+    <div class="tag-similar-tag">
+      <span class="tag-similar-name">#${first.name}</span>
+      <span class="tag-similar-count">${noteWord(first.count)}</span>
+    </div>
+    <span class="tag-similar-sep">↔</span>
+    <div class="tag-similar-tag">
+      <span class="tag-similar-name">#${second.name}</span>
+      <span class="tag-similar-count">${noteWord(second.count)}</span>
+    </div>
+    <div class="tag-similar-actions">
+      <button class="btn-keep-tag" data-keep="${first.id}" data-remove="${second.id}" title="Keep #${first.name}, merge #${second.name} into it">Keep #${first.name}</button>
+      <button class="btn-keep-tag" data-keep="${second.id}" data-remove="${first.id}" title="Keep #${second.name}, merge #${first.name} into it">Keep #${second.name}</button>
+      <button class="btn-skip-pair">Skip</button>
+    </div>
+  `;
+
+  row.querySelectorAll('.btn-keep-tag').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const keepId   = btn.dataset.keep;
+      const removeId = btn.dataset.remove;
+      const res = await window.neurologue.mergeTag(removeId, keepId);
+      if (res.ok) {
+        row.remove();
+        if (tagSimilarList.children.length === 0) tagSimilarSec.classList.add('hidden');
+        // Refresh full list to reflect updated counts
+        const tags = await window.neurologue.listTagsWithCounts();
+        tagAllList.innerHTML = '';
+        tags.forEach((t) => tagAllList.appendChild(buildTagRow(t)));
+        await loadTags(); // refresh sidebar
+      }
+    });
+  });
+
+  row.querySelector('.btn-skip-pair').addEventListener('click', () => {
+    row.remove();
+    if (tagSimilarList.children.length === 0) tagSimilarSec.classList.add('hidden');
+  });
+
+  tagSimilarList.appendChild(row);
+}
+
+function buildTagRow(tag) {
+  const row = document.createElement('div');
+  row.className = 'tag-row';
+  row.dataset.tagId = tag.id;
+
+  const noteWord = (n) => n === 1 ? '1 note' : `${n} notes`;
+
+  row.innerHTML = `
+    <span class="tag-row-name">#${tag.name}</span>
+    <span class="tag-row-count">${noteWord(tag.count)}</span>
+    <div class="tag-row-actions">
+      <button class="btn-rename-tag">Rename</button>
+      <button class="btn-delete-tag">Delete</button>
+    </div>
+  `;
+
+  row.querySelector('.btn-rename-tag').addEventListener('click', () => startRename(row, tag));
+  row.querySelector('.btn-delete-tag').addEventListener('click', () => startDelete(row, tag));
+
+  return row;
+}
+
+function startRename(row, tag) {
+  const nameEl    = row.querySelector('.tag-row-name');
+  const countEl   = row.querySelector('.tag-row-count');
+  const actionsEl = row.querySelector('.tag-row-actions');
+
+  nameEl.classList.add('hidden');
+  actionsEl.classList.add('hidden');
+
+  const renameEl = document.createElement('div');
+  renameEl.className = 'tag-row-rename';
+  renameEl.innerHTML = `
+    <input type="text" value="${tag.name}" autocomplete="off" spellcheck="false" />
+    <button class="btn-rename-save">Save</button>
+    <button class="btn-rename-cancel">Cancel</button>
+  `;
+  row.insertBefore(renameEl, countEl);
+
+  const input = renameEl.querySelector('input');
+  input.focus();
+  input.select();
+
+  const cancel = () => {
+    renameEl.remove();
+    nameEl.classList.remove('hidden');
+    actionsEl.classList.remove('hidden');
+  };
+
+  const save = async () => {
+    const newName = input.value.trim();
+    if (!newName || newName === tag.name) { cancel(); return; }
+    const res = await window.neurologue.renameTag(tag.id, newName);
+    if (res.ok) {
+      tag.name = newName.toLowerCase();
+      nameEl.textContent = `#${tag.name}`;
+      cancel();
+      await loadTags(); // refresh sidebar
+    } else {
+      input.style.borderColor = 'var(--danger)';
+      input.title = res.error || 'Could not rename';
+    }
+  };
+
+  renameEl.querySelector('.btn-rename-save').addEventListener('click', save);
+  renameEl.querySelector('.btn-rename-cancel').addEventListener('click', cancel);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') save();
+    if (e.key === 'Escape') cancel();
+  });
+}
+
+function startDelete(row, tag) {
+  const actionsEl = row.querySelector('.tag-row-actions');
+  row.classList.add('tag-row--confirm-delete');
+  actionsEl.innerHTML = `
+    <button class="btn-confirm-delete">Delete</button>
+    <button class="btn-cancel-delete">Cancel</button>
+  `;
+  actionsEl.querySelector('.btn-confirm-delete').addEventListener('click', async () => {
+    const res = await window.neurologue.deleteTag(tag.id);
+    if (res.ok) {
+      row.remove();
+      if (tagAllList.children.length === 0) tagMgmtEmpty.classList.remove('hidden');
+      await loadTags(); // refresh sidebar
+    }
+  });
+  actionsEl.querySelector('.btn-cancel-delete').addEventListener('click', () => {
+    row.classList.remove('tag-row--confirm-delete');
+    row.querySelector('.tag-row-actions').innerHTML = `
+      <button class="btn-rename-tag">Rename</button>
+      <button class="btn-delete-tag">Delete</button>
+    `;
+    row.querySelector('.btn-rename-tag').addEventListener('click', () => startRename(row, tag));
+    row.querySelector('.btn-delete-tag').addEventListener('click', () => startDelete(row, tag));
+  });
+}
+
 // ── Startup setup check ────────────────────────────────────────────
 
 // True if a model name from settings matches one of the available model strings

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1086,6 +1086,10 @@ btnSettings.addEventListener('click', async () => {
   const tagFmtSelect = document.getElementById('select-tag-format');
   if (tagFmtSelect) tagFmtSelect.value = settings.tagSuggestionFormat || 'hyphenated';
 
+  // Duplicate detection threshold
+  const simSelect = document.getElementById('select-similarity-threshold');
+  if (simSelect) simSelect.value = String(settings.tagSimilarityThreshold ?? 0.88);
+
   // Populate hotkey display
   const currentHotkey = settings.captureHotkey || 'CommandOrControl+Shift+Space';
   hotkeyDisplay.dataset.saved = currentHotkey;
@@ -1105,6 +1109,8 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
   const embedModel = document.getElementById('select-embed-model').value;
   const llmModel   = document.getElementById('select-llm-model').value;
   const tagFmt     = (document.getElementById('select-tag-format') || {}).value || 'hyphenated';
+  const tagSimRaw  = (document.getElementById('select-similarity-threshold') || {}).value;
+  const tagSimilarityThreshold = tagSimRaw ? parseFloat(tagSimRaw) : 0.88;
 
   // Apply hotkey change first if the user recorded a new one
   if (_pendingHotkey) {
@@ -1118,7 +1124,7 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
     _pendingHotkey = null;
   }
 
-  await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel, tagSuggestionFormat: tagFmt });
+  await window.neurologue.saveSettings({ embeddingModel: embedModel, llmModel, tagSuggestionFormat: tagFmt, tagSimilarityThreshold });
   const msg = document.getElementById('settings-saved-msg');
   msg.classList.remove('hidden');
   setTimeout(() => msg.classList.add('hidden'), 2000);
@@ -1184,6 +1190,14 @@ function renderSimilarPair(pair) {
 
   const noteWord = (n) => n === 1 ? '1 note' : `${n} notes`;
 
+  const reasonLabels = {
+    'format-variant':   'Format variant',
+    'similar-spelling': 'Spelling',
+    'similar-meaning':  pair.similarity ? `Similar meaning \u00b7 ${pair.similarity}%` : 'Similar meaning',
+  };
+  const reasonLabel = reasonLabels[pair.reason] || pair.reason || '';
+  const reasonClass = pair.reason === 'similar-meaning' ? 'tag-similar-reason--semantic' : 'tag-similar-reason--structural';
+
   row.innerHTML = `
     <div class="tag-similar-tag">
       <span class="tag-similar-name">#${first.name}</span>
@@ -1194,6 +1208,7 @@ function renderSimilarPair(pair) {
       <span class="tag-similar-name">#${second.name}</span>
       <span class="tag-similar-count">${noteWord(second.count)}</span>
     </div>
+    <span class="tag-similar-reason ${reasonClass}">${reasonLabel}</span>
     <div class="tag-similar-actions">
       <button class="btn-keep-tag" data-keep="${first.id}" data-remove="${second.id}" title="Keep #${first.name}, merge #${second.name} into it">Keep #${first.name}</button>
       <button class="btn-keep-tag" data-keep="${second.id}" data-remove="${first.id}" title="Keep #${second.name}, merge #${first.name} into it">Keep #${second.name}</button>

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1192,6 +1192,7 @@ function renderSimilarPair(pair) {
 
   const reasonLabels = {
     'format-variant':   'Format variant',
+    'prefix-variant':   'Abbreviation',
     'similar-spelling': 'Spelling',
     'similar-meaning':  pair.similarity ? `Similar meaning \u00b7 ${pair.similarity}%` : 'Similar meaning',
   };

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1220,15 +1220,19 @@ function renderSimilarPair(pair) {
     btn.addEventListener('click', async () => {
       const keepId   = btn.dataset.keep;
       const removeId = btn.dataset.remove;
+      // Disable all actions while the merge + rescan runs
+      row.querySelectorAll('button').forEach((b) => { b.disabled = true; });
+      row.querySelector('.tag-similar-reason').textContent = 'Merging…';
       const res = await window.neurologue.mergeTag(removeId, keepId);
       if (res.ok) {
-        row.remove();
-        if (tagSimilarList.children.length === 0) tagSimilarSec.classList.add('hidden');
-        // Refresh full list to reflect updated counts
-        const tags = await window.neurologue.listTagsWithCounts();
-        tagAllList.innerHTML = '';
-        tags.forEach((t) => tagAllList.appendChild(buildTagRow(t)));
-        await loadTags(); // refresh sidebar
+        // Full rescan: removes stale pairs that referenced the deleted tag,
+        // rebuilds both sections, updates the all-tags list and sidebar
+        await refreshTagManagement();
+        await loadTags();
+      } else {
+        // Re-enable on failure
+        row.querySelectorAll('button').forEach((b) => { b.disabled = false; });
+        row.querySelector('.tag-similar-reason').textContent = 'Error — try again';
       }
     });
   });
@@ -1323,9 +1327,9 @@ function startDelete(row, tag) {
   actionsEl.querySelector('.btn-confirm-delete').addEventListener('click', async () => {
     const res = await window.neurologue.deleteTag(tag.id);
     if (res.ok) {
-      row.remove();
-      if (tagAllList.children.length === 0) tagMgmtEmpty.classList.remove('hidden');
-      await loadTags(); // refresh sidebar
+      // Full rescan so any similar-pair rows referencing this tag are removed
+      await refreshTagManagement();
+      await loadTags();
     }
   });
   actionsEl.querySelector('.btn-cancel-delete').addEventListener('click', () => {

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -16,6 +16,13 @@ contextBridge.exposeInMainWorld('neurologue', {
   suggestTags: (text) => ipcRenderer.invoke('library:suggest-tags', { text }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
 
+  // ── Tag management ───────────────────────────────────────────────────────
+  listTagsWithCounts: () => ipcRenderer.invoke('tags:list-with-counts'),
+  renameTag: (id, newName) => ipcRenderer.invoke('tags:rename', { id, newName }),
+  deleteTag: (id) => ipcRenderer.invoke('tags:delete', { id }),
+  mergeTag: (removeId, keepId) => ipcRenderer.invoke('tags:merge', { removeId, keepId }),
+  similarTags: () => ipcRenderer.invoke('tags:similar'),
+
   // ── Themes ───────────────────────────────────────────────────────────────
   listThemes: () => ipcRenderer.invoke('themes:list'),
   getTheme: (id) => ipcRenderer.invoke('themes:get', { id }),

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
 const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory } = require('./backend/db/entries');
-const { setTagsForEntry, listTags } = require('./backend/db/tags');
+const { setTagsForEntry, listTags, listTagsWithCounts, renameTag, deleteTag, mergeTag, findSimilarTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
@@ -132,6 +132,28 @@ ipcMain.handle('library:suggest-tags', async (_event, { text }) => {
     return { ok: false, suggestions: [], error: err.message };
   }
 });
+
+// ── Tag management IPC ──────────────────────────────────────────────────────
+
+ipcMain.handle('tags:list-with-counts', async () => listTagsWithCounts());
+
+ipcMain.handle('tags:rename', async (_event, { id, newName }) => {
+  if (!id || !newName) return { ok: false, error: 'Invalid input' };
+  return renameTag(id, newName);
+});
+
+ipcMain.handle('tags:delete', async (_event, { id }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  return deleteTag(id);
+});
+
+ipcMain.handle('tags:merge', async (_event, { removeId, keepId }) => {
+  if (!removeId || !keepId) return { ok: false, error: 'Invalid input' };
+  if (removeId === keepId) return { ok: false, error: 'Cannot merge a tag with itself' };
+  return mergeTag(removeId, keepId);
+});
+
+ipcMain.handle('tags:similar', async () => findSimilarTags());
 
 // ── Themes IPC ───────────────────────────────────────────────────────────────
 

--- a/src/main.js
+++ b/src/main.js
@@ -153,7 +153,61 @@ ipcMain.handle('tags:merge', async (_event, { removeId, keepId }) => {
   return mergeTag(removeId, keepId);
 });
 
-ipcMain.handle('tags:similar', async () => findSimilarTags());
+ipcMain.handle('tags:similar', async () => {
+  const settings  = getSettings();
+  const threshold = typeof settings.tagSimilarityThreshold === 'number'
+    ? settings.tagSimilarityThreshold
+    : 0.88;
+
+  // Always run the fast structural pass (format variants + spelling)
+  const structural = await findSimilarTags();
+  const structuralKeys = new Set(structural.map((p) => [p.a.id, p.b.id].sort().join('|')));
+
+  // Semantic pass — only when Ollama is available
+  const ollamaUp = await isOllamaAvailable();
+  if (!ollamaUp) return structural;
+
+  const tags = await listTagsWithCounts();
+  if (tags.length < 2) return structural;
+
+  // Embed all tag names concurrently (best-effort — skip failures)
+  const embeddings = Object.create(null);
+  await Promise.all(tags.map(async (tag) => {
+    try {
+      embeddings[tag.id] = await generateEmbedding(tag.name);
+    } catch { /* skip tag if embedding fails */ }
+  }));
+
+  function cosineSim(a, b) {
+    let dot = 0, magA = 0, magB = 0;
+    for (let i = 0; i < a.length; i++) {
+      dot  += a[i] * b[i];
+      magA += a[i] * a[i];
+      magB += b[i] * b[i];
+    }
+    const denom = Math.sqrt(magA) * Math.sqrt(magB);
+    return denom === 0 ? 0 : dot / denom;
+  }
+
+  const semanticPairs = [];
+  for (let i = 0; i < tags.length; i++) {
+    for (let j = i + 1; j < tags.length; j++) {
+      const a = tags[i], b = tags[j];
+      const key = [a.id, b.id].sort().join('|');
+      if (structuralKeys.has(key)) continue; // already flagged structurally
+      const ea = embeddings[a.id], eb = embeddings[b.id];
+      if (!ea || !eb) continue;
+      const sim = cosineSim(ea, eb);
+      if (sim >= threshold) {
+        semanticPairs.push({ a, b, reason: 'similar-meaning', similarity: Math.round(sim * 100) });
+      }
+    }
+  }
+
+  // Semantic pairs sorted by similarity desc, then appended after structural
+  semanticPairs.sort((x, y) => y.similarity - x.similarity);
+  return [...structural, ...semanticPairs];
+});
 
 // ── Themes IPC ───────────────────────────────────────────────────────────────
 

--- a/tests/unit/db/tags.test.js
+++ b/tests/unit/db/tags.test.js
@@ -107,3 +107,178 @@ describe('setTagsForEntry / getTagsForEntry', () => {
     expect(tags).toEqual([]);
   });
 });
+
+describe('listTagsWithCounts', () => {
+  async function makeEntry(content = 'test') {
+    const { createEntry } = require('../../../src/backend/db/entries');
+    return createEntry({ content });
+  }
+
+  test('returns count of entries per tag', async () => {
+    const { setTagsForEntry, listTagsWithCounts } = require('../../../src/backend/db/tags');
+    const e1 = await makeEntry('one');
+    const e2 = await makeEntry('two');
+    await setTagsForEntry(e1.id, ['alpha', 'beta']);
+    await setTagsForEntry(e2.id, ['alpha']);
+    const tags = await listTagsWithCounts();
+    const alpha = tags.find((t) => t.name === 'alpha');
+    const beta  = tags.find((t) => t.name === 'beta');
+    expect(alpha.count).toBe(2);
+    expect(beta.count).toBe(1);
+  });
+
+  test('sorts by count desc then name asc', async () => {
+    const { setTagsForEntry, listTagsWithCounts } = require('../../../src/backend/db/tags');
+    const e1 = await makeEntry('a');
+    const e2 = await makeEntry('b');
+    const e3 = await makeEntry('c');
+    await setTagsForEntry(e1.id, ['rare', 'common']);
+    await setTagsForEntry(e2.id, ['common']);
+    await setTagsForEntry(e3.id, ['common']);
+    const tags = await listTagsWithCounts();
+    expect(tags[0].name).toBe('common');
+    expect(tags[1].name).toBe('rare');
+  });
+
+  test('includes tags with zero usage', async () => {
+    const { upsertTag, listTagsWithCounts } = require('../../../src/backend/db/tags');
+    await upsertTag('orphan');
+    const tags = await listTagsWithCounts();
+    const orphan = tags.find((t) => t.name === 'orphan');
+    expect(orphan).toBeDefined();
+    expect(orphan.count).toBe(0);
+  });
+});
+
+describe('renameTag', () => {
+  test('renames a tag successfully', async () => {
+    const { upsertTag, renameTag, listTags } = require('../../../src/backend/db/tags');
+    const tag = await upsertTag('oldname');
+    const res = await renameTag(tag.id, 'newname');
+    expect(res.ok).toBe(true);
+    const all = await listTags();
+    expect(all.map((t) => t.name)).toContain('newname');
+    expect(all.map((t) => t.name)).not.toContain('oldname');
+  });
+
+  test('normalises the new name to lowercase', async () => {
+    const { upsertTag, renameTag, listTags } = require('../../../src/backend/db/tags');
+    const tag = await upsertTag('original');
+    await renameTag(tag.id, 'UPPER');
+    const all = await listTags();
+    expect(all.map((t) => t.name)).toContain('upper');
+  });
+
+  test('returns error on collision with existing tag', async () => {
+    const { upsertTag, renameTag } = require('../../../src/backend/db/tags');
+    const a = await upsertTag('apple');
+    await upsertTag('banana');
+    const res = await renameTag(a.id, 'banana');
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/already exists/i);
+  });
+
+  test('returns error for empty name', async () => {
+    const { upsertTag, renameTag } = require('../../../src/backend/db/tags');
+    const tag = await upsertTag('foo');
+    const res = await renameTag(tag.id, '  ');
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('deleteTag', () => {
+  async function makeEntry(content = 'test') {
+    const { createEntry } = require('../../../src/backend/db/entries');
+    return createEntry({ content });
+  }
+
+  test('removes the tag and its associations', async () => {
+    const { upsertTag, deleteTag, listTags, setTagsForEntry, getTagsForEntry } = require('../../../src/backend/db/tags');
+    const entry = await makeEntry('del-test');
+    await setTagsForEntry(entry.id, ['todelete']);
+    const tag = (await listTags()).find((t) => t.name === 'todelete');
+    await deleteTag(tag.id);
+    const remaining = await listTags();
+    expect(remaining.map((t) => t.name)).not.toContain('todelete');
+    const entryTags = await getTagsForEntry(entry.id);
+    expect(entryTags).toHaveLength(0);
+  });
+});
+
+describe('mergeTag', () => {
+  async function makeEntry(content = 'test') {
+    const { createEntry } = require('../../../src/backend/db/entries');
+    return createEntry({ content });
+  }
+
+  test('re-tags all entries and removes the source tag', async () => {
+    const { setTagsForEntry, getTagsForEntry, listTags, mergeTag } = require('../../../src/backend/db/tags');
+    const e1 = await makeEntry('entry-one');
+    const e2 = await makeEntry('entry-two');
+    await setTagsForEntry(e1.id, ['src']);
+    await setTagsForEntry(e2.id, ['dst']);
+    const all = await listTags();
+    const srcTag = all.find((t) => t.name === 'src');
+    const dstTag = all.find((t) => t.name === 'dst');
+
+    const res = await mergeTag(srcTag.id, dstTag.id);
+    expect(res.ok).toBe(true);
+    expect(res.affected).toBe(1);
+
+    // e1 should now have dst, src tag deleted
+    const e1Tags = await getTagsForEntry(e1.id);
+    expect(e1Tags.map((t) => t.name)).toContain('dst');
+    const remaining = await listTags();
+    expect(remaining.map((t) => t.name)).not.toContain('src');
+  });
+
+  test('does not duplicate tag if keep already present', async () => {
+    const { setTagsForEntry, getTagsForEntry, listTags, mergeTag } = require('../../../src/backend/db/tags');
+    const entry = await makeEntry('overlap');
+    await setTagsForEntry(entry.id, ['src', 'dst']);
+    const all = await listTags();
+    const srcTag = all.find((t) => t.name === 'src');
+    const dstTag = all.find((t) => t.name === 'dst');
+    await mergeTag(srcTag.id, dstTag.id);
+    const tags = await getTagsForEntry(entry.id);
+    expect(tags.filter((t) => t.name === 'dst')).toHaveLength(1);
+  });
+});
+
+describe('findSimilarTags', () => {
+  test('finds format variants (hyphen vs concatenated)', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('deep-learning');
+    await upsertTag('deeplearning');
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('deep-learning') &&
+      [p.a.name, p.b.name].includes('deeplearning')
+    );
+    expect(found).toBe(true);
+  });
+
+  test('finds spelling variants within edit distance', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('neural');
+    await upsertTag('neual'); // 1 edit
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('neural') &&
+      [p.a.name, p.b.name].includes('neual')
+    );
+    expect(found).toBe(true);
+  });
+
+  test('does not flag unrelated short tags as similar', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('cat');
+    await upsertTag('dog');
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('cat') &&
+      [p.a.name, p.b.name].includes('dog')
+    );
+    expect(found).toBe(false);
+  });
+});

--- a/tests/unit/db/tags.test.js
+++ b/tests/unit/db/tags.test.js
@@ -281,4 +281,42 @@ describe('findSimilarTags', () => {
     );
     expect(found).toBe(false);
   });
+
+  test('finds short-tag spelling variants (minLen 3)', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('dev');
+    await upsertTag('devs');
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('dev') &&
+      [p.a.name, p.b.name].includes('devs')
+    );
+    expect(found).toBe(true);
+  });
+
+  test('finds prefix variants (dev ↔ development)', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('dev');
+    await upsertTag('development');
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('dev') &&
+      [p.a.name, p.b.name].includes('development') &&
+      p.reason === 'prefix-variant'
+    );
+    expect(found).toBe(true);
+  });
+
+  test('finds plural-stem prefix variants (devs ↔ development)', async () => {
+    const { upsertTag, findSimilarTags } = require('../../../src/backend/db/tags');
+    await upsertTag('devs');
+    await upsertTag('development');
+    const pairs = await findSimilarTags();
+    const found = pairs.some((p) =>
+      [p.a.name, p.b.name].includes('devs') &&
+      [p.a.name, p.b.name].includes('development') &&
+      p.reason === 'prefix-variant'
+    );
+    expect(found).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the Tag Management panel, closing issues #43 and #86.

## Features

### Tag Management Panel
- New **Maintenance** toolbar button opens the Tag Management modal
- **Rename** any tag inline — Enter to save, Escape to cancel
- **Delete** any tag (with confirmation step before committing)
- **Merge** near-duplicate tags — pick which name to keep, all entries are retagged

### Duplicate Detection
Runs a two-pass similarity scan each time the panel opens or after a merge/delete:

**Structural pass** (no Ollama required):
| Rule | Examples |
|---|---|
| Format variant | \machine-learning\ ↔ \machine_learning\ |
| Abbreviation / prefix | \dev\ ↔ \development\, \devs\ ↔ \development\ |
| Spelling variant | \colour\ ↔ \color\, \dev\ ↔ \devs\ |

**Semantic pass** (requires Ollama):
- Embeds each tag name and computes cosine similarity
- Configurable threshold in Settings: Strict / Balanced / Broad

### Settings
- New *Duplicate detection sensitivity* dropdown (Strict 0.93 / Balanced 0.88 / Broad 0.82)

## Bug fixes
- Empty-state message always visible — added scoped \.hidden\ CSS rules
- Stale pair rows after merge/delete — replaced manual row removal with full \efreshTagManagement()\ rescan
- Levenshtein guard \minLen >= 4\ skipped 3-char tags — lowered to \>= 3\
- No prefix rule meant short abbreviations only surfaced at max embedding sensitivity — added prefix/plural-stem check

## Tests
- 175 tests passing across 14 suites
- New suites: \listTagsWithCounts\, \enameTag\, \deleteTag\, \mergeTag\, \indSimilarTags\
- \indSimilarTags\ covers: format variants, spelling variants, short-tag spelling (minLen 3), prefix variants, plural-stem prefix variants, unrelated short tags not flagged