### PR TITLE
feat: semantic neighbours, reindex, tabbed settings (0.4.x Cognitive Layer)

### DIFF
--- a/src/backend/db/embeddings.js
+++ b/src/backend/db/embeddings.js
@@ -67,4 +67,14 @@ async function deleteEmbedding(entryId) {
   db.prepare('DELETE FROM embeddings WHERE entry_id = ?').run(entryId);
 }
 
-module.exports = { upsertEmbedding, getEmbedding, listEntriesWithoutEmbedding, deleteEmbedding };
+/**
+ * Delete ALL embeddings. Used to force a full reindex.
+ * @returns {Promise<number>} number of rows deleted
+ */
+async function clearAllEmbeddings() {
+  const db = await openDb();
+  const info = db.prepare('DELETE FROM embeddings').run();
+  return info.changes;
+}
+
+module.exports = { upsertEmbedding, getEmbedding, listEntriesWithoutEmbedding, deleteEmbedding, clearAllEmbeddings };

--- a/src/backend/vector/store.js
+++ b/src/backend/vector/store.js
@@ -71,4 +71,12 @@ async function deleteVector(entryId) {
   await _table.delete(`entry_id = '${entryId}'`);
 }
 
-module.exports = { initVectorStore, upsertVector, searchNearest, deleteVector };
+/**
+ * Delete ALL vectors. Used to force a full reindex.
+ */
+async function clearAllVectors() {
+  if (!_table) throw new Error('Vector store not initialised. Call initVectorStore() first.');
+  await _table.delete('entry_id IS NOT NULL');
+}
+
+module.exports = { initVectorStore, upsertVector, searchNearest, deleteVector, clearAllVectors };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -134,6 +134,14 @@
                 </div>
                 <div id="detail-tags-suggestions"></div>
               </div>
+              <!-- Similar entries -->
+              <div id="similar-entries-section">
+                <button id="similar-entries-toggle" class="similar-toggle" aria-expanded="false">
+                  <span class="similar-toggle-icon">▸</span>
+                  <span>Similar entries</span>
+                </button>
+                <div id="similar-entries-list" hidden></div>
+              </div>
             </div>
             <!-- Edit form (hidden by default) -->
             <div id="detail-edit" style="display:none">

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -321,58 +321,73 @@
   </div>
   <!-- ── Settings modal ────────────────────────────────────────────────────── -->
   <div id="settings-modal" class="modal-overlay hidden">
-    <div class="modal-box">
+    <div class="modal-box modal-box--settings">
       <button class="modal-close" id="settings-close" title="Close">✕</button>
       <h2>Settings</h2>
 
-      <h3 class="settings-section-heading">Model settings</h3>
-      <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
-      <div class="settings-field">
-        <label for="select-embed-model">Embedding model</label>
-        <select id="select-embed-model"></select>
-        <span class="settings-hint">Used for semantic search. Changing this will re-embed your entries over time.</span>
-      </div>
-      <div class="settings-field">
-        <label for="select-llm-model">LLM model (theme summaries)</label>
-        <select id="select-llm-model"></select>
-        <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
+      <div class="settings-tabs" role="tablist">
+        <button class="settings-tab active" data-tab="models" role="tab" aria-selected="true">Models</button>
+        <button class="settings-tab" data-tab="tags"   role="tab" aria-selected="false">Tags</button>
+        <button class="settings-tab" data-tab="hotkey" role="tab" aria-selected="false">Hotkey</button>
+        <button class="settings-tab" data-tab="data"   role="tab" aria-selected="false">Data</button>
       </div>
 
-      <h3 class="settings-section-heading">Tag suggestions</h3>
-      <div class="settings-field">
-        <label for="select-tag-format">Multi-word tag format</label>
-        <select id="select-tag-format">
-          <option value="hyphenated">Hyphenated (two-words)</option>
-          <option value="concatenated">Concatenated (twowords)</option>
-        </select>
-        <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
-      </div>
-      <div class="settings-field">
-        <label for="select-similarity-threshold">Duplicate detection sensitivity</label>
-        <select id="select-similarity-threshold">
-          <option value="0.93">Strict — near-identical meanings only</option>
-          <option value="0.88">Balanced — recommended</option>
-          <option value="0.82">Broad — more suggestions, more noise</option>
-        </select>
-        <span class="settings-hint">How closely two tags must be related (semantically) to appear as possible duplicates. Requires Ollama.</span>
-      </div>
-
-      <h3 class="settings-section-heading">Capture hotkey</h3>
-      <div class="settings-field">
-        <label>Global shortcut</label>
-        <div class="hotkey-row">
-          <span id="hotkey-display" class="hotkey-display"></span>
-          <button id="btn-record-hotkey" class="btn-record-hotkey">Change</button>
+      <!-- Models panel -->
+      <div class="settings-panel" id="settings-tab-models">
+        <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
+        <div class="settings-field">
+          <label for="select-embed-model">Embedding model</label>
+          <select id="select-embed-model"></select>
+          <span class="settings-hint">Used for semantic search. Changing this will re-embed your entries over time.</span>
         </div>
