### PR TITLE
feat: Themes view — LLM names, multi-sentence summaries, rename (#45 …

### DIFF
--- a/src/backend/clustering/themes.js
+++ b/src/backend/clustering/themes.js
@@ -97,19 +97,28 @@ async function runClustering() {
       score: cosineSimilarity(vector, centroid),
     })).sort((a, b) => b.score - a.score);
 
-    // Draft a name from the top entry's first 40 chars until LLM can do better
-    const draftName = `Theme ${i + 1}`;
-
-    // Generate LLM summary if Ollama is available
+    // Use LLM to generate a descriptive name, or fall back to positional draft
+    let themeName = `Theme ${i + 1}`;
     let description = '';
     if (ollamaUp) {
+      const topContent = scored.slice(0, 5).map((m, n) => `${n + 1}. ${m.content}`).join('\n');
       try {
-        const topContent = scored.slice(0, 5).map((m, n) => `${n + 1}. ${m.content}`).join('\n');
-        const prompt =
-          `You are a personal knowledge assistant. The following are a cluster of related notes:\n\n${topContent}\n\n` +
-          `In one concise sentence (max 20 words), summarise what these notes are about. ` +
-          `Reply with the summary only, no preamble.`;
-        description = await generateTextCompletion(prompt);
+        const namePrompt =
+          `You are a personal knowledge assistant. The following are a cluster of related journal entries:\n\n${topContent}\n\n` +
+          `Give this cluster a short, meaningful name of 2–4 words that captures its essence. ` +
+          `Use title case. Reply with the name only — no punctuation, no explanation.`;
+        themeName = await generateTextCompletion(namePrompt);
+        // Trim stray punctuation/quotes the LLM occasionally adds
+        themeName = themeName.replace(/^["'""]+|["'""]+$/g, '').trim() || `Theme ${i + 1}`;
+      } catch (err) {
+        console.warn(`[clustering] LLM name generation failed for cluster ${i}:`, err.message);
+      }
+      try {
+        const summaryPrompt =
+          `You are a personal knowledge assistant. The following are a cluster of related journal entries:\n\n${topContent}\n\n` +
+          `Write a 3–5 sentence summary of what these entries are collectively about. ` +
+          `Be specific and insightful. Do not use bullet points. Reply with the summary only.`;
+        description = await generateTextCompletion(summaryPrompt);
       } catch (err) {
         console.warn(`[clustering] LLM summary failed for cluster ${i}:`, err.message);
       }
@@ -117,7 +126,7 @@ async function runClustering() {
 
     const theme = await upsertTheme({
       id: themeIds[i],
-      name: draftName,
+      name: themeName,
       description,
     });
 

--- a/src/backend/db/themes.js
+++ b/src/backend/db/themes.js
@@ -5,6 +5,8 @@ const { openDb } = require('./connection');
 
 /**
  * Create or update a theme.
+ * When updating, `name` is only written when the theme has no user-set name.
+ * `description` is always updated (LLM re-generates on each cluster run).
  * @param {{ id?: string, name: string, description?: string }} data
  * @returns {Promise<object>}
  */
@@ -12,28 +14,72 @@ async function upsertTheme({ id = randomUUID(), name, description = '' }) {
   const db = await openDb();
   db.prepare(`
     INSERT INTO themes (id, name, description) VALUES (?, ?, ?)
-    ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description
+    ON CONFLICT(id) DO UPDATE SET
+      name        = CASE WHEN themes.user_name IS NULL THEN excluded.name ELSE themes.name END,
+      description = excluded.description
   `).run(id, name, description);
   return getThemeById(id);
 }
 
 /**
- * Get a single theme by ID.
+ * Set a user-chosen name for a theme.
+ * This name takes precedence over the LLM-generated name and is preserved
+ * across re-clustering runs.
+ * @param {string} id
+ * @param {string} newName
+ * @returns {Promise<object>}
+ */
+async function renameTheme(id, newName) {
+  const db = await openDb();
+  db.prepare('UPDATE themes SET user_name = ? WHERE id = ?').run(newName.trim(), id);
+  return getThemeById(id);
+}
+
+/**
+ * Get a single theme by ID, including its member entries.
  * @param {string} id
  * @returns {Promise<object|undefined>}
  */
 async function getThemeById(id) {
   const db = await openDb();
-  return db.prepare('SELECT * FROM themes WHERE id = ?').get(id);
+  const theme = db.prepare(`
+    SELECT t.*,
+           COALESCE(t.user_name, t.name) AS display_name,
+           COUNT(te.entry_id)            AS entry_count
+    FROM themes t
+    LEFT JOIN theme_entries te ON te.theme_id = t.id
+    WHERE t.id = ?
+    GROUP BY t.id
+  `).get(id);
+  if (!theme) return undefined;
+
+  theme.entries = db.prepare(`
+    SELECT e.id, e.content, e.created_at, te.score
+    FROM theme_entries te
+    JOIN entries e ON e.id = te.entry_id
+    WHERE te.theme_id = ?
+    ORDER BY te.score DESC
+  `).all(id);
+
+  return theme;
 }
 
 /**
- * List all themes.
+ * List all themes with entry counts.
+ * The `display_name` field resolves to `user_name` when set, otherwise `name`.
  * @returns {Promise<object[]>}
  */
 async function listThemes() {
   const db = await openDb();
-  return db.prepare('SELECT * FROM themes ORDER BY name ASC').all();
+  return db.prepare(`
+    SELECT t.*,
+           COALESCE(t.user_name, t.name) AS display_name,
+           COUNT(te.entry_id)            AS entry_count
+    FROM themes t
+    LEFT JOIN theme_entries te ON te.theme_id = t.id
+    GROUP BY t.id
+    ORDER BY entry_count DESC, display_name ASC
+  `).all();
 }
 
 /**
@@ -81,6 +127,7 @@ async function getEntriesForTheme(themeId) {
 
 module.exports = {
   upsertTheme,
+  renameTheme,
   getThemeById,
   listThemes,
   deleteTheme,

--- a/src/db/migrations/004_themes_user_name.sql
+++ b/src/db/migrations/004_themes_user_name.sql
@@ -1,0 +1,6 @@
+-- Migration 004: Add user_name column to themes
+-- user_name stores an explicit name set by the user.
+-- When set, it takes precedence over the LLM-generated name.
+-- The clustering pipeline respects this and will not overwrite it.
+
+ALTER TABLE themes ADD COLUMN user_name TEXT;

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -78,9 +78,6 @@
 
         <div id="sidebar-categories-header" class="sidebar-section-header">Categories</div>
         <div id="category-list"></div>
-
-        <div id="sidebar-themes-header">Themes</div>
-        <div id="theme-list"></div>
       </div>
 
       <!-- Timeline: entry list -->
@@ -174,16 +171,6 @@
             </div>
           </div>
         </div>
-        <div id="theme-detail-content">
-          <div id="theme-detail-header">
-            <div id="theme-detail-name"></div>
-            <div id="theme-detail-summary"></div>
-          </div>
-          <div id="theme-detail-body">
-            <div id="theme-detail-entries-label">Entries in this theme</div>
-            <div id="theme-detail-entries"></div>
-          </div>
-        </div>
       </div>
 
     </div><!-- /#body -->
@@ -191,10 +178,40 @@
 
         <!-- ── View: Themes ──────────────────────────────────────── -->
         <div id="view-themes" class="view">
-          <div class="view-placeholder">
-            <div class="vp-icon">&#9672;</div>
-            <div class="vp-title">Themes</div>
-            <div class="vp-desc">Theme management, summaries, and evolution — coming in 0.4.x</div>
+          <!-- Left column: theme list -->
+          <div id="themes-list-col">
+            <div id="themes-list-header">
+              <span class="themes-list-title">Themes</span>
+              <span id="themes-list-count"></span>
+            </div>
+            <div id="themes-list"></div>
+          </div>
+          <!-- Right column: theme detail -->
+          <div id="themes-detail-col">
+            <div id="themes-detail-placeholder">
+              <div class="td-ph-icon">&#9672;</div>
+              <div class="td-ph-text">Select a theme to view its summary and entries</div>
+            </div>
+            <div id="themes-detail-content">
+              <div id="themes-detail-header">
+                <!-- Name row: display name + rename button -->
+                <div id="themes-detail-name-row">
+                  <div id="themes-detail-name"></div>
+                  <button id="themes-btn-rename" class="btn-icon-sm" title="Rename theme">✎</button>
+                </div>
+                <!-- Inline rename form (hidden by default) -->
+                <div id="themes-rename-form">
+                  <input id="themes-rename-input" type="text" autocomplete="off" spellcheck="false" placeholder="Theme name…" />
+                  <button id="themes-rename-save" class="btn-sm">Save</button>
+                  <button id="themes-rename-cancel" class="btn-sm btn-secondary">Cancel</button>
+                </div>
+                <div id="themes-detail-summary"></div>
+              </div>
+              <div id="themes-detail-body">
+                <div id="themes-entries-label">Entries in this theme</div>
+                <div id="themes-entries-list"></div>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -953,99 +953,207 @@ html, body {
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
 
-/* ── Themes sidebar section ───────────────────────────────────────────── */
-#sidebar-themes-header {
-  padding: 12px 12px 6px;
+/* ── Themes view ──────────────────────────────────────────────────────── */
+#view-themes {
+  flex-direction: row;
+  overflow: hidden;
+}
+
+/* Left column: theme list */
+#themes-list-col {
+  width: 240px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+}
+
+#themes-list-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.themes-list-title {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
-  border-top: 1px solid var(--border);
-  margin-top: 8px;
+}
+#themes-list-count {
+  font-size: 11px;
+  color: var(--text-dim);
 }
 
