### PR TITLE
feat: timeline improvements — infinite scroll, grouping, activity heatmap [#44]

### DIFF
--- a/src/backend/db/entries.js
+++ b/src/backend/db/entries.js
@@ -129,6 +129,24 @@ async function listEntriesWithoutCategory(limit = 50) {
     .map((r) => r.id);
 }
 
+/**
+ * Return entry counts grouped by day for the last N days.
+ * @param {number} [days=364]
+ * @returns {Promise<Array<{day: string, count: number}>>}
+ */
+async function getActivityByDay(days = 364) {
+  const db = await openDb();
+  return db
+    .prepare(`
+      SELECT DATE(created_at) AS day, COUNT(*) AS count
+      FROM entries
+      WHERE created_at >= DATE('now', ?)
+      GROUP BY DATE(created_at)
+      ORDER BY day ASC
+    `)
+    .all(`-${days} days`);
+}
+
 module.exports = {
   createEntry,
   getEntryById,
@@ -138,4 +156,5 @@ module.exports = {
   getEntryRevisions,
   updateEntryCategory,
   listEntriesWithoutCategory,
+  getActivityByDay,
 };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -50,6 +50,20 @@
 
       <!-- Timeline: entry list -->
       <div id="timeline">
+        <div id="timeline-controls">
+          <div id="timeline-groupby">
+            <span class="tl-ctrl-label">Group</span>
+            <button id="grp-none"  class="tl-grp-btn active">None</button>
+            <button id="grp-day"   class="tl-grp-btn">Day</button>
+            <button id="grp-week"  class="tl-grp-btn">Week</button>
+            <button id="grp-month" class="tl-grp-btn">Month</button>
+          </div>
+          <button id="btn-heatmap-toggle" class="tl-grp-btn" title="Toggle activity heatmap">Heatmap</button>
+        </div>
+        <div id="heatmap-panel" class="hidden">
+          <div id="heatmap-months"></div>
+          <div id="heatmap-grid"></div>
+        </div>
         <div id="timeline-list"></div>
         <button id="load-more-btn">Load more</button>
       </div>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -264,6 +264,93 @@ html, body {
 }
 #load-more-btn:hover { border-color: var(--cortex-teal); color: var(--text); }
 
+/* ── Timeline controls bar ────────────────────────────────────────────── */
+#timeline-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+#timeline-groupby {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tl-ctrl-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-right: 2px;
+}
+
+.tl-grp-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.tl-grp-btn:hover  { border-color: var(--cortex-teal); color: var(--text-muted); }
+.tl-grp-btn.active { border-color: var(--cortex-teal); color: var(--cortex-teal); }
+
+/* ── Heatmap ──────────────────────────────────────────────────────────── */
+#heatmap-panel {
+  padding: 8px 12px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+#heatmap-panel.hidden { display: none; }
+
+#heatmap-months {
+  height: 14px;
+  margin-bottom: 4px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+#heatmap-grid {
+  display: flex;
+  gap: 2px;
+}
+
+.heatmap-week {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.heatmap-cell {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--surface2);
+  flex-shrink: 0;
+}
+.heatmap-cell[data-level="1"] { background: #1a4f4e; }
+.heatmap-cell[data-level="2"] { background: #1d756f; }
+.heatmap-cell[data-level="3"] { background: #22918a; }
+.heatmap-cell[data-level="4"] { background: var(--cortex-teal); }
+
+/* ── Group headers (day / week / month separators) ────────────────────── */
+.tl-group-header {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  padding: 12px 4px 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.tl-group-header:first-child { padding-top: 4px; }
+
 /* ── Detail panel ─────────────────────────────────────────────────────── */
 #detail {
   width: var(--detail-w);

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -12,7 +12,10 @@ let _state = {
   tagFilter: null,   // tag name string or null
   selectedId: null,
   activeThemeId: null,
+  groupBy: null,       // null | 'day' | 'week' | 'month'
+  lastGroupKey: null,  // last rendered group separator key (for append)
 };
+let _loadingMore = false;
 
 // ── DOM refs ───────────────────────────────────────────────────────────────
 const searchInput   = document.getElementById('search-input');
@@ -54,6 +57,16 @@ const semanticNotice = document.getElementById('semantic-notice');
 const statusOllama  = document.getElementById('status-ollama');
 const statusWorker  = document.getElementById('status-worker');
 
+// ── Timeline controls DOM refs ─────────────────────────────────────────────
+const grpNoneBtn      = document.getElementById('grp-none');
+const grpDayBtn       = document.getElementById('grp-day');
+const grpWeekBtn      = document.getElementById('grp-week');
+const grpMonthBtn     = document.getElementById('grp-month');
+const heatmapToggle   = document.getElementById('btn-heatmap-toggle');
+const heatmapPanel    = document.getElementById('heatmap-panel');
+const heatmapGrid     = document.getElementById('heatmap-grid');
+const heatmapMonths   = document.getElementById('heatmap-months');
+
 // ── Utilities ──────────────────────────────────────────────────────────────
 
 function formatDate(dateStr) {
@@ -71,6 +84,46 @@ function debounce(fn, ms) {
 }
 
 // ── Render helpers ─────────────────────────────────────────────────────────
+
+// Return a string key for grouping an entry by the current groupBy mode.
+function _groupKey(entry, groupBy) {
+  const d = new Date(entry.created_at);
+  if (groupBy === 'day')   return d.toISOString().slice(0, 10);
+  if (groupBy === 'month') return d.toISOString().slice(0, 7);
+  if (groupBy === 'week') {
+    // ISO week: use Thursday of the week to determine year, per ISO 8601
+    const thu = new Date(d);
+    thu.setDate(d.getDate() - ((d.getDay() + 6) % 7) + 3);
+    const jan4 = new Date(thu.getFullYear(), 0, 4);
+    const week = Math.ceil(((thu - jan4) / 86400000 + 1) / 7);
+    return `${thu.getFullYear()}-W${String(week).padStart(2, '0')}`;
+  }
+  return null;
+}
+
+// Return a human-readable label for a group key.
+function _groupLabel(key, groupBy) {
+  if (groupBy === 'day') {
+    return new Date(key + 'T12:00:00').toLocaleDateString(undefined, {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+  }
+  if (groupBy === 'month') {
+    const [year, month] = key.split('-');
+    return new Date(Number(year), Number(month) - 1, 1).toLocaleDateString(undefined, {
+      month: 'long', year: 'numeric',
+    });
+  }
+  if (groupBy === 'week') {
+    const [year, weekStr] = key.split('-W');
+    // Compute the Monday of the ISO week
+    const jan4  = new Date(Number(year), 0, 4);
+    const mon   = new Date(jan4);
+    mon.setDate(jan4.getDate() - ((jan4.getDay() + 6) % 7) + (Number(weekStr) - 1) * 7);
+    return `Week of ${mon.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })}`;
+  }
+  return key;
+}
 
 function renderEntryCard(entry) {
   const card = document.createElement('div');
@@ -129,7 +182,10 @@ function renderEntryCard(entry) {
 }
 
 function renderTimeline(entries, append = false) {
-  if (!append) timelineList.innerHTML = '';
+  if (!append) {
+    timelineList.innerHTML = '';
+    _state.lastGroupKey = null;
+  }
 
   if (entries.length === 0 && !append) {
     const empty = document.createElement('div');
@@ -139,12 +195,89 @@ function renderTimeline(entries, append = false) {
       : `<strong>No entries yet</strong>Press Ctrl+Shift+Space to capture your first thought`;
     timelineList.appendChild(empty);
   } else {
-    entries.forEach((e) => timelineList.appendChild(renderEntryCard(e)));
+    entries.forEach((e) => {
+      if (_state.groupBy) {
+        const key = _groupKey(e, _state.groupBy);
+        if (key !== _state.lastGroupKey) {
+          const header = document.createElement('div');
+          header.className = 'tl-group-header';
+          header.textContent = _groupLabel(key, _state.groupBy);
+          timelineList.appendChild(header);
+          _state.lastGroupKey = key;
+        }
+      }
+      timelineList.appendChild(renderEntryCard(e));
+    });
   }
 }
 
 function updateCount(total) {
   entryCount.textContent = total === 1 ? '1 entry' : `${total} entries`;
+}
+
+// ── Heatmap ────────────────────────────────────────────────────────────────
+
+async function renderHeatmap() {
+  heatmapGrid.innerHTML = '';
+  heatmapMonths.innerHTML = '';
+
+  const data = await window.neurologue.getActivity();
+  const countMap = {};
+  data.forEach(({ day, count }) => { countMap[day] = count; });
+
+  // Build 52 full weeks (364 cells) ending today, aligned to Sunday
+  const today = new Date();
+  today.setHours(12, 0, 0, 0);
+
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - 363);            // 364 days back
+  startDate.setDate(startDate.getDate() - startDate.getDay()); // rewind to Sunday
+
+  const WEEK_PX = 12; // 10px cell + 2px gap
+  let lastMonth = -1;
+  const monthLabels = [];
+
+  for (let w = 0; w < 52; w++) {
+    const weekEl = document.createElement('div');
+    weekEl.className = 'heatmap-week';
+
+    for (let d = 0; d < 7; d++) {
+      const cellDate = new Date(startDate);
+      cellDate.setDate(startDate.getDate() + w * 7 + d);
+
+      const cell = document.createElement('div');
+      cell.className = 'heatmap-cell';
+
+      if (cellDate <= today) {
+        const key = cellDate.toISOString().slice(0, 10);
+        const count = countMap[key] || 0;
+        const level = count === 0 ? 0 : count === 1 ? 1 : count <= 3 ? 2 : count <= 6 ? 3 : 4;
+        if (level > 0) cell.dataset.level = String(level);
+        cell.title = `${key}: ${count} entr${count === 1 ? 'y' : 'ies'}`;
+
+        if (d === 0 && cellDate.getMonth() !== lastMonth) {
+          monthLabels.push({
+            col: w,
+            label: cellDate.toLocaleDateString(undefined, { month: 'short' }),
+          });
+          lastMonth = cellDate.getMonth();
+        }
+      }
+
+      weekEl.appendChild(cell);
+    }
+    heatmapGrid.appendChild(weekEl);
+  }
+
+  // Render month labels using absolute positioning
+  heatmapMonths.style.position = 'relative';
+  monthLabels.forEach(({ col, label }) => {
+    const span = document.createElement('span');
+    span.textContent = label;
+    span.style.position = 'absolute';
+    span.style.left = `${col * WEEK_PX}px`;
+    heatmapMonths.appendChild(span);
+  });
 }
 
 // ── Data loading ───────────────────────────────────────────────────────────
@@ -496,6 +629,45 @@ btnText.addEventListener('click', () => setMode('text'));
 btnSemantic.addEventListener('click', () => setMode('semantic'));
 tagAll.addEventListener('click', () => applyTagFilter(null));
 loadMoreBtn.addEventListener('click', () => loadEntries(true));
+
+// Infinite scroll: trigger when within 200px of the bottom of the list
+timelineList.addEventListener('scroll', () => {
+  if (!_state.hasMore || _loadingMore) return;
+  const { scrollTop, scrollHeight, clientHeight } = timelineList;
+  if (scrollHeight - scrollTop - clientHeight < 200) {
+    _loadingMore = true;
+    loadEntries(true).finally(() => { _loadingMore = false; });
+  }
+});
+
+// Group-by buttons
+function setGroupBy(groupBy) {
+  _state.groupBy = groupBy;
+  [grpNoneBtn, grpDayBtn, grpWeekBtn, grpMonthBtn].forEach((btn) => btn.classList.remove('active'));
+  const active = groupBy === 'day' ? grpDayBtn
+    : groupBy === 'week' ? grpWeekBtn
+    : groupBy === 'month' ? grpMonthBtn
+    : grpNoneBtn;
+  active.classList.add('active');
+  loadEntries();
+}
+grpNoneBtn.addEventListener('click',  () => setGroupBy(null));
+grpDayBtn.addEventListener('click',   () => setGroupBy('day'));
+grpWeekBtn.addEventListener('click',  () => setGroupBy('week'));
+grpMonthBtn.addEventListener('click', () => setGroupBy('month'));
+
+// Heatmap toggle
+heatmapToggle.addEventListener('click', async () => {
+  const visible = !heatmapPanel.classList.contains('hidden');
+  if (visible) {
+    heatmapPanel.classList.add('hidden');
+    heatmapToggle.classList.remove('active');
+  } else {
+    heatmapPanel.classList.remove('hidden');
+    heatmapToggle.classList.add('active');
+    await renderHeatmap();
+  }
+});
 
 // ── Category override ──────────────────────────────────────────────────────
 

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -225,13 +225,17 @@ async function renderHeatmap() {
   const countMap = {};
   data.forEach(({ day, count }) => { countMap[day] = count; });
 
-  // Build 52 full weeks (364 cells) ending today, aligned to Sunday
+  // Build 52 columns ending with the week that contains today.
+  // Anchoring to the *last* Sunday keeps today always in the final column,
+  // regardless of what day of the week today falls on.
   const today = new Date();
   today.setHours(12, 0, 0, 0);
 
-  const startDate = new Date(today);
-  startDate.setDate(today.getDate() - 363);            // 364 days back
-  startDate.setDate(startDate.getDate() - startDate.getDay()); // rewind to Sunday
+  const lastSunday = new Date(today);
+  lastSunday.setDate(today.getDate() - today.getDay()); // Sunday of this week
+
+  const startDate = new Date(lastSunday);
+  startDate.setDate(lastSunday.getDate() - 51 * 7);    // 52 weeks back
 
   const WEEK_PX = 12; // 10px cell + 2px gap
   let lastMonth = -1;

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   setTags: (id, tags) => ipcRenderer.invoke('library:set-tags', { id, tags }),
   suggestTags: (text) => ipcRenderer.invoke('library:suggest-tags', { text }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
+  getActivity: () => ipcRenderer.invoke('library:activity'),
 
   // ── Tag management ───────────────────────────────────────────────────────
   listTagsWithCounts: () => ipcRenderer.invoke('tags:list-with-counts'),

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ const { app, BrowserWindow, globalShortcut, ipcMain, shell } = require('electron
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
-const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory } = require('./backend/db/entries');
+const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory, getActivityByDay } = require('./backend/db/entries');
 const { setTagsForEntry, listTags, listTagsWithCounts, renameTag, deleteTag, mergeTag, findSimilarTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
@@ -112,6 +112,9 @@ ipcMain.handle('library:set-category', async (_event, { id, category }) => {
 ipcMain.handle('library:list-tags', async () => {
   return listTags();
 });
+
+// Activity heatmap: entry counts by day for the last 364 days
+ipcMain.handle('library:activity', async () => getActivityByDay(364));
 
 // Update tags for an existing entry
 ipcMain.handle('library:set-tags', async (_event, { id, tags }) => {

--- a/tests/unit/db/entries.test.js
+++ b/tests/unit/db/entries.test.js
@@ -231,3 +231,39 @@ describe('listEntriesWithoutCategory', () => {
     expect(ids).toHaveLength(0);
   });
 });
+
+describe('getActivityByDay', () => {
+  test('returns counts grouped by day', async () => {
+    const { createEntry, getActivityByDay } = require('../../../src/backend/db/entries');
+    await createEntry({ content: 'a' });
+    await createEntry({ content: 'b' });
+    const rows = await getActivityByDay(364);
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const today = new Date().toISOString().slice(0, 10);
+    const todayRow = rows.find((r) => r.day === today);
+    expect(todayRow).toBeDefined();
+    expect(todayRow.count).toBe(2);
+  });
+
+  test('returns empty array when no entries exist', async () => {
+    const { getActivityByDay } = require('../../../src/backend/db/entries');
+    const rows = await getActivityByDay(364);
+    expect(rows).toEqual([]);
+  });
+
+  test('excludes entries older than the requested window', async () => {
+    const { getActivityByDay } = require('../../../src/backend/db/entries');
+    // Insert an entry with a very old timestamp directly via connection
+    const { openDb } = require('../../../src/backend/db/connection');
+    const db = await openDb();
+    const { randomUUID } = require('crypto');
+    db.prepare(
+      `INSERT INTO entries (id, content, source, type, metadata, created_at)
+       VALUES (?, ?, 'manual', 'note', '{}', ?)`
+    ).run(randomUUID(), 'ancient', '1990-01-01T00:00:00.000Z');
+
+    const rows = await getActivityByDay(364);
+    const oldRow = rows.find((r) => r.day === '1990-01-01');
+    expect(oldRow).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #44.

## Features

### Infinite scroll
- A scroll listener on the timeline fires loadEntries(true) when the user is within 200px of the bottom — no more clicking *Load more* each time.
- A _loadingMore guard prevents concurrent fetches.
- The *Load more* button is kept as a visible fallback.

### Group by day / week / month
A control bar appears above the entry list with four toggle buttons: **None · Day · Week · Month**.

When a grouping is active, sticky-style date headers are inserted between entries whenever the group boundary changes:
| Mode | Example header |
|---|---|
| Day | Tuesday, 6 May 2025 |
| Week | Week of 5 May 2025 |
| Month | May 2025 |

Headers are skipped on append (infinite scroll) if the boundary hasn't changed, so the same label is never duplicated.

### Activity heatmap
A **Heatmap** toggle button in the control bar shows/hides a collapsible contribution-graph panel:
- 52 weeks × 7 days = 364 days ending today, aligned to Sunday columns
- Four teal intensity levels: 1 entry · 2–3 · 4–6 · 7+
- Month labels absolutely positioned above the grid
- Tooltip per cell: 2026-05-07: 3 entries

**Backend:** getActivityByDay(days) queries DATE(created_at) grouped counts from SQLite, exposed as library:activity IPC.

## Tests
- 3 new getActivityByDay cases (counts by day, empty DB, window exclusion)
- 178 tests passing, 14 suites