-        <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
-        <span class="hotkey-conflict hidden" id="hotkey-conflict">⚠ That shortcut is already claimed by another application.</span>
+        <div class="settings-field">
+          <label for="select-llm-model">LLM model (theme summaries)</label>
+          <select id="select-llm-model"></select>
+          <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
+        </div>
       </div>
 
-      <h3 class="settings-section-heading">Data maintenance</h3>
-      <div class="settings-field">
-        <label>Reindex all entries</label>
-        <button id="btn-reindex-all" class="btn-secondary">Reindex all entries…</button>
-        <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
+      <!-- Tags panel -->
+      <div class="settings-panel hidden" id="settings-tab-tags">
+        <div class="settings-field">
+          <label for="select-tag-format">Multi-word tag format</label>
+          <select id="select-tag-format">
+            <option value="hyphenated">Hyphenated (two-words)</option>
+            <option value="concatenated">Concatenated (twowords)</option>
+          </select>
+          <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
+        </div>
+        <div class="settings-field">
+          <label for="select-similarity-threshold">Duplicate detection sensitivity</label>
+          <select id="select-similarity-threshold">
+            <option value="0.93">Strict — near-identical meanings only</option>
+            <option value="0.88">Balanced — recommended</option>
+            <option value="0.82">Broad — more suggestions, more noise</option>
+          </select>
+          <span class="settings-hint">How closely two tags must be related (semantically) to appear as possible duplicates. Requires Ollama.</span>
+        </div>
+      </div>
+
+      <!-- Hotkey panel -->
+      <div class="settings-panel hidden" id="settings-tab-hotkey">
+        <div class="settings-field">
+          <label>Global shortcut</label>
+          <div class="hotkey-row">
+            <span id="hotkey-display" class="hotkey-display"></span>
+            <button id="btn-record-hotkey" class="btn-record-hotkey">Change</button>
+          </div>
+          <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
+          <span class="hotkey-conflict hidden" id="hotkey-conflict">⚠ That shortcut is already claimed by another application.</span>
+        </div>
+      </div>
+
+      <!-- Data panel -->
+      <div class="settings-panel hidden" id="settings-tab-data">
+        <div class="settings-field">
+          <label>Reindex all entries</label>
+          <button id="btn-reindex-all" class="btn-secondary">Reindex all entries…</button>
+          <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
+        </div>
       </div>
 
       <div class="settings-actions">

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -141,6 +141,10 @@
                   <span>Similar entries</span>
                 </button>
                 <div id="similar-entries-list" hidden></div>
+                <div id="similar-entries-no-embedding" hidden>
+                  <p class="sec-no-embedding">This entry has not been embedded yet.</p>
+                  <button id="btn-reindex-entry" class="btn-secondary btn-reindex-entry">Embed now</button>
+                </div>
               </div>
             </div>
             <!-- Edit form (hidden by default) -->
@@ -362,6 +366,13 @@
         </div>
         <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
         <span class="hotkey-conflict hidden" id="hotkey-conflict">⚠ That shortcut is already claimed by another application.</span>
+      </div>
+
+      <h3 class="settings-section-heading">Data maintenance</h3>
+      <div class="settings-field">
+        <label>Reindex all entries</label>
+        <button id="btn-reindex-all" class="btn-secondary">Reindex all entries…</button>
+        <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
       </div>
 
       <div class="settings-actions">

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1417,6 +1417,42 @@ html, body {
 }
 
 /* ── Settings modal fields ──────────────────────────────────────────────── */