-#theme-list { padding: 4px 0 8px; }
+#themes-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
 
-.theme-item {
+.themes-list-item {
   display: flex;
-  align-items: center;
-  padding: 5px 12px;
+  flex-direction: column;
+  padding: 7px 14px;
   cursor: pointer;
-  color: var(--text-muted);
+  gap: 2px;
+  border-left: 2px solid transparent;
+}
+.themes-list-item:hover { background: var(--surface2); }
+.themes-list-item.active {
+  background: var(--surface2);
+  border-left-color: var(--synapse-gold);
+}
+.tli-name {
   font-size: 13px;
-  gap: 6px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.themes-list-item.active .tli-name { color: var(--synapse-gold); }
+.tli-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* Right column: theme detail */
+#themes-detail-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
-.theme-item:hover { background: var(--surface2); color: var(--text); }
-.theme-item.active { background: var(--surface2); color: var(--synapse-gold); }
-.theme-item .theme-icon { font-size: 11px; flex-shrink: 0; }
-.theme-item .theme-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-/* ── Theme detail panel ───────────────────────────────────────────────── */
-#theme-detail-content {
+#themes-detail-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-dim);
+  user-select: none;
+}
+.td-ph-icon { font-size: 32px; opacity: 0.3; }
+.td-ph-text { font-size: 13px; color: var(--text-dim); }
+
+#themes-detail-content {
   display: none;
   flex-direction: column;
   flex: 1;
   overflow: hidden;
 }
 
