### PR TITLE
feat: introduce nav rail shell and view routing [#91]

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,6 +74,38 @@ Each roadmap item is written to be convertible into GitHub Issues.
 
 ---
 
+## 0.7.x — Neurologue Priority Model
+
+### 0.7.1 Priority Data Model
+- Add `ThemeMetrics` table (time-sliced E/V/O/M + priority score per theme)
+- Add `EntrySignals` table (per-entry sentiment, emotional intensity, obligation/motivation/value/open-loop flags)
+- Wire into existing entry/theme system via DB migrations
+
+### 0.7.2 Entry Signal Classification
+- LLM classification call on entry ingestion to produce `EntrySignals`
+- JSON prompt with structured output (sentiment, emotional intensity, flags)
+- Feature flag to enable/disable classification
+- Error handling for JSON parse failures
+
+### 0.7.3 Priority Scoring Pipeline
+- Aggregation job to compute E, V, O, M, and final Priority score per theme
+- Scores normalised to 0–1 range
+- Runs on schedule (e.g. hourly) and on demand
+- Debug endpoint for inspection
+
+### 0.7.4 Priority Dashboard UI
+- New **Priorities** view in the nav rail
+- Theme list with E/V/O/M score bars
+- Quadrant visualisation (Energy × Value axes)
+- Click-through to full theme detail
+
+### 0.7.5 Drift Analysis
+- Time-series graph of theme energy and priority drift
+- Highlight rising and falling themes
+- Detect neglected obligations (high O, declining E)
+
+---
+
 ## 0.4.x — Themes & Cognitive Layer
 
 ### 0.4.1 Theme Naming & Summaries

--- a/docs/architecture/06-ui-shell.md
+++ b/docs/architecture/06-ui-shell.md
@@ -1,0 +1,138 @@
+# UI Shell Architecture
+
+## Overview
+
+Neurologue's main window uses a **nav-rail + view** shell model. A narrow left rail provides permanent top-level navigation between distinct perspectives; each perspective owns its own layout and chrome.
+
+This document is the authoritative reference for where new features go visually. It should be updated whenever a new view is introduced.
+
+---
+
+## Shell Layout
+
+```
+┌──────┬────────────────────────────────────────────────────┐
+│      │  #toolbar  (global — search, entry count, actions) │
+│      ├────────────────────────────────────────────────────┤
+│ nav  │                                                    │
+│ rail │  #view-container  (active view fills this space)  │
+│      │                                                    │
+│      ├────────────────────────────────────────────────────┤
+│      │  #status-bar  (global — Ollama + worker status)   │
+└──────┴────────────────────────────────────────────────────┘
+```
+
+- **`#toolbar`** spans the full window width above the rail+content area.
+- **`#nav-rail`** is ~48 px wide. Each item has an icon and a short text label. The active item is highlighted in teal.
+- **`#view-container`** fills all remaining space. Only one view is visible at a time (`display:none` on inactive views).
+- **`#status-bar`** spans the full window width below the rail+content area.
+- Modals (Settings, Tag Management, Setup) are global overlays, not scoped to any view.
+
+---
+
+## Views
+
+| ID | Nav label | Icon | Status | Milestone(s) |
+|---|---|---|---|---|
+| `view-library` | Library | ≡ | Implemented | Current |
+| `view-themes` | Themes | ◈ | Placeholder | 0.4.1, 0.4.2, 0.4.4 |
+| `view-priorities` | Priorities | ▲ | Placeholder | 0.7.x |
+| `view-graph` | Graph | ⬡ | Placeholder | 0.6.2 |
+| `view-explore` | Explore | ↺ | Placeholder | 0.6.1, 0.6.3, 0.6.4 |
+
+Placeholder views show a centered "Coming soon" message until their milestone is implemented.
+
+---
+
+## View: Library
+
+Three-column layout: sidebar | timeline | detail.
+
+- **Left sidebar** — Tags (with counts), Categories, Themes (until Themes view is fully built)
+- **Timeline** — entry list with controls (grouping, heatmap, infinite scroll), filter bar
+- **Detail** — entry detail (read, edit, history, tag editing, category override, tag suggestions)
+
+Toolbar items scoped to this view: Search, Text/Semantic toggle, entry count, Export, Maintenance (tag management), + New note.
+
+---
+
+## View: Themes
+
+Two-column layout: theme list | theme detail.
+
+Will contain:
+- Theme list with name, entry count, and priority/energy indicators
+- Theme detail: LLM summary, member entries, trend chart, contradiction badges
+- Theme rename
+- Evolution timeline (rising/falling energy)
+
+Implemented in **0.4.1**, **0.4.2**, **0.4.4**.
+
+---
+
+## View: Priorities
+
+Layout TBD — likely two-panel: ranked list | quadrant + drift chart.
+
+Will contain:
+- Theme list with E/V/O/M score bars
+- Quadrant visualisation (Energy × Value axes)
+- Drift analysis chart (theme energy over time)
+- Click-through to Themes view for selected theme
+
+Implemented in **0.7.4**, **0.7.5**.
+
+---
+
+## View: Graph
+
+Full-canvas layout.
+
+Will contain:
+- Force-directed knowledge graph of entries and themes
+- Semantic cluster visualisation
+- Click to explore / open entry detail
+
+Implemented in **0.6.2**.
+
+---
+
+## View: Explore
+
+Split layout TBD.
+
+Will contain:
+- Cognitive dashboard (active themes, open loops, contradictions, thought density)
+- Memory replay ("What was I thinking last month?", "What changed?")
+- Agentic query interface
+
+Implemented in **0.6.1**, **0.6.3**, **0.6.4**.
+
+---
+
+## Toolbar items by scope
+
+| Item | Scope |
+|---|---|
+| Search bar + Text/Semantic toggle | Library only (hidden in other views) |
+| Entry count | Library only |
+| + New note | Global (always visible) |
+| Export… | Global |
+| Maintenance | Library only |
+| ⚙ Settings | Global |
+| Help | Global |
+
+The toolbar adapts its visible items based on the active view.
+
+---
+
+## Design tokens
+
+The rail uses the existing token set:
+
+- Active item background: `var(--surface2)`
+- Active item icon/label colour: `var(--cortex-teal)`
+- Inactive item colour: `var(--text-dim)`
+- Hover: `var(--text-muted)`
+- Rail background: `var(--surface)` (same as sidebar)
+- Rail border-right: `1px solid var(--border)`

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -14,30 +14,61 @@
     <!-- ── Toolbar ─────────────────────────────────────────────────── -->
     <div id="toolbar">
       <span class="logo">Neurologue</span>
-      <input id="search-input" type="text" placeholder="Search entries…" autocomplete="off" />
-      <div id="search-mode">
+      <input id="search-input" type="text" placeholder="Search entries…" autocomplete="off" class="toolbar-library-only" />
+      <div id="search-mode" class="toolbar-library-only">
         <button id="btn-text" class="mode-btn active">Text</button>
         <button id="btn-semantic" class="mode-btn">Semantic</button>
       </div>
-      <span id="entry-count"></span>
+      <span id="entry-count" class="toolbar-library-only"></span>
       <button id="btn-export" class="mode-btn">Export…</button>
       <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
-      <button id="btn-maintenance" class="mode-btn" title="Tag management">Maintenance</button>
+      <button id="btn-maintenance" class="mode-btn toolbar-library-only" title="Tag management">Maintenance</button>
       <button id="btn-settings" class="mode-btn" title="Settings">⚙</button>
       <button id="btn-help" class="mode-btn">Help</button>
     </div>
 
-    <!-- ── Export toast ─────────────────────────────────────────── -->
-    <div id="export-toast"></div>
-    <!-- ── Active filter pills ──────────────────────────────────────────── -->
-    <div id="filter-bar" class="hidden"></div>
-    <!-- ── Semantic notice ─────────────────────────────────────────── -->
-    <div id="semantic-notice">
-      Ollama not available — showing text results instead
-    </div>
+    <!-- ── Shell: nav rail + view container ───────────────────────── -->
+    <div id="shell">
 
-    <!-- ── Body ────────────────────────────────────────────────────── -->
-    <div id="body">
+      <!-- ── Nav rail ──────────────────────────────────────────────── -->
+      <nav id="nav-rail">
+        <button class="nav-item active" data-view="library" title="Library">
+          <span class="nav-icon">&#9776;</span>
+          <span class="nav-label">Library</span>
+        </button>
+        <button class="nav-item" data-view="themes" title="Themes">
+          <span class="nav-icon">&#9672;</span>
+          <span class="nav-label">Themes</span>
+        </button>
+        <button class="nav-item" data-view="priorities" title="Priorities">
+          <span class="nav-icon">&#9650;</span>
+          <span class="nav-label">Priorities</span>
+        </button>
+        <button class="nav-item" data-view="graph" title="Graph">
+          <span class="nav-icon">&#11041;</span>
+          <span class="nav-label">Graph</span>
+        </button>
+        <button class="nav-item" data-view="explore" title="Explore">
+          <span class="nav-icon">&#8635;</span>
+          <span class="nav-label">Explore</span>
+        </button>
+      </nav>
+
+      <!-- ── View container ────────────────────────────────────────── -->
+      <div id="view-container">
+
+        <!-- ── View: Library ─────────────────────────────────────── -->
+        <div id="view-library" class="view active-view">
+          <!-- Export toast -->
+          <div id="export-toast"></div>
+          <!-- Active filter pills -->
+          <div id="filter-bar" class="hidden"></div>
+          <!-- Semantic notice -->
+          <div id="semantic-notice">
+            Ollama not available — showing text results instead
+          </div>
+          <!-- Three-column body -->
+          <div id="body">
 
       <!-- Sidebar: tags + themes -->
       <div id="sidebar">
@@ -156,6 +187,46 @@
       </div>
 
     </div><!-- /#body -->
+        </div><!-- /#view-library -->
+
+        <!-- ── View: Themes ──────────────────────────────────────── -->
+        <div id="view-themes" class="view">
+          <div class="view-placeholder">
+            <div class="vp-icon">&#9672;</div>
+            <div class="vp-title">Themes</div>
+            <div class="vp-desc">Theme management, summaries, and evolution — coming in 0.4.x</div>
+          </div>
+        </div>
+
+        <!-- ── View: Priorities ──────────────────────────────────── -->
+        <div id="view-priorities" class="view">
+          <div class="view-placeholder">
+            <div class="vp-icon">&#9650;</div>
+            <div class="vp-title">Priorities</div>
+            <div class="vp-desc">Energy, value, obligation, and motivation scoring — coming in 0.7.x</div>
+          </div>
+        </div>
+
+        <!-- ── View: Graph ───────────────────────────────────────── -->
+        <div id="view-graph" class="view">
+          <div class="view-placeholder">
+            <div class="vp-icon">&#11041;</div>
+            <div class="vp-title">Graph</div>
+            <div class="vp-desc">Knowledge graph and semantic cluster visualisation — coming in 0.6.x</div>
+          </div>
+        </div>
+
+        <!-- ── View: Explore ─────────────────────────────────────── -->
+        <div id="view-explore" class="view">
+          <div class="view-placeholder">
+            <div class="vp-icon">&#8635;</div>
+            <div class="vp-title">Explore</div>
+            <div class="vp-desc">Cognitive dashboard, memory replay, and agentic queries — coming in 0.6.x</div>
+          </div>
+        </div>
+
+      </div><!-- /#view-container -->
+    </div><!-- /#shell -->
 
     <!-- ── Status bar ───────────────────────────────────────────────── -->
     <div id="status-bar">

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -105,6 +105,93 @@ html, body {
   white-space: nowrap;
 }
 
+/* ── Shell: nav rail + view container ────────────────────────────────── */
+#shell {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ── Nav rail ─────────────────────────────────────────────────────────── */
+#nav-rail {
+  width: 56px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 0;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  width: 48px;
+  padding: 8px 4px;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.nav-item:hover { background: var(--surface2); color: var(--text-muted); }
+.nav-item.active { background: var(--surface2); color: var(--cortex-teal); }
+
+.nav-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+.nav-label {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+/* ── View container ───────────────────────────────────────────────────── */
+#view-container {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.view { display: none; flex: 1; min-height: 0; flex-direction: column; }
+.view.active-view { display: flex; }
+
+/* ── View: Library ────────────────────────────────────────────────────── */
+#view-library {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Toolbar items hidden outside Library view */
+.toolbar-library-only.hidden-for-view { display: none !important; }
+
+/* ── View placeholder (Themes, Graph, etc.) ───────────────────────────── */
+.view-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-dim);
+  user-select: none;
+}
+.vp-icon { font-size: 40px; opacity: 0.4; }
+.vp-title { font-size: 18px; font-weight: 600; color: var(--text-muted); }
+.vp-desc  { font-size: 13px; max-width: 320px; text-align: center; line-height: 1.6; }
+
 /* ── Three-column body ────────────────────────────────────────────────── */
 #body {
   display: flex;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1651,6 +1651,24 @@ async function runSetupCheck() {
   }
 }
 