+.modal-box--settings {
+  max-width: 500px;
+}
+
+/* Tab bar */
+.settings-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+  margin: 12px 0 20px;
+}
+.settings-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 6px 14px 8px;
+  cursor: pointer;
+  border-radius: var(--radius) var(--radius) 0 0;
+  transition: color 0.15s;
+}
+.settings-tab:hover { color: var(--text-muted); }
+.settings-tab.active {
+  color: var(--cortex-teal);
+  border-bottom-color: var(--cortex-teal);
+}
+
+/* Tab panels */
+.settings-panel { min-height: 140px; }
+.settings-panel.hidden { display: none; }
+
 .settings-field {
   margin-bottom: 20px;
 }

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -794,6 +794,23 @@ html, body {
   -webkit-box-orient: vertical;
 }
 
+#similar-entries-no-embedding {
+  padding: 8px 0 4px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.sec-no-embedding {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.btn-reindex-entry {
+  font-size: 11px;
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+
 /* ── Detail footer (Edit / History buttons) ───────────────────────────── */
 #detail-footer {
   padding: 8px 16px 12px;

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -732,6 +732,68 @@ html, body {
 }
 .detail-tag-suggestion:hover { background: var(--cortex-teal); color: var(--text); }
 
+/* ── Similar entries section ──────────────────────────────────────────── */
+#similar-entries-section {
+  margin-top: 16px;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.similar-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 0;
+  width: 100%;
+  text-align: left;
+}
+.similar-toggle:hover { color: var(--text-muted); }
+.similar-toggle-icon { font-size: 9px; transition: transform 0.15s; }
+.similar-toggle[aria-expanded="true"] .similar-toggle-icon { transform: rotate(90deg); }
+
+#similar-entries-list {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.similar-entry-card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 7px 10px;
+  cursor: pointer;
+}
+.similar-entry-card:hover { border-color: var(--cortex-teal); }
+.sec-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.sec-date  { font-size: 10px; color: var(--text-dim); }
+.sec-sim   { font-size: 10px; color: var(--cortex-teal); }
+.sec-preview {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 /* ── Detail footer (Edit / History buttons) ───────────────────────────── */
 #detail-footer {
   padding: 8px 16px 12px;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -584,22 +584,32 @@ detailTagsInput.addEventListener('blur', () => _commitTagInput());
 
 // ── Similar entries (semantic neighbours) ─────────────────────────────────
 
-const similarSection  = document.getElementById('similar-entries-section');
-const similarToggle   = document.getElementById('similar-entries-toggle');
-const similarList     = document.getElementById('similar-entries-list');
-let _similarTimer     = null;
+const similarSection   = document.getElementById('similar-entries-section');
+const similarToggle    = document.getElementById('similar-entries-toggle');
+const similarList      = document.getElementById('similar-entries-list');
+const similarNoEmbed   = document.getElementById('similar-entries-no-embedding');
+let _similarTimer      = null;
 
 function resetSimilarEntries() {
   similarToggle.setAttribute('aria-expanded', 'false');
   similarList.hidden = true;
   similarList.innerHTML = '';
+  similarNoEmbed.hidden = true;
   similarSection.style.display = 'block';
 }
 
 async function _loadSimilarEntries(entryId) {
   try {
     const result = await window.neurologue.similarEntries(entryId);
-    if (!result.ok || result.results.length === 0) {
+    if (!result.ok) {
+      if (result.reason === 'no_embedding') {
+        similarNoEmbed.hidden = false;
+      } else {
+        similarSection.style.display = 'none';
+      }
+      return;
+    }
+    if (result.results.length === 0) {
       similarSection.style.display = 'none';
       return;
     }
@@ -629,6 +639,14 @@ similarToggle.addEventListener('click', () => {
   const expanded = similarToggle.getAttribute('aria-expanded') === 'true';
   similarToggle.setAttribute('aria-expanded', String(!expanded));
   similarList.hidden = expanded;
+});
+
+// Re-embed a single entry on demand (shown when no embedding exists yet)
+document.getElementById('btn-reindex-entry').addEventListener('click', async () => {
+  const id = _state.selectedId;
+  if (!id) return;
+  similarNoEmbed.hidden = true;
+  await window.neurologue.reindexEntry(id);
 });
 
 // ── Select entry (show in detail panel) ────────────────────────────────────
@@ -1385,6 +1403,20 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
   const msg = document.getElementById('settings-saved-msg');
   msg.classList.remove('hidden');
   setTimeout(() => msg.classList.add('hidden'), 2000);
+});
+
+// Reindex all entries — clear all embeddings and re-queue everything
+document.getElementById('btn-reindex-all').addEventListener('click', async () => {
+  const confirmed = confirm(
+    'This will clear all stored embeddings and re-process every entry from scratch.\n\n' +
+    'Ollama must be running, and processing will happen in the background. Continue?'
+  );
+  if (!confirmed) return;
+  const { queued } = await window.neurologue.reindexAll();
+  const settingsModal = document.getElementById('settings-modal');
+  settingsModal.classList.add('hidden');
+  window.neurologue.resumeHotkey();
+  console.info(`[library] Reindex started — ${queued} entries queued`);
 });
 
 // ── Tag Management modal ─────────────────────────────────────────────────────

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -582,6 +582,56 @@ detailTagsInput.addEventListener('keydown', async (e) => {
 });
 detailTagsInput.addEventListener('blur', () => _commitTagInput());
 
+// ── Similar entries (semantic neighbours) ─────────────────────────────────
+
+const similarSection  = document.getElementById('similar-entries-section');
+const similarToggle   = document.getElementById('similar-entries-toggle');
+const similarList     = document.getElementById('similar-entries-list');
+let _similarTimer     = null;
+
+function resetSimilarEntries() {
+  similarToggle.setAttribute('aria-expanded', 'false');
+  similarList.hidden = true;
+  similarList.innerHTML = '';
+  similarSection.style.display = 'block';
+}
+
+async function _loadSimilarEntries(entryId) {
+  try {
+    const result = await window.neurologue.similarEntries(entryId);
+    if (!result.ok || result.results.length === 0) {
+      similarSection.style.display = 'none';
+      return;
+    }
+    similarList.innerHTML = '';
+    result.results.forEach((entry) => {
+      const card = document.createElement('div');
+      card.className = 'similar-entry-card';
+      // Convert distance to a 0–100% similarity score (LanceDB uses L2 distance)
+      const sim = entry._distance !== undefined
+        ? Math.max(0, Math.round((1 - Math.min(entry._distance, 1)) * 100))
+        : null;
+      card.innerHTML =
+        `<div class="sec-meta">` +
+        `<span class="sec-date">${formatDate(entry.created_at)}</span>` +
+        (sim !== null ? `<span class="sec-sim">${sim}% similar</span>` : '') +
+        `</div>` +
+        `<div class="sec-preview">${escHtml(entry.content)}</div>`;
+      card.addEventListener('click', () => selectEntry(entry.id));
+      similarList.appendChild(card);
+    });
+  } catch {
+    similarSection.style.display = 'none';
+  }
+}
+
+similarToggle.addEventListener('click', () => {
+  const expanded = similarToggle.getAttribute('aria-expanded') === 'true';
+  similarToggle.setAttribute('aria-expanded', String(!expanded));
+  similarList.hidden = expanded;
+});
+
+// ── Select entry (show in detail panel) ────────────────────────────────────
 async function selectEntry(id) {
   _state.selectedId = id;
 
@@ -616,6 +666,11 @@ async function selectEntry(id) {
     clearTimeout(_detailSuggestTimer);
     _detailSuggestTimer = setTimeout(() => _fetchDetailSuggestions(entry.content), 600);
 
+    // Reset similar entries — collapse and clear, then load lazily
+    resetSimilarEntries();
+    clearTimeout(_similarTimer);
+    _similarTimer = setTimeout(() => _loadSimilarEntries(id), 800);
+
     detailPlaceholder.style.display = 'none';
     detailContent.style.display = 'flex';
   } catch (err) {
@@ -627,6 +682,8 @@ function clearDetail() {
   _state.selectedId = null;
   exitEditMode();
   exitHistoryMode();
+  clearTimeout(_similarTimer);
+  resetSimilarEntries();
   detailPlaceholder.style.display = 'flex';
   detailContent.style.display = 'none';
 }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -595,7 +595,7 @@ function resetSimilarEntries() {
   similarList.hidden = true;
   similarList.innerHTML = '';
   similarNoEmbed.hidden = true;
-  similarSection.style.display = 'block';
+  similarSection.style.display = 'none';
 }
 
 async function _loadSimilarEntries(entryId) {
@@ -603,16 +603,17 @@ async function _loadSimilarEntries(entryId) {
     const result = await window.neurologue.similarEntries(entryId);
     if (!result.ok) {
       if (result.reason === 'no_embedding') {
+        similarSection.style.display = 'block';
         similarNoEmbed.hidden = false;
-      } else {
-        similarSection.style.display = 'none';
       }
+      // any other failure: leave section hidden
       return;
     }
     if (result.results.length === 0) {
-      similarSection.style.display = 'none';
+      // leave section hidden — nothing to show
       return;
     }
+    similarSection.style.display = 'block';
     similarList.innerHTML = '';
     result.results.forEach((entry) => {
       const card = document.createElement('div');
@@ -631,7 +632,7 @@ async function _loadSimilarEntries(entryId) {
       similarList.appendChild(card);
     });
   } catch {
-    similarSection.style.display = 'none';
+    // leave section hidden on error
   }
 }
 
@@ -1257,6 +1258,22 @@ document.getElementById('btn-pull-all').addEventListener('click', pullAllMissing
 
 // ── Settings modal ─────────────────────────────────────────────────
 
+// Tab switching
+function activateSettingsTab(name) {
+  document.querySelectorAll('.settings-tab').forEach((t) => {
+    const active = t.dataset.tab === name;
+    t.classList.toggle('active', active);
+    t.setAttribute('aria-selected', String(active));
+  });
+  document.querySelectorAll('.settings-panel').forEach((p) => {
+    p.classList.toggle('hidden', p.id !== `settings-tab-${name}`);
+  });
+}
+
+document.querySelectorAll('.settings-tab').forEach((tab) => {
+  tab.addEventListener('click', () => activateSettingsTab(tab.dataset.tab));
+});
+
 // ── Hotkey recorder ─────────────────────────────────────────────────────────
 let _recordingHotkey = false;
 let _pendingHotkey   = null;
@@ -1370,6 +1387,7 @@ btnSettings.addEventListener('click', async () => {
   hotkeyDisplay.dataset.saved = currentHotkey;
   hotkeyDisplay.textContent   = formatAccelerator(currentHotkey);
 
+  activateSettingsTab('models');
   settingsModal.classList.remove('hidden');
   window.neurologue.pauseHotkey();
 });

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   list: (opts) => ipcRenderer.invoke('library:list', opts),
   searchText: (query, opts) => ipcRenderer.invoke('library:search-text', { query, ...opts }),
   searchSemantic: (query, opts) => ipcRenderer.invoke('library:search-semantic', { query, ...opts }),
+  similarEntries: (id, opts) => ipcRenderer.invoke('library:similar-entries', { id, ...opts }),
   getEntry: (id) => ipcRenderer.invoke('library:get-entry', { id }),
   updateEntry: (id, content) => ipcRenderer.invoke('library:update-entry', { id, content }),
   getRevisions: (id) => ipcRenderer.invoke('library:get-revisions', { id }),

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -37,6 +37,10 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Help ─────────────────────────────────────────────────────────────────
   openHelp: () => ipcRenderer.invoke('help:open'),
 
+  // ── Reindex ──────────────────────────────────────────────────────────────
+  reindexAll:   ()   => ipcRenderer.invoke('worker:reindex-all'),
+  reindexEntry: (id) => ipcRenderer.invoke('worker:reindex-entry', { id }),
+
   // ── Status ───────────────────────────────────────────────────────────────
   getStatus: () => ipcRenderer.invoke('status:get'),
   onWorkerStatus:     (cb) => { ipcRenderer.on('worker:status',           (_e, d) => cb(d)); },

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const { listThemes, getThemeById, renameTheme } = require('./backend/db/themes')
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
-const { startWorker, stopWorker, setMainWindow, workerStatus } = require('./worker/index');
+const { startWorker, stopWorker, setMainWindow, workerStatus, reindexAll, reindexEntry } = require('./worker/index');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -304,6 +304,19 @@ app.whenReady().then(async () => {
 ipcMain.handle('status:get', async () => {
   const ollama = await getOllamaStatus();
   return { worker: workerStatus(), ollama };
+});
+
+// ── Reindex IPC ───────────────────────────────────────────────────────────
+
+// Clears ALL embeddings so the worker re-processes every entry
+ipcMain.handle('worker:reindex-all', async () => {
+  return reindexAll();
+});
+
+// Clears the embedding for a single entry so the worker re-processes it
+ipcMain.handle('worker:reindex-entry', async (_e, { id }) => {
+  if (!id) return { ok: false, error: 'Missing id' };
+  return reindexEntry(id);
 });
 
 // ── Settings IPC ──────────────────────────────────────────────────────────

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCat
 const { setTagsForEntry, listTags, listTagsWithCounts, renameTag, deleteTag, mergeTag, findSimilarTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags, listEntriesFiltered, listCategoriesWithCounts } = require('./backend/db/search');
 const { searchNearest } = require('./backend/vector/store');
+const { getEmbedding } = require('./backend/db/embeddings');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
 const { listThemes, getThemeById, renameTheme } = require('./backend/db/themes');
@@ -87,7 +88,21 @@ ipcMain.handle('library:search-semantic', async (_event, { query, topN = 10 }) =
   return { ok: true, results: entries.filter(Boolean) };
 });
 
-// Get a single entry with its tags
+// Semantic neighbours — find entries similar to a given entry (no Ollama needed)
+ipcMain.handle('library:similar-entries', async (_event, { id, topN = 8 }) => {
+  const emb = await getEmbedding(id);
+  if (!emb) return { ok: false, reason: 'no_embedding', results: [] };
+  // topN + 1 so we can exclude the source entry itself
+  const hits = await searchNearest(emb.vector, topN + 1);
+  const neighbours = hits.filter((h) => h.entry_id !== id).slice(0, topN);
+  const entries = await Promise.all(
+    neighbours.map(async (h) => {
+      const entry = await getEntryWithTags(h.entry_id);
+      return entry ? { ...entry, _distance: h._distance } : null;
+    })
+  );
+  return { ok: true, results: entries.filter(Boolean) };
+});
 ipcMain.handle('library:get-entry', async (_event, { id }) => {
   return getEntryWithTags(id);
 });

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -10,9 +10,9 @@
  * Never blocks the UI — all operations are async with await.
  */
 
-const { listEntriesWithoutEmbedding, upsertEmbedding } = require('../backend/db/embeddings');
+const { listEntriesWithoutEmbedding, upsertEmbedding, deleteEmbedding, clearAllEmbeddings } = require('../backend/db/embeddings');
 const { getEntryById, updateEntryCategory, listEntriesWithoutCategory } = require('../backend/db/entries');
-const { upsertVector } = require('../backend/vector/store');
+const { upsertVector, deleteVector, clearAllVectors } = require('../backend/vector/store');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, classifyEntry } = require('./ollama');
 const { runClustering } = require('../backend/clustering/themes');
 const { getSettings } = require('../backend/settings');
@@ -215,4 +215,29 @@ function setMainWindow(webContents) {
   _webContents = webContents;
 }
 
-module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus, setMainWindow, getOllamaStatus };
+/**
+ * Clear embeddings for ALL entries so the worker re-processes everything.
+ * Returns the number of entries queued for reindex.
+ */
+async function reindexAll() {
+  await clearAllEmbeddings();
+  await clearAllVectors();
+  _embeddedSinceCluster = 0;
+  // Kick off an immediate batch so the status bar updates right away
+  processBatch().catch((e) => console.error('[worker] reindexAll batch error:', e.message));
+  const queued = (await listEntriesWithoutEmbedding()).length;
+  return { queued };
+}
+
+/**
+ * Clear the embedding for a single entry so the worker re-processes it.
+ * @param {string} entryId
+ */
+async function reindexEntry(entryId) {
+  await deleteEmbedding(entryId);
+  await deleteVector(entryId);
+  processBatch().catch((e) => console.error('[worker] reindexEntry batch error:', e.message));
+  return { ok: true };
+}
+
+module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus, setMainWindow, getOllamaStatus, reindexAll, reindexEntry };

--- a/website/library.html
+++ b/website/library.html
@@ -142,7 +142,39 @@
     <li>Source and type metadata (if edited, the edit timestamp is shown alongside the capture time)</li>
     <li>All tags as clickable pills — clicking a tag applies that tag filter to the timeline</li>
     <li><strong>Category badge</strong> — the effective category (auto or user-set); click the badge to open a dropdown and override it manually</li>
-    <li><strong>Suggest tags</strong> button — asks the LLM (via Ollama) to suggest tags for this entry; each suggestion appears as a pill you can click to add. Requires Ollama to be running.</li>
+    <li><strong>Tag suggestions</strong> — if Ollama is running, suggested tags appear below the tag editor as pills you can click to add</li>
+    <li><strong>Similar entries</strong> — a collapsible section at the bottom of the panel listing conceptually related entries (see below)</li>
+  </ul>
+
+  <h3 id="similar-entries">Similar entries</h3>
+  <p>
+    At the bottom of every entry's detail panel is a collapsed <strong>Similar entries</strong> section. Click the header to expand it and see up to 8 entries that are semantically close to the one you're reading.
+  </p>
+
+  <h4>How similarity is measured</h4>
+  <p>
+    Similarity is based on <strong>meaning, not wording</strong>. When an entry is saved, the background worker passes its text through the <code>nomic-embed-text</code> embedding model, which produces a 768-dimensional vector encoding the conceptual content of the entry. To find similar entries, Neurologue looks up the stored vector for the selected entry and searches for the nearest neighbours in the vector database — no additional Ollama call is needed.
+  </p>
+  <p>
+    This means:
+  </p>
+  <ul>
+    <li>Two entries can be highly similar even if they share <em>no words in common</em> — what matters is whether they are about the same idea or topic.</li>
+    <li>Entries that share words but are about different things will <em>not</em> be considered similar.</li>
+    <li>Similarity is <em>not</em> sentiment — an anxious note and a calm note about the same topic will still rank as similar.</li>
+  </ul>
+
+  <h4>The similarity percentage</h4>
+  <p>
+    Each card shows a percentage derived from the vector distance between the two entries. It is an approximate indicator — use it as a rough guide rather than a precise score. 80%+ generally indicates strong topical overlap; below 50% the connection may be loose.
+  </p>
+
+  <h4>Requirements and limitations</h4>
+  <ul>
+    <li>Only entries that have been processed by the background worker (and therefore have an embedding) can appear in the list. Newly captured entries may not appear until the worker has run.</li>
+    <li>A working Ollama installation is <em>not</em> required to view similar entries — the lookup uses stored embeddings. Ollama is only needed to <em>generate</em> new embeddings for future entries.</li>
+    <li>The section is hidden if no embedding exists for the selected entry, or if no similar entries are found.</li>
+    <li>Result count (currently 8) and similarity threshold are not user-configurable in this version.</li>
   </ul>
 
   <h3 id="editing">Editing an entry</h3>
@@ -188,9 +220,9 @@
     <li><strong>Broad</strong> — flags loosely related tags (may include false positives)</li>
   </ul>
 
-  <h2>Theme sidebar</h2>
+  <h2>Themes view</h2>
   <p>
-    Below the tag list is a <strong>Themes</strong> section. This lists all auto-generated theme clusters. Click any theme to open its detail view in the right panel. See the <a href="themes.html">Themes</a> section for more.
+    The <strong>Themes</strong> item in the left navigation rail opens a dedicated Themes view with a full two-column layout for browsing and managing your theme clusters. See the <a href="themes.html">Themes</a> page for full details.
   </p>
 
   <h2 id="settings">Settings</h2>

--- a/website/themes.html
+++ b/website/themes.html
@@ -31,7 +31,7 @@
     A <strong>theme</strong> is a group of entries that are semantically similar — they're about the same subject, even if you never labelled them that way. Neurologue discovers themes automatically by running k-means clustering on your entry embeddings.
   </p>
   <p>
-    Once clusters are found, Neurologue sends the top entries from each cluster to a local LLM (Phi-3 Mini via Ollama) and asks it to write a short natural-language summary. That summary becomes the theme's description.
+    Once clusters are found, Neurologue sends the top entries from each cluster to a local LLM (Phi-3 Mini via Ollama) to generate two things: a short descriptive <strong>name</strong> (2–4 words, title case) and a multi-sentence <strong>summary</strong> of the cluster. Both are stored and displayed in the Themes view.
   </p>
 
   <div class="callout">
@@ -58,7 +58,7 @@
     </li>
     <li>
       <div>
-        <p><strong>LLM summaries</strong> — Neurologue sends the top 5 entries from each cluster to Phi-3 Mini and asks for a short summary. This becomes the theme description. If Ollama is unavailable, themes are still created but show "No summary yet" until Ollama comes back.</p>
+        <p><strong>LLM name and summary</strong> — Neurologue sends the top 5 entries from each cluster to Phi-3 Mini and makes two requests: one for a 2–4 word descriptive name (replacing the generic "Theme N" placeholder), and one for a 3–5 sentence summary. Both fail gracefully — if Ollama is unavailable, themes are still created with a placeholder name and "No summary yet" until Ollama comes back.</p>
       </div>
     </li>
   </ol>
@@ -88,19 +88,31 @@
   </table>
 
   <div class="callout warning">
-    <p><strong>There is currently no visible indicator</strong> that the background worker is running or that clustering is in progress. If themes don't appear, check that Ollama is running and you have at least 4 captured entries. See <a href="troubleshooting.html">Troubleshooting</a>.</p>
+    <p><strong>There is currently no visible progress indicator</strong> for clustering. If themes don't appear, check that Ollama is running, you have at least 4 captured entries, and wait for the background worker to finish embedding them. See <a href="troubleshooting.html">Troubleshooting</a>.</p>
   </div>
 
   <h2>Viewing themes</h2>
   <p>
-    Themes appear in the <strong>Themes</strong> section of the left sidebar in the library. Each theme is listed by name (e.g. "Theme 1", "Theme 2").
+    Click <strong>Themes</strong> in the left navigation rail to open the dedicated Themes view. The view has two columns:
   </p>
-  <p>Click a theme to open the theme detail panel on the right, which shows:</p>
   <ul>
-    <li><strong>Theme name</strong></li>
-    <li><strong>Summary</strong> — the LLM-generated description, or a placeholder if not yet generated</li>
-    <li><strong>Member entries</strong> — up to 20 entries from the cluster, sorted by similarity score (how close each entry is to the cluster centre). Click any entry to jump to its full detail view.</li>
+    <li><strong>Left column</strong> — the full list of themes, each showing its name and entry count, sorted by size (largest first). The active theme is highlighted.</li>
+    <li><strong>Right column</strong> — the selected theme's detail: name, summary, and up to 30 member entries sorted by similarity score.</li>
   </ul>
+  <p>Click any member entry to jump directly to that entry in the Library view.</p>
+
+  <h2>Theme names</h2>
+  <p>
+    When Ollama is available, each theme is automatically given a short descriptive name by the LLM (e.g. <em>"Meal Planning Ideas"</em> or <em>"Work Stress Reflections"</em>). Without Ollama, themes fall back to placeholder names like <em>"Theme 1"</em>.
+  </p>
+
+  <h3>Renaming a theme</h3>
+  <p>
+    You can override the LLM-generated name with your own. Click the <strong>✎</strong> (pencil) button next to the theme name to open the rename form. Type a new name and press <kbd>Enter</kbd> or <strong>Save</strong>. Press <kbd>Escape</kbd> or <strong>Cancel</strong> to discard.
+  </p>
+  <p>
+    User-set names are <strong>preserved across re-clustering</strong> — even when themes are regenerated as you add new entries, your custom name is kept.
+  </p>
 
   <h2>Understanding the similarity score</h2>
   <p>


### PR DESCRIPTION
## Summary

Closes #49

Stacks several related features onto the 0.4.x Cognitive Layer milestone.

---

### ✨ Similar entries (semantic neighbours) — #49

Adds a collapsible **Similar entries** section to every entry's detail panel.

- Looks up the stored embedding for the selected entry and finds the 8 nearest neighbours in LanceDB — no live Ollama call needed
- Similarity is **meaning-based** (nomic-embed-text embeddings), not keyword or sentiment matching
- Shows a similarity % derived from the L2 vector distance
- Section stays hidden until the async lookup resolves; only shown when there is something to display
- If the entry has no embedding yet, shows an **'Embed now'** button to queue it immediately

### 🔄 Reindex / re-embed on demand

- **Settings → Data tab → 'Reindex all entries'** — clears all SQLite embeddings and LanceDB vectors, then kicks an immediate worker batch to re-queue everything. Useful after switching embedding models
- **'Embed now' button** on unembedded entries — clears and re-queues just that entry

Backend:
- \embeddings.js\: \clearAllEmbeddings()\
- \ector/store.js\: \clearAllVectors()\
- \worker/index.js\: \eindexAll()\, \eindexEntry(id)\
- \main.js\: \worker:reindex-all\, \worker:reindex-entry\ IPC handlers

### ⚙️ Tabbed Settings modal

Replaces the single tall settings form (which could overflow at non-maximised window sizes) with a four-tab layout:

| Tab | Contents |
|-----|----------|
| **Models** | Embedding model, LLM model |
| **Tags** | Multi-word format, duplicate detection sensitivity |
| **Hotkey** | Global capture shortcut |
| **Data** | Reindex all entries |

Modal always opens on the **Models** tab.

### 📄 Website documentation

- \website/library.html\: new **Similar entries** section explaining semantic vs wording vs sentiment similarity, the % approximation, requirements and limitations; updated stale Theme sidebar reference
- \website/themes.html\: updated for LLM-generated names, two-column Themes view, rename feature, multi-sentence summaries

---

### Tests

186/186 passing ✅