-#theme-detail-header {
-  padding: 12px 16px 10px;
+#themes-detail-header {
+  padding: 14px 18px 12px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
-#theme-detail-name {
-  font-size: 15px;
+
+#themes-detail-name-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+#themes-detail-name {
+  font-size: 16px;
   font-weight: 600;
   color: var(--synapse-gold);
-  margin-bottom: 6px;
+  flex: 1;
 }
-#theme-detail-summary {
+.btn-icon-sm {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-dim);
+  border-radius: var(--radius);
+  padding: 2px 6px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+.btn-icon-sm:hover { border-color: var(--border); color: var(--text); }
+
+#themes-rename-form {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+#themes-rename-input {
+  flex: 1;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  padding: 4px 8px;
+  outline: none;
+}
+#themes-rename-input:focus { border-color: var(--cortex-teal); }
+
+.btn-sm {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: var(--radius);
+  padding: 4px 10px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.btn-sm:hover { border-color: var(--cortex-teal); }
+.btn-sm.btn-secondary { color: var(--text-muted); }
+
+#themes-detail-summary {
   font-size: 13px;
   color: var(--text-muted);
-  line-height: 1.5;
-  font-style: italic;
+  line-height: 1.65;
 }
 
-#theme-detail-body {
+#themes-detail-body {
   flex: 1;
   overflow-y: auto;