+// ── Nav rail / view routing ──────────────────────────────────────────
+
+const navItems        = document.querySelectorAll('.nav-item');
+const views           = document.querySelectorAll('.view');
+const libraryOnlyEls  = document.querySelectorAll('.toolbar-library-only');
+
+function activateView(viewId) {
+  navItems.forEach(btn => btn.classList.toggle('active', btn.dataset.view === viewId));
+  views.forEach(v   => v.classList.toggle('active-view', v.id === `view-${viewId}`));
+
+  const isLibrary = viewId === 'library';
+  libraryOnlyEls.forEach(el => el.classList.toggle('hidden-for-view', !isLibrary));
+}
+
+navItems.forEach(btn => {
+  btn.addEventListener('click', () => activateView(btn.dataset.view));
+});
+
 // ── Init ────────────────────────────────────────────────────────────
 
 (async () => {


### PR DESCRIPTION
Add a left nav rail giving the app five top-level perspectives: Library, Themes, Priorities, Graph, Explore. Only Library is currently implemented; the other four show a 'Coming soon' placeholder. This infrastructure unblocks all future milestones (0.4.x Themes, 0.6.x Graph/Explore, 0.7.x Priorities) without changing any existing Library behaviour.

Changes:
- index.html: wrap existing body in #view-library inside a new #shell layout; add #nav-rail with five nav-item buttons; add placeholder views for Themes, Priorities, Graph, Explore; mark toolbar items that are Library-only with .toolbar-library-only
- library.css: add #shell, #nav-rail, .nav-item, #view-container, .view/.active-view, .view-placeholder styles
- library.js: add activateView() routing + nav-item click handler; toggle .hidden-for-view on Library-only toolbar items
- ROADMAP.md: add 0.7.x Neurologue Priority Model milestone
- docs/architecture/06-ui-shell.md: new doc capturing the view architecture, nav rail design, toolbar scoping, and where each future milestone lives