### PR TITLE
feat: filter library by tag or category [#83]

### DIFF
--- a/src/backend/db/search.js
+++ b/src/backend/db/search.js
@@ -114,4 +114,62 @@ async function listEntriesWithTags({ limit = 50, offset = 0 } = {}) {
   return _enrichWithTags(db, entries);
 }
 
-module.exports = { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags };
+/**
+ * Filtered list of entries supporting any combination of tag, category,
+ * and text-search query (all applied with AND semantics).
+ *
+ * @param {{ tag?: string, category?: string, query?: string, limit?: number, offset?: number }} opts
+ * @returns {Promise<object[]>}
+ */
+async function listEntriesFiltered({ tag, category, query, limit = 50, offset = 0 } = {}) {
+  const db = await openDb();
+
+  let sql = 'SELECT DISTINCT e.* FROM entries e';
+  const conditions = [];
+  const params = [];
+
+  if (tag) {
+    sql += ' INNER JOIN entry_tags et ON et.entry_id = e.id'
+         + ' INNER JOIN tags t ON t.id = et.tag_id';
+    conditions.push('t.name = ?');
+    params.push(tag.trim().toLowerCase());
+  }
+
+  if (category) {
+    conditions.push('COALESCE(e.user_category, e.category) = ?');
+    params.push(category);
+  }
+
+  if (query && query.trim()) {
+    conditions.push('e.content LIKE ?');
+    params.push(`%${query.trim()}%`);
+  }
+
+  if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ');
+  sql += ' ORDER BY e.created_at DESC LIMIT ? OFFSET ?';
+  params.push(limit, offset);
+
+  const entries = db.prepare(sql).all(...params);
+  return _enrichWithTags(db, entries);
+}
+
+/**
+ * Return distinct categories that are in use, with entry counts.
+ * Uses user_category when set, otherwise category.
+ *
+ * @returns {Promise<Array<{category: string, count: number}>>}
+ */
+async function listCategoriesWithCounts() {
+  const db = await openDb();
+  return db
+    .prepare(`
+      SELECT COALESCE(user_category, category) AS category, COUNT(*) AS count
+      FROM entries
+      WHERE COALESCE(user_category, category) IS NOT NULL
+      GROUP BY COALESCE(user_category, category)
+      ORDER BY count DESC, category ASC
+    `)
+    .all();
+}
+
+module.exports = { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags, listEntriesFiltered, listCategoriesWithCounts };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -29,7 +29,8 @@
 
     <!-- ── Export toast ─────────────────────────────────────────── -->
     <div id="export-toast"></div>
-
+    <!-- ── Active filter pills ──────────────────────────────────────────── -->
+    <div id="filter-bar" class="hidden"></div>
     <!-- ── Semantic notice ─────────────────────────────────────────── -->
     <div id="semantic-notice">
       Ollama not available — showing text results instead
@@ -43,6 +44,9 @@
         <div id="sidebar-header">Tags</div>
         <div id="tag-all">All entries</div>
         <div id="tag-list"></div>
+
+        <div id="sidebar-categories-header" class="sidebar-section-header">Categories</div>
+        <div id="category-list"></div>
 
         <div id="sidebar-themes-header">Themes</div>
         <div id="theme-list"></div>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -172,6 +172,99 @@ html, body {
 }
 .tag-all:hover { color: var(--text); }
 
+/* ── Sidebar: categories ──────────────────────────────────────────────── */
+.sidebar-section-header {
+  padding: 10px 12px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+}
+
+.cat-item {
+  display: flex;
+  align-items: center;
+  padding: 5px 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 13px;
+  gap: 6px;
+}
+.cat-item:hover { background: var(--surface2); color: var(--text); }
+.cat-item.active { background: var(--surface2); color: var(--cortex-teal); }
+.cat-item .cat-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cat-item .cat-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  min-width: 20px;
+  text-align: right;
+}
+.cat-item .tag-clear {
+  font-size: 10px;
+  color: var(--text-dim);
+  padding: 1px 4px;
+  border-radius: 3px;
+  display: none;
+}
+.cat-item.active .tag-clear { display: inline; }
+.cat-item.active .tag-clear:hover { background: var(--danger); color: #fff; }
+
+/* ── Filter bar ───────────────────────────────────────────────────────── */
+#filter-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 5px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+#filter-bar.hidden { display: none; }
+
+.active-filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--surface2);
+  border: 1px solid var(--cortex-teal);
+  border-radius: 20px;
+  padding: 2px 8px 2px 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.active-filter-pill .afp-label { color: var(--text-muted); }
+.active-filter-pill .afp-label strong { color: var(--cortex-teal); font-weight: 500; }
+.active-filter-pill .afp-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-dim);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+}
+.active-filter-pill .afp-remove:hover { color: var(--danger); }
+
+.afp-clear-all {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  color: var(--text-dim);
+  font-size: 11px;
+  padding: 2px 10px;
+  cursor: pointer;
+}
+.afp-clear-all:hover { border-color: var(--danger); color: var(--danger); }
+
+/* Clickable tag/category on entry cards */
+.tag-pill--clickable:hover { border-color: var(--cortex-teal); color: var(--cortex-teal); cursor: pointer; }
+.category-badge--clickable { cursor: pointer; }
+.category-badge--clickable:hover { opacity: 0.8; }
+
 /* ── Timeline ─────────────────────────────────────────────────────────── */
 #timeline {
   flex: 1;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -9,7 +9,8 @@ let _state = {
   hasMore: false,
   query: '',
   mode: 'text',      // 'text' | 'semantic'
-  tagFilter: null,   // tag name string or null
+  tagFilter: null,      // tag name string or null
+  categoryFilter: null, // category string or null
   selectedId: null,
   activeThemeId: null,
   groupBy: null,       // null | 'day' | 'week' | 'month'
@@ -66,6 +67,10 @@ const heatmapToggle   = document.getElementById('btn-heatmap-toggle');
 const heatmapPanel    = document.getElementById('heatmap-panel');
 const heatmapGrid     = document.getElementById('heatmap-grid');
 const heatmapMonths   = document.getElementById('heatmap-months');
+
+// ── Filter DOM refs ────────────────────────────────────────────────────────
+const filterBar    = document.getElementById('filter-bar');
+const categoryList = document.getElementById('category-list');
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 
@@ -160,17 +165,21 @@ function renderEntryCard(entry) {
     if (hasTags) {
       entry.tags.slice(0, 6).forEach((t) => {
         const pill = document.createElement('span');
-        pill.className = 'tag-pill';
+        pill.className = 'tag-pill tag-pill--clickable';
         pill.textContent = `#${t.name || t}`;
+        pill.title = `Filter by tag: ${t.name || t}`;
+        pill.addEventListener('click', (e) => { e.stopPropagation(); applyTagFilter(t.name || t); });
         chipRow.appendChild(pill);
       });
     }
 
     if (cat) {
       const badge = document.createElement('span');
-      badge.className = 'category-badge category-badge--card';
+      badge.className = 'category-badge category-badge--card category-badge--clickable';
       badge.setAttribute('data-cat', cat);
       badge.textContent = cat;
+      badge.title = `Filter by category: ${cat}`;
+      badge.addEventListener('click', (e) => { e.stopPropagation(); applyCategoryFilter(cat); });
       chipRow.appendChild(badge);
     }
 
@@ -288,26 +297,32 @@ async function renderHeatmap() {
 
 async function loadEntries(append = false) {
   const offset = append ? _state.offset : 0;
+  const { tagFilter: tag, categoryFilter: category, query } = _state;
   let entries = [];
 
   try {
-    if (_state.mode === 'semantic' && _state.query.trim()) {
-      const result = await window.neurologue.searchSemantic(_state.query);
+    if (_state.mode === 'semantic' && query.trim()) {
+      const result = await window.neurologue.searchSemantic(query);
       if (!result.ok) {
         semanticNotice.style.display = 'block';
-        // Fall back to text search
-        entries = await window.neurologue.searchText(_state.query, { limit: PAGE_SIZE, offset });
+        // Fall back to text search with active filters
+        entries = await window.neurologue.searchText(query, { tag, category, limit: PAGE_SIZE, offset });
       } else {
         semanticNotice.style.display = 'none';
-        entries = result.results;
+        // Post-filter semantic results by active tag/category (result set is small)
+        entries = result.results.filter((e) => {
+          if (tag && !((e.tags || []).some((t) => (t.name || t) === tag))) return false;
+          if (category && (e.user_category || e.category) !== category) return false;
+          return true;
+        });
       }
       _state.hasMore = false;
       loadMoreBtn.style.display = 'none';
-    } else if (_state.query.trim()) {
-      entries = await window.neurologue.searchText(_state.query, { limit: PAGE_SIZE, offset });
+    } else if (query.trim() || tag || category) {
+      entries = await window.neurologue.searchText(query, { tag, category, limit: PAGE_SIZE, offset });
       _state.hasMore = entries.length === PAGE_SIZE;
     } else {
-      entries = await window.neurologue.list({ limit: PAGE_SIZE, offset, tag: _state.tagFilter });
+      entries = await window.neurologue.list({ limit: PAGE_SIZE, offset });
       _state.hasMore = entries.length === PAGE_SIZE;
     }
 
@@ -347,15 +362,96 @@ async function loadTags() {
   }
 }
 
+async function loadCategories() {
+  try {
+    const cats = await window.neurologue.listCategories();
+    categoryList.innerHTML = '';
+    if (!cats.length) return;
+    cats.forEach(({ category, count }) => {
+      const item = document.createElement('div');
+      item.className = 'cat-item' + (category === _state.categoryFilter ? ' active' : '');
+      item.dataset.cat = category;
+      item.innerHTML = `<span class="cat-name">${category}</span>`
+        + `<span class="cat-count">${count}</span>`
+        + `<span class="tag-clear" title="Clear filter">✕</span>`;
+      item.querySelector('.cat-name').addEventListener('click', () => applyCategoryFilter(category));
+      item.querySelector('.cat-count').addEventListener('click', () => applyCategoryFilter(category));
+      item.querySelector('.tag-clear').addEventListener('click', (e) => {
+        e.stopPropagation();
+        applyCategoryFilter(null);
+      });
+      categoryList.appendChild(item);
+    });
+  } catch (err) {
+    console.error('[library] loadCategories failed:', err);
+  }
+}
+
 function applyTagFilter(tagName) {
   _state.tagFilter = tagName;
   _state.selectedId = null;
-  // Update sidebar active state
   document.querySelectorAll('.tag-item').forEach((el) => {
     el.classList.toggle('active', el.querySelector('.tag-name').textContent === tagName);
   });
+  renderActiveFilters();
   loadEntries();
   clearDetail();
+}
+
+function applyCategoryFilter(cat) {
+  _state.categoryFilter = cat;
+  _state.selectedId = null;
+  document.querySelectorAll('.cat-item').forEach((el) => {
+    el.classList.toggle('active', el.dataset.cat === cat);
+  });
+  renderActiveFilters();
+  loadEntries();
+  clearDetail();
+}
+
+function renderActiveFilters() {
+  filterBar.innerHTML = '';
+  const hasTag = !!_state.tagFilter;
+  const hasCat = !!_state.categoryFilter;
+
+  if (!hasTag && !hasCat) {
+    filterBar.classList.add('hidden');
+    return;
+  }
+  filterBar.classList.remove('hidden');
+
+  if (hasTag) {
+    const pill = document.createElement('span');
+    pill.className = 'active-filter-pill';
+    pill.innerHTML = `<span class="afp-label">Tag: <strong>#${_state.tagFilter}</strong></span>`
+      + `<button class="afp-remove" title="Clear tag filter">×</button>`;
+    pill.querySelector('.afp-remove').addEventListener('click', () => applyTagFilter(null));
+    filterBar.appendChild(pill);
+  }
+
+  if (hasCat) {
+    const pill = document.createElement('span');
+    pill.className = 'active-filter-pill';
+    pill.innerHTML = `<span class="afp-label">Category: <strong>${_state.categoryFilter}</strong></span>`
+      + `<button class="afp-remove" title="Clear category filter">×</button>`;
+    pill.querySelector('.afp-remove').addEventListener('click', () => applyCategoryFilter(null));
+    filterBar.appendChild(pill);
+  }
+
+  if (hasTag && hasCat) {
+    const clear = document.createElement('button');
+    clear.className = 'afp-clear-all';
+    clear.textContent = 'Clear all';
+    clear.addEventListener('click', () => {
+      _state.tagFilter = null;
+      _state.categoryFilter = null;
+      document.querySelectorAll('.tag-item, .cat-item').forEach((el) => el.classList.remove('active'));
+      renderActiveFilters();
+      loadEntries();
+      clearDetail();
+    });
+    filterBar.appendChild(clear);
+  }
 }
 
 // ── Entry detail ───────────────────────────────────────────────────────────
@@ -619,8 +715,6 @@ function setMode(mode) {
 
 const debouncedSearch = debounce(() => {
   _state.query = searchInput.value;
-  _state.tagFilter = null;
-  document.querySelectorAll('.tag-item').forEach((el) => el.classList.remove('active'));
   loadEntries();
 }, 300);
 
@@ -1025,6 +1119,7 @@ window.neurologue.onWorkerStatus(updateStatus);
 window.neurologue.onEntriesUpdated(async () => {
   await loadEntries();
   await loadTags();
+  await loadCategories();
   // Refresh the detail panel if a selected entry may now have a category assigned
   if (_state.selectedId) {
     const entry = await window.neurologue.getEntry(_state.selectedId);
@@ -1560,6 +1655,7 @@ async function runSetupCheck() {
 
 (async () => {
   await loadTags();
+  await loadCategories();
   await loadThemes();
   await loadEntries();
   runSetupCheck(); // checks Ollama install + models, shows modal if needed

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -16,6 +16,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   suggestTags: (text) => ipcRenderer.invoke('library:suggest-tags', { text }),
   listTags: () => ipcRenderer.invoke('library:list-tags'),
   getActivity: () => ipcRenderer.invoke('library:activity'),
+  listCategories: () => ipcRenderer.invoke('library:list-categories'),
 
   // ── Tag management ───────────────────────────────────────────────────────
   listTagsWithCounts: () => ipcRenderer.invoke('tags:list-with-counts'),

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const { runMigrations } = require('./db/migrate');
 const { initVectorStore } = require('./backend/vector/store');
 const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory, getActivityByDay } = require('./backend/db/entries');
 const { setTagsForEntry, listTags, listTagsWithCounts, renameTag, deleteTag, mergeTag, findSimilarTags } = require('./backend/db/tags');
-const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags } = require('./backend/db/search');
+const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags, listEntriesFiltered, listCategoriesWithCounts } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
@@ -56,17 +56,20 @@ ipcMain.on('capture:close', (event) => {
 
 // ── Library IPC ──────────────────────────────────────────────────────────────
 
-// List entries (paginated, optional tag filter)
-ipcMain.handle('library:list', async (_event, { limit = 50, offset = 0, tag } = {}) => {
-  if (tag) return listEntriesByTag(tag, { limit, offset });
+// List entries (paginated) — supports tag, category, and text-query filters combined
+ipcMain.handle('library:list', async (_event, { limit = 50, offset = 0, tag, category } = {}) => {
+  if (tag || category) return listEntriesFiltered({ tag, category, limit, offset });
   return listEntriesWithTags({ limit, offset });
 });
 
-// Full-text search
-ipcMain.handle('library:search-text', async (_event, { query, limit = 50, offset = 0 }) => {
-  if (!query || !query.trim()) return listEntries({ limit, offset });
-  return searchEntriesText(query, { limit, offset });
+// Full-text search — optionally narrowed by active tag / category filter
+ipcMain.handle('library:search-text', async (_event, { query, tag, category, limit = 50, offset = 0 }) => {
+  if (!query || !query.trim()) return listEntriesFiltered({ tag, category, limit, offset });
+  return listEntriesFiltered({ query, tag, category, limit, offset });
 });
+
+// Distinct categories in use (for sidebar)
+ipcMain.handle('library:list-categories', async () => listCategoriesWithCounts());
 
 // Semantic search — requires Ollama to be running
 ipcMain.handle('library:search-semantic', async (_event, { query, topN = 10 }) => {

--- a/tests/unit/db/search.test.js
+++ b/tests/unit/db/search.test.js
@@ -139,3 +139,96 @@ describe('getEntryWithTags', () => {
     expect(result).toBeUndefined();
   });
 });
+
+// ── listEntriesFiltered ───────────────────────────────────────────────────
+
+describe('listEntriesFiltered', () => {
+  async function makeEntryWithCategory(content, category, tags = []) {
+    const { createEntry, updateEntryCategory } = require('../../../src/backend/db/entries');
+    const { setTagsForEntry } = require('../../../src/backend/db/tags');
+    const entry = await createEntry({ content });
+    await updateEntryCategory(entry.id, category, 'llm');
+    if (tags.length) await setTagsForEntry(entry.id, tags);
+    return entry;
+  }
+
+  test('returns all entries when no filters are set', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntry('alpha');
+    await makeEntry('beta');
+    const results = await listEntriesFiltered();
+    expect(results.length).toBe(2);
+  });
+
+  test('filters by tag only', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntry('tagged', ['node']);
+    await makeEntry('untagged');
+    const results = await listEntriesFiltered({ tag: 'node' });
+    expect(results.length).toBe(1);
+    expect(results[0].content).toBe('tagged');
+  });
+
+  test('filters by category only', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntryWithCategory('task entry', 'Task');
+    await makeEntryWithCategory('idea entry', 'Idea');
+    const results = await listEntriesFiltered({ category: 'Task' });
+    expect(results.length).toBe(1);
+    expect(results[0].content).toBe('task entry');
+  });
+
+  test('filters by tag AND category (AND semantics)', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntryWithCategory('match', 'Task', ['work']);
+    await makeEntryWithCategory('wrong cat', 'Idea', ['work']);
+    await makeEntryWithCategory('wrong tag', 'Task', ['home']);
+    const results = await listEntriesFiltered({ tag: 'work', category: 'Task' });
+    expect(results.length).toBe(1);
+    expect(results[0].content).toBe('match');
+  });
+
+  test('filters by text query only', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntry('needle in haystack');
+    await makeEntry('nothing here');
+    const results = await listEntriesFiltered({ query: 'needle' });
+    expect(results.length).toBe(1);
+  });
+
+  test('combines text query with category filter', async () => {
+    const { listEntriesFiltered } = require('../../../src/backend/db/search');
+    await makeEntryWithCategory('buy groceries', 'Task');
+    await makeEntryWithCategory('buy a thought', 'Thought');
+    await makeEntryWithCategory('sell stocks', 'Task');
+    const results = await listEntriesFiltered({ query: 'buy', category: 'Task' });
+    expect(results.length).toBe(1);
+    expect(results[0].content).toBe('buy groceries');
+  });
+});
+
+// ── listCategoriesWithCounts ───────────────────────────────────────────────
+
+describe('listCategoriesWithCounts', () => {
+  test('returns categories with counts', async () => {
+    const { createEntry, updateEntryCategory } = require('../../../src/backend/db/entries');
+    const { listCategoriesWithCounts } = require('../../../src/backend/db/search');
+    const e1 = await createEntry({ content: 'a' });
+    const e2 = await createEntry({ content: 'b' });
+    const e3 = await createEntry({ content: 'c' });
+    await updateEntryCategory(e1.id, 'Task', 'llm');
+    await updateEntryCategory(e2.id, 'Task', 'llm');
+    await updateEntryCategory(e3.id, 'Idea', 'llm');
+    const cats = await listCategoriesWithCounts();
+    const taskRow = cats.find((r) => r.category === 'Task');
+    const ideaRow = cats.find((r) => r.category === 'Idea');
+    expect(taskRow.count).toBe(2);
+    expect(ideaRow.count).toBe(1);
+  });
+
+  test('returns empty array when no categories assigned', async () => {
+    const { listCategoriesWithCounts } = require('../../../src/backend/db/search');
+    const cats = await listCategoriesWithCounts();
+    expect(cats).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #83.

## Features

### Clickable chips on entry cards
- Tag pills and category badges on entry cards are now interactive. Clicking one sets that as the active filter (stopping propagation so the entry detail doesn't open).

### Filter bar
A #filter-bar appears below the toolbar whenever a tag or category filter is active. Each active filter is shown as a rounded pill with the filter value and an × to remove it. When both are active, a *Clear all* button appears.

### Sidebar: Categories section
A new **Categories** section below Tags lists every category currently in use with its entry count. Clicking any item sets the category filter; the ✕ on an active item clears it. The list refreshes when the worker finishes processing entries.

### Combined AND filtering
All three filter axes — tag, category, and text search query — can be combined simultaneously:

| Tag filter | Category filter | Text query | Result |
|---|---|---|---|
| ✓ | | | Entries with that tag |
| | ✓ | | Entries with that category |
| ✓ | ✓ | | Entries with tag AND category |
| | | ✓ | Entries matching text |
| ✓ | ✓ | ✓ | All three ANDed |

Text search no longer clears active tag/category filters. Semantic search post-filters its top-N results by active tag/category (small result sets, fine to filter in JS).

## Backend

- listEntriesFiltered({ tag, category, query, limit, offset }) — single dynamic SQL query with DISTINCT covering all filter combinations
- listCategoriesWithCounts() — returns COALESCE(user_category, category) groups with counts
- library:list and library:search-text IPC handlers both accept 	ag + category params
- New library:list-categories IPC handler

## Tests
- 8 new test cases covering all filter combinations and listCategoriesWithCounts
- 186 tests passing, 14 suites