-  padding: 10px 12px;
+  padding: 14px 18px;
 }
-#theme-detail-entries-label {
+#themes-entries-label {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin-bottom: 8px;
-  padding: 0 4px;
+  margin-bottom: 10px;
 }
-
-.theme-entry-card {
-  background: var(--surface2);
+.themes-entry-card {
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px 10px;
-  margin-bottom: 6px;
+  padding: 9px 12px;
+  margin-bottom: 8px;
   cursor: pointer;
 }
-.theme-entry-card:hover { border-color: var(--cortex-teal); }
-.theme-entry-card .te-meta {
+.themes-entry-card:hover { border-color: var(--cortex-teal); }
+.tec-meta {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 3px;
+  margin-bottom: 4px;
 }
-.theme-entry-card .te-date { font-size: 10px; color: var(--text-dim); }
-.theme-entry-card .te-score { font-size: 10px; color: var(--synapse-gold); }
-.theme-entry-card .te-preview {
+.tec-date  { font-size: 10px; color: var(--text-dim); }
+.tec-score { font-size: 10px; color: var(--synapse-gold); }
+.tec-preview {
   font-size: 12px;
   color: var(--text);
+  line-height: 1.5;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }
 

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -12,7 +12,6 @@ let _state = {
   tagFilter: null,      // tag name string or null
   categoryFilter: null, // category string or null
   selectedId: null,
-  activeThemeId: null,
   groupBy: null,       // null | 'day' | 'week' | 'month'
   lastGroupKey: null,  // last rendered group separator key (for append)
 };
@@ -27,10 +26,8 @@ const timelineList  = document.getElementById('timeline-list');
 const loadMoreBtn   = document.getElementById('load-more-btn');
 const tagList       = document.getElementById('tag-list');
 const tagAll        = document.getElementById('tag-all');
-const themeList     = document.getElementById('theme-list');
 const detailPlaceholder      = document.getElementById('detail-placeholder');
 const detailContent          = document.getElementById('detail-content');
-const themeDetailContent     = document.getElementById('theme-detail-content');
 const detailDate    = document.getElementById('detail-date');
 const detailSource  = document.getElementById('detail-source');
 const detailCategoryBadge  = document.getElementById('detail-category-badge');
@@ -628,78 +625,10 @@ async function selectEntry(id) {
 
 function clearDetail() {
   _state.selectedId = null;
-  _state.activeThemeId = null;
   exitEditMode();
   exitHistoryMode();
   detailPlaceholder.style.display = 'flex';
   detailContent.style.display = 'none';
-  themeDetailContent.style.display = 'none';
-}
-
-// ── Theme sidebar + detail ─────────────────────────────────────────────────
-
-async function loadThemes() {
-  try {
-    const themes = await window.neurologue.listThemes();
-    themeList.innerHTML = '';
-    if (themes.length === 0) return;
-    themes.forEach((theme) => {
-      const item = document.createElement('div');
-      item.className = 'theme-item' + (theme.id === _state.activeThemeId ? ' active' : '');
-      item.dataset.id = theme.id;
-      item.innerHTML =
-        `<span class="theme-icon">◆</span>` +
-        `<span class="theme-name">${theme.name}</span>`;
-      item.addEventListener('click', () => selectTheme(theme.id));
-      themeList.appendChild(item);
-    });
-  } catch (err) {
-    console.error('[library] loadThemes failed:', err);
-  }
-}
-
-async function selectTheme(id) {
-  _state.activeThemeId = id;
-  _state.selectedId = null;
-  document.querySelectorAll('.theme-item').forEach((el) => {
-    el.classList.toggle('active', el.dataset.id === id);
-  });
-  document.querySelectorAll('.tag-item').forEach((el) => el.classList.remove('active'));
-
-  try {
-    const theme = await window.neurologue.getTheme(id);
-    if (!theme) return;
-
-    document.getElementById('theme-detail-name').textContent = theme.name;
-    document.getElementById('theme-detail-summary').textContent =
-      theme.description || 'No summary yet — clustering will generate one when Ollama is available.';
-
-    const entriesEl = document.getElementById('theme-detail-entries');
-    entriesEl.innerHTML = '';
-    (theme.entries || []).forEach((entry) => {
-      const card = document.createElement('div');
-      card.className = 'theme-entry-card';
-      card.innerHTML =
-        `<div class="te-meta">` +
-        `<span class="te-date">${formatDate(entry.created_at)}</span>` +
-        `<span class="te-score">${entry.score !== undefined ? entry.score.toFixed(2) : ''}</span>` +
-        `</div>` +
-        `<div class="te-preview">${entry.content}</div>`;
-      card.addEventListener('click', () => {
-        // Jump to entry detail
-        _state.activeThemeId = null;
-        document.querySelectorAll('.theme-item').forEach((el) => el.classList.remove('active'));
-        selectEntry(entry.id);
-      });
-      entriesEl.appendChild(card);
-    });
-
-    detailPlaceholder.style.display = 'none';
-    detailContent.style.display = 'none';
-    themeDetailContent.style.display = 'flex';
-  } catch (err) {
-    console.error('[library] selectTheme failed:', err);
-  }
 }
 
 // ── Search mode toggle ─────────────────────────────────────────────────────
@@ -1130,7 +1059,7 @@ window.neurologue.onEntriesUpdated(async () => {
     }
   }
 });
-window.neurologue.onThemesUpdated(() => loadThemes());
+window.neurologue.onThemesUpdated(() => loadThemesView());
 
 // ── Setup + settings modals ────────────────────────────────────────
 
@@ -1663,10 +1592,149 @@ function activateView(viewId) {
 
   const isLibrary = viewId === 'library';
   libraryOnlyEls.forEach(el => el.classList.toggle('hidden-for-view', !isLibrary));
+
+  if (viewId === 'themes') loadThemesView();
 }
 
 navItems.forEach(btn => {
   btn.addEventListener('click', () => activateView(btn.dataset.view));
+});
+
+// ── Themes view controller ───────────────────────────────────────────────────
+
+const themesListEl       = document.getElementById('themes-list');
+const themesListCountEl  = document.getElementById('themes-list-count');
+const themesDetailPh     = document.getElementById('themes-detail-placeholder');
+const themesDetailCont   = document.getElementById('themes-detail-content');
+const themesDetailName   = document.getElementById('themes-detail-name');
+const themesDetailSum    = document.getElementById('themes-detail-summary');
+const themesEntriesList  = document.getElementById('themes-entries-list');
+const themesNameRow      = document.getElementById('themes-detail-name-row');
+const themesRenameForm   = document.getElementById('themes-rename-form');
+const themesRenameInput  = document.getElementById('themes-rename-input');
+const themesBtnRename    = document.getElementById('themes-btn-rename');
+const themesRenameSave   = document.getElementById('themes-rename-save');
+const themesRenameCancel = document.getElementById('themes-rename-cancel');
+
+let _themesActiveId = null;
+
+async function loadThemesView() {
+  try {
+    const themes = await window.neurologue.listThemes();
+    themesListEl.innerHTML = '';
+    themesListCountEl.textContent = themes.length ? `${themes.length} themes` : '';
+
+    if (themes.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.cssText = 'padding:16px 14px;font-size:13px;color:var(--text-dim)';
+      empty.textContent = 'No themes yet — clustering runs automatically as you add entries.';
+      themesListEl.appendChild(empty);
+      return;
+    }
+
+    themes.forEach((theme) => {
+      const item = document.createElement('div');
+      item.className = 'themes-list-item' + (theme.id === _themesActiveId ? ' active' : '');
+      item.dataset.id = theme.id;
+      const entryWord = theme.entry_count === 1 ? '1 entry' : `${theme.entry_count} entries`;
+      item.innerHTML =
+        `<div class="tli-name">${escHtml(theme.display_name || theme.name)}</div>` +
+        `<div class="tli-meta">${entryWord}</div>`;
+      item.addEventListener('click', () => selectThemeView(theme.id));
+      themesListEl.appendChild(item);
+    });
+
+    // If we had an active theme, re-select it so detail stays fresh
+    if (_themesActiveId) selectThemeView(_themesActiveId);
+  } catch (err) {
+    console.error('[themes-view] loadThemesView failed:', err);
+  }
+}
+
+async function selectThemeView(id) {
+  _themesActiveId = id;
+  document.querySelectorAll('.themes-list-item').forEach((el) => {
+    el.classList.toggle('active', el.dataset.id === id);
+  });
+  closeRenameForm();
+
+  try {
+    const theme = await window.neurologue.getTheme(id);
+    if (!theme) return;
+
+    const displayName = theme.display_name || theme.name;
+    themesDetailName.textContent = displayName;
+    themesDetailSum.textContent = theme.description ||
+      'No summary yet — clustering will generate one when Ollama is available.';
+
+    // Populate entries
+    themesEntriesList.innerHTML = '';
+    (theme.entries || []).slice(0, 30).forEach((entry) => {
+      const card = document.createElement('div');
+      card.className = 'themes-entry-card';
+      card.innerHTML =
+        `<div class="tec-meta">` +
+        `<span class="tec-date">${formatDate(entry.created_at)}</span>` +
+        `<span class="tec-score">${entry.score !== undefined ? entry.score.toFixed(2) : ''}</span>` +
+        `</div>` +
+        `<div class="tec-preview">${escHtml(entry.content)}</div>`;
+      card.addEventListener('click', () => {
+        // Jump to Library view + entry
+        activateView('library');
+        selectEntry(entry.id);
+      });
+      themesEntriesList.appendChild(card);
+    });
+
+    themesDetailPh.style.display   = 'none';
+    themesDetailCont.style.display = 'flex';
+  } catch (err) {
+    console.error('[themes-view] selectThemeView failed:', err);
+  }
+}
+
+// ── Rename flow ──────────────────────────────────────────────────────────────
+
+function openRenameForm() {
+  const currentName = themesDetailName.textContent;
+  themesRenameInput.value = currentName;
+  themesNameRow.style.display      = 'none';
+  themesRenameForm.style.display   = 'flex';
+  themesRenameInput.focus();
+  themesRenameInput.select();
+}
+
+function closeRenameForm() {
+  themesRenameForm.style.display = 'none';
+  themesNameRow.style.display    = 'flex';
+  themesRenameInput.value        = '';
+}
+
+async function saveRename() {
+  const newName = themesRenameInput.value.trim();
+  if (!newName || !_themesActiveId) { closeRenameForm(); return; }
+
+  themesRenameSave.disabled = true;
+  themesRenameSave.textContent = 'Saving…';
+  try {
+    await window.neurologue.renameTheme(_themesActiveId, newName);
+    closeRenameForm();
+    await loadThemesView();
+  } catch (err) {
+    console.error('[themes-view] rename failed:', err);
+    themesRenameInput.style.borderColor = 'var(--danger)';
+  } finally {
+    themesRenameSave.disabled = false;
+    themesRenameSave.textContent = 'Save';
+  }
+}
+
+themesBtnRename.addEventListener('click', openRenameForm);
+themesRenameSave.addEventListener('click', saveRename);
+themesRenameCancel.addEventListener('click', closeRenameForm);
+themesRenameInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter')  saveRename();
+  if (e.key === 'Escape') closeRenameForm();
 });
 
 // ── Init ────────────────────────────────────────────────────────────
@@ -1674,7 +1742,6 @@ navItems.forEach(btn => {
 (async () => {
   await loadTags();
   await loadCategories();
-  await loadThemes();
   await loadEntries();
   runSetupCheck(); // checks Ollama install + models, shows modal if needed
 })();

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -28,6 +28,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Themes ───────────────────────────────────────────────────────────────
   listThemes: () => ipcRenderer.invoke('themes:list'),
   getTheme: (id) => ipcRenderer.invoke('themes:get', { id }),
+  renameTheme: (id, newName) => ipcRenderer.invoke('themes:rename', { id, newName }),
   triggerClustering: () => ipcRenderer.invoke('themes:cluster'),
   // ── Export ───────────────────────────────────────────────────────────────
   exportAll: (opts) => ipcRenderer.invoke('export:run', opts),

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTa
 const { searchNearest } = require('./backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
-const { listThemes, getThemeById, getEntriesForTheme } = require('./backend/db/themes');
+const { listThemes, getThemeById, renameTheme } = require('./backend/db/themes');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
@@ -223,18 +223,15 @@ ipcMain.handle('themes:list', async () => {
   return themes;
 });
 
-// Get a single theme with its top entries (enriched with content + tags)
+// Get a single theme with its member entries
 ipcMain.handle('themes:get', async (_event, { id }) => {
-  const theme = await getThemeById(id);
-  if (!theme) return null;
-  const members = await getEntriesForTheme(id);
-  const entries = await Promise.all(
-    members.slice(0, 20).map(async ({ entry_id, score }) => {
-      const entry = await getEntryWithTags(entry_id);
-      return entry ? { ...entry, score } : null;
-    })
-  );
-  return { ...theme, entries: entries.filter(Boolean) };
+  return getThemeById(id);
+});
+
+// Rename a theme (stores as user_name, preserved across re-clustering)
+ipcMain.handle('themes:rename', async (_event, { id, newName }) => {
+  if (!newName || !newName.trim()) throw new Error('Name cannot be empty');
+  return renameTheme(id, newName.trim());
 });
 
 // Manually trigger clustering (for dev/debug)


### PR DESCRIPTION
…#46)

- Add DB migration 004: themes.user_name column (preserved across re-clustering)
- Update themes.js: upsertTheme preserves user_name; renameTheme() stores user choice; getThemeById() returns member entries inline; listThemes() includes entry_count + display_name
- Update clustering pipeline: two LLM calls per cluster — 2–4 word title-case name (replaces 'Theme N'), then 3–5 sentence summary; both skip gracefully if Ollama is down
- Add IPC handler themes:rename; expose renameTheme() in preload
- Build Themes view (#view-themes): two-column layout (theme list | theme detail) with inline rename form (pencil button → input → Save/Cancel, Enter/Escape)
- Entry cards in detail panel are clickable — jump to Library view + select the entry
- Remove themes from Library sidebar and detail panel (Themes view is their home)
- Remove stale DOM refs and old loadThemes/selectTheme functions from library.js
- onThemesUpdated listener now refreshes Themes view