### PR TITLE
feat: export formats — Markdown bundle, JSONL, Vector DB (#51)

### DIFF
--- a/src/backend/export/formatters.js
+++ b/src/backend/export/formatters.js
@@ -95,6 +95,29 @@ function themesToMarkdown(themes) {
   return lines.join('\n');
 }
 
+// ── Entries JSONL ─────────────────────────────────────────────────────────────
+
+/**
+ * Serialise entries to JSONL — one full entry object per line.
+ * Suitable for LLM fine-tuning pipelines and bulk ingest tools.
+ * @param {object[]} entries
+ * @returns {string}
+ */
+function entriesToJsonl(entries) {
+  return entries
+    .map((e) => JSON.stringify({
+      id: e.id,
+      content: e.content,
+      source: e.source || 'manual',
+      type: e.type || 'note',
+      category: e.user_category || e.category || null,
+      created_at: e.created_at,
+      edited_at: e.edited_at || null,
+      tags: (e.tags || []).map((t) => t.name),
+    }))
+    .join('\n');
+}
+
 // ── Embeddings JSONL ───────────────────────────────────────────────────────────
 
 /**
@@ -112,6 +135,57 @@ function embeddingsToJsonl(embeddings) {
     .join('\n');
 }
 
+// ── Markdown bundle helpers ───────────────────────────────────────────────────
+
+/**
+ * Produce the content for a single per-entry Markdown file with YAML frontmatter.
+ * @param {object} entry
+ * @returns {string}
+ */
+function entryToMarkdownFile(entry) {
+  const tags = (entry.tags || []).map((t) => t.name);
+  const category = entry.user_category || entry.category || null;
+  const lines = [
+    '---',
+    `id: ${entry.id}`,
+    `created_at: "${entry.created_at}"`,
+  ];
+  if (entry.edited_at) lines.push(`edited_at: "${entry.edited_at}"`);
+  if (category) lines.push(`category: ${category}`);
+  if (tags.length > 0) lines.push(`tags: [${tags.map((t) => `"${t}"`).join(', ')}]`);
+  lines.push(`source: ${entry.source || 'manual'}`);
+  lines.push('---');
+  lines.push('');
+  lines.push(entry.content);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Build an index.md linking all per-entry files, grouped by date.
+ * @param {object[]} entries  Must be sorted newest-first.
+ * @param {Map<string, string>} filenameMap  entry.id → filename
+ * @returns {string}
+ */
+function buildMarkdownIndex(entries, filenameMap) {
+  const lines = ['# Neurologue — Entry Index', ''];
+  let lastDate = null;
+  for (const e of entries) {
+    const dateStr = (e.created_at || '').slice(0, 10);
+    if (dateStr !== lastDate) {
+      if (lastDate !== null) lines.push('');
+      lines.push(`## ${dateStr}`);
+      lines.push('');
+      lastDate = dateStr;
+    }
+    const filename = filenameMap.get(e.id) || `${e.id}.md`;
+    const preview = (e.content || '').slice(0, 80).replace(/\n/g, ' ');
+    lines.push(`- [${preview}…](./${filename})`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function formatDate(dateStr) {
@@ -120,4 +194,13 @@ function formatDate(dateStr) {
   return d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
 }
 
-module.exports = { entriesToJson, themesToJson, entriesToMarkdown, themesToMarkdown, embeddingsToJsonl };
+module.exports = {
+  entriesToJson,
+  entriesToJsonl,
+  themesToJson,
+  entriesToMarkdown,
+  themesToMarkdown,
+  embeddingsToJsonl,
+  entryToMarkdownFile,
+  buildMarkdownIndex,
+};

--- a/src/backend/export/runner.js
+++ b/src/backend/export/runner.js
@@ -109,7 +109,9 @@ async function runExport(destDir, { formats = ['json', 'jsonl', 'markdown', 'mar
       const safeName = (t.display_name || t.name)
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '');
+        .replace(/^-|-$/g, '')
+        .slice(0, 60)          // guard against Windows MAX_PATH on long AI names
+        .replace(/-+$/, '');   // strip any trailing dash after truncation
       const themePath = path.join(themeMdDir, `${safeName}.md`);
       const themeLines = [
         `# ${t.display_name || t.name}`,

--- a/src/backend/export/runner.js
+++ b/src/backend/export/runner.js
@@ -4,51 +4,56 @@
  * Export runner — fetches all data, formats it, and writes files to a
  * user-chosen directory.
  *
- * Output (all in destDir):
- *   entries.json      — all entries as JSON array
- *   entries.md        — all entries as Markdown
- *   themes.json       — themes + summaries as JSON
- *   themes.md         — themes as Markdown
- *   embeddings.jsonl  — all embeddings as JSONL (one per line)
+ * Supported formats (all enabled by default):
+ *   json           — entries.json + themes.json
+ *   jsonl          — entries.jsonl (one full entry per line)
+ *   markdown       — entries.md + themes.md (flat single-file documents)
+ *   markdownBundle — markdown/ subfolder, one .md per entry + index.md + themes/
+ *   embeddings     — embeddings.jsonl (raw vectors)
+ *   vectorDb       — vectors/ subfolder (copy of the LanceDB store)
  */
 
-const fs = require('fs');
+const fs   = require('fs');
 const path = require('path');
 const { openDb } = require('../db/connection');
 const { getEntryWithTags } = require('../db/search');
 const { listThemes, getEntriesForTheme } = require('../db/themes');
+const config = require('../../config');
 const {
   entriesToJson,
+  entriesToJsonl,
   themesToJson,
   entriesToMarkdown,
   themesToMarkdown,
   embeddingsToJsonl,
+  entryToMarkdownFile,
+  buildMarkdownIndex,
 } = require('./formatters');
 
 /**
- * Run a full export to destDir.
+ * Run an export to destDir.
  *
  * @param {string} destDir  Absolute path to the destination directory
  * @param {object} [opts]
- * @param {boolean} [opts.includeEmbeddings=true]
- * @returns {Promise<{ files: string[], entryCount: number, themeCount: number, embeddingCount: number }>}
+ * @param {string[]} [opts.formats]  Which formats to include. Defaults to all.
+ *   Possible values: 'json', 'jsonl', 'markdown', 'markdownBundle', 'embeddings', 'vectorDb'
+ * @returns {Promise<{
+ *   files: string[],
+ *   entryCount: number,
+ *   themeCount: number,
+ *   embeddingCount: number
+ * }>}
  */
-async function runExport(destDir, { includeEmbeddings = true } = {}) {
+async function runExport(destDir, { formats = ['json', 'jsonl', 'markdown', 'markdownBundle', 'embeddings', 'vectorDb'] } = {}) {
   fs.mkdirSync(destDir, { recursive: true });
 
   const db = await openDb();
+  const files = [];
 
-  // ── 1. Entries ────────────────────────────────────────────────────────────
+  // ── Common data ───────────────────────────────────────────────────────────
   const rawEntries = db.prepare('SELECT * FROM entries ORDER BY created_at DESC').all();
+  const entries = (await Promise.all(rawEntries.map((e) => getEntryWithTags(e.id)))).filter(Boolean);
 
-  // Enrich with tags
-  const entries = await Promise.all(rawEntries.map((e) => getEntryWithTags(e.id)));
-  const validEntries = entries.filter(Boolean);
-
-  write(destDir, 'entries.json', entriesToJson(validEntries));
-  write(destDir, 'entries.md', entriesToMarkdown(validEntries));
-
-  // ── 2. Themes ─────────────────────────────────────────────────────────────
   const themes = await listThemes();
   const enrichedThemes = await Promise.all(
     themes.map(async (t) => {
@@ -57,31 +62,100 @@ async function runExport(destDir, { includeEmbeddings = true } = {}) {
     })
   );
 
-  write(destDir, 'themes.json', themesToJson(enrichedThemes));
-  write(destDir, 'themes.md', themesToMarkdown(enrichedThemes));
+  // ── JSON ──────────────────────────────────────────────────────────────────
+  if (formats.includes('json')) {
+    write(destDir, 'entries.json', entriesToJson(entries));
+    write(destDir, 'themes.json', themesToJson(enrichedThemes));
+    files.push('entries.json', 'themes.json');
+  }
 
-  // ── 3. Embeddings ─────────────────────────────────────────────────────────
+  // ── JSONL ─────────────────────────────────────────────────────────────────
+  if (formats.includes('jsonl')) {
+    write(destDir, 'entries.jsonl', entriesToJsonl(entries));
+    files.push('entries.jsonl');
+  }
+
+  // ── Flat Markdown ─────────────────────────────────────────────────────────
+  if (formats.includes('markdown')) {
+    write(destDir, 'entries.md', entriesToMarkdown(entries));
+    write(destDir, 'themes.md', themesToMarkdown(enrichedThemes));
+    files.push('entries.md', 'themes.md');
+  }
+
+  // ── Markdown bundle ───────────────────────────────────────────────────────
+  if (formats.includes('markdownBundle')) {
+    const mdDir = path.join(destDir, 'markdown');
+    const themeMdDir = path.join(mdDir, 'themes');
+    fs.mkdirSync(themeMdDir, { recursive: true });
+
+    // One file per entry: YYYY-MM-DD-<id-prefix>.md
+    const filenameMap = new Map();
+    for (const entry of entries) {
+      const datePrefix = (entry.created_at || '').slice(0, 10) || 'undated';
+      const filename = `${datePrefix}-${entry.id.slice(0, 8)}.md`;
+      filenameMap.set(entry.id, filename);
+      const filePath = path.join(mdDir, filename);
+      fs.writeFileSync(filePath, entryToMarkdownFile(entry), 'utf8');
+      files.push(path.relative(destDir, filePath));
+    }
+
+    // index.md
+    const indexPath = path.join(mdDir, 'index.md');
+    fs.writeFileSync(indexPath, buildMarkdownIndex(entries, filenameMap), 'utf8');
+    files.push(path.relative(destDir, indexPath));
+
+    // One theme file per theme: themes/<name>.md
+    for (const t of enrichedThemes) {
+      const safeName = (t.display_name || t.name)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      const themePath = path.join(themeMdDir, `${safeName}.md`);
+      const themeLines = [
+        `# ${t.display_name || t.name}`,
+        '',
+        t.description ? `> ${t.description}` : '',
+        '',
+        '## Entries',
+        '',
+        ...(t.entries || []).map((e) => {
+          const fn = filenameMap.get(e.entry_id || e.id);
+          const preview = (e.content || '').slice(0, 80).replace(/\n/g, ' ');
+          return fn ? `- [${preview}…](../${fn})` : `- ${preview}…`;
+        }),
+        '',
+      ];
+      fs.writeFileSync(themePath, themeLines.join('\n'), 'utf8');
+      files.push(path.relative(destDir, themePath));
+    }
+  }
+
+  // ── Embeddings JSONL ──────────────────────────────────────────────────────
   let embeddingCount = 0;
-  if (includeEmbeddings) {
+  if (formats.includes('embeddings')) {
     const embRows = db.prepare('SELECT entry_id, vector, model_name FROM embeddings').all();
     const embeddings = embRows.map((r) => {
       const bytes = new Uint8Array(r.vector);
-      return {
-        entry_id: r.entry_id,
-        model_name: r.model_name,
-        vector: new Float32Array(bytes.buffer),
-      };
+      return { entry_id: r.entry_id, model_name: r.model_name, vector: new Float32Array(bytes.buffer) };
     });
     write(destDir, 'embeddings.jsonl', embeddingsToJsonl(embeddings));
     embeddingCount = embeddings.length;
+    files.push('embeddings.jsonl');
   }
 
-  const files = ['entries.json', 'entries.md', 'themes.json', 'themes.md'];
-  if (includeEmbeddings) files.push('embeddings.jsonl');
+  // ── Vector DB folder ──────────────────────────────────────────────────────
+  if (formats.includes('vectorDb')) {
+    const srcDir = config.vectorStore.path;
+    if (fs.existsSync(srcDir)) {
+      const destVecDir = path.join(destDir, 'vectors');
+      copyDirRecursive(srcDir, destVecDir);
+      files.push('vectors/');
+    }
+  }
 
   return {
-    files: files.map((f) => path.join(destDir, f)),
-    entryCount: validEntries.length,
+    files: files.map((f) => (path.isAbsolute(f) ? f : path.join(destDir, f))),
+    entryCount: entries.length,
     themeCount: enrichedThemes.length,
     embeddingCount,
   };
@@ -89,6 +163,19 @@ async function runExport(destDir, { includeEmbeddings = true } = {}) {
 
 function write(dir, filename, content) {
   fs.writeFileSync(path.join(dir, filename), content, 'utf8');
+}
+
+function copyDirRecursive(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath  = path.join(src,  entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
 }
 
 module.exports = { runExport };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -464,6 +464,53 @@
     </div>
   </div>
 
+  <!-- ── Export modal ──────────────────────────────────────────────────────── -->
+  <div id="export-modal" class="modal-overlay hidden">
+    <div class="modal-box modal-box--export">
+      <button class="modal-close" id="export-modal-close" title="Cancel">✕</button>
+      <h2 class="modal-title">Export your data</h2>
+      <p class="export-modal-desc">Choose the formats to include in the export.</p>
+
+      <div class="export-format-list">
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="json" checked />
+          <span class="export-fmt-label">JSON files</span>
+          <span class="export-fmt-desc">entries.json + themes.json</span>
+        </label>
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="jsonl" checked />
+          <span class="export-fmt-label">JSONL</span>
+          <span class="export-fmt-desc">entries.jsonl — one entry per line, LLM-ready</span>
+        </label>
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="markdown" checked />
+          <span class="export-fmt-label">Markdown (flat)</span>
+          <span class="export-fmt-desc">entries.md + themes.md — single documents</span>
+        </label>
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="markdownBundle" checked />
+          <span class="export-fmt-label">Markdown bundle</span>
+          <span class="export-fmt-desc">markdown/ folder — one file per entry with frontmatter + index</span>
+        </label>
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="embeddings" />
+          <span class="export-fmt-label">Embeddings JSONL</span>
+          <span class="export-fmt-desc">embeddings.jsonl — raw vectors (large file)</span>
+        </label>
+        <label class="export-format-row">
+          <input type="checkbox" class="export-fmt-check" value="vectorDb" />
+          <span class="export-fmt-label">Vector DB copy</span>
+          <span class="export-fmt-desc">vectors/ folder — LanceDB store snapshot</span>
+        </label>
+      </div>
+
+      <div class="export-modal-actions">
+        <button id="btn-export-cancel" class="btn-secondary">Cancel</button>
+        <button id="btn-export-confirm" class="btn-primary">Choose folder…</button>
+      </div>
+    </div>
+  </div>
+
   <script src="library.js"></script>
 </body>
 </html>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2001,3 +2001,72 @@ html, body {
 .tag-mgmt-empty { font-size: 13px; color: var(--text-muted); padding: 16px 0; text-align: center; }
 .tag-mgmt-empty.hidden { display: none; }
 #tag-similar-section.hidden { display: none; }
+
+/* ── Export modal ────────────────────────────────────────────────────────── */
+.modal-box--export { max-width: 460px; }
+
+.modal-title {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.export-modal-desc {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin: 0 0 16px;
+}
+
+.export-format-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 20px;
+}
+
+.export-format-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+.export-format-row:hover { background: var(--surface2); border-color: var(--border); }
+
+.export-fmt-check { flex-shrink: 0; cursor: pointer; accent-color: var(--cortex-teal); }
+
+.export-fmt-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  min-width: 140px;
+}
+
+.export-fmt-desc {
+  font-size: 11px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.export-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.btn-primary {
+  background: var(--cortex-teal);
+  border: 1px solid var(--cortex-teal);
+  color: #fff;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 18px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.1s;
+}
+.btn-primary:hover { background: var(--teal-hover, #1ab8a0); }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1045,7 +1045,7 @@ document.getElementById('btn-history-export').addEventListener('click', async ()
   }
 });
 
-// ── Export ─────────────────────────────────────────────────────────────────
+// ── Export modal ────────────────────────────────────────────────────────────
 
 let _exportToastTimer = null;
 
@@ -1057,16 +1057,43 @@ function showToast(message, type = 'success') {
   _exportToastTimer = setTimeout(() => { exportToast.style.display = 'none'; }, 5000);
 }
 
-exportBtn.addEventListener('click', async () => {
+const exportModal      = document.getElementById('export-modal');
+const exportModalClose = document.getElementById('export-modal-close');
+const exportCancelBtn  = document.getElementById('btn-export-cancel');
+const exportConfirmBtn = document.getElementById('btn-export-confirm');
+const exportFmtChecks  = () => [...document.querySelectorAll('.export-fmt-check')];
+
+function openExportModal() { exportModal.classList.remove('hidden'); }
+function closeExportModal() { exportModal.classList.add('hidden'); }
+
+exportBtn.addEventListener('click', openExportModal);
+exportModalClose.addEventListener('click', closeExportModal);
+exportCancelBtn.addEventListener('click', closeExportModal);
+
+exportModal.addEventListener('click', (e) => {
+  if (e.target === exportModal) closeExportModal();
+});
+
+exportConfirmBtn.addEventListener('click', async () => {
+  const formats = exportFmtChecks()
+    .filter((cb) => cb.checked)
+    .map((cb) => cb.value);
+
+  if (formats.length === 0) {
+    showToast('Select at least one format.', 'error');
+    return;
+  }
+
+  closeExportModal();
   exportBtn.disabled = true;
   exportBtn.textContent = 'Exporting…';
   try {
-    const result = await window.neurologue.exportAll({ includeEmbeddings: true });
+    const result = await window.neurologue.exportAll({ formats });
     if (result.canceled) {
       showToast('Export cancelled.', 'success');
     } else {
       showToast(
-        `Exported ${result.entryCount} entries, ${result.themeCount} themes to ${result.destDir}`,
+        `Exported ${result.entryCount} entries, ${result.themeCount} themes → ${result.destDir}`,
         'success'
       );
     }

--- a/src/main.js
+++ b/src/main.js
@@ -293,7 +293,7 @@ ipcMain.handle('ollama:open-download', () => {
 // ── Export IPC ───────────────────────────────────────────────────────────────
 
 // Show native folder picker and run export to chosen directory
-ipcMain.handle('export:run', async (_event, { includeEmbeddings = true } = {}) => {
+ipcMain.handle('export:run', async (_event, { formats } = {}) => {
   const { dialog } = require('electron');
   const win = BrowserWindow.getFocusedWindow();
   const { canceled, filePaths } = await dialog.showOpenDialog(win || undefined, {
@@ -303,7 +303,7 @@ ipcMain.handle('export:run', async (_event, { includeEmbeddings = true } = {}) =
   if (canceled || !filePaths || filePaths.length === 0) {
     return { canceled: true };
   }
-  const result = await runExport(filePaths[0], { includeEmbeddings });
+  const result = await runExport(filePaths[0], { formats });
   return { canceled: false, destDir: filePaths[0], ...result };
 });
 

--- a/tests/unit/export/runner.test.js
+++ b/tests/unit/export/runner.test.js
@@ -106,10 +106,10 @@ describe('runExport', () => {
     expect(lines).toHaveLength(2);
   });
 
-  test('skips embeddings.jsonl when includeEmbeddings=false', async () => {
+  test('skips embeddings.jsonl when embeddings format not requested', async () => {
     const { runExport } = require('../../../src/backend/export/runner');
     await seedData();
-    const result = await runExport(exportDir, { includeEmbeddings: false });
+    const result = await runExport(exportDir, { formats: ['json', 'markdown'] });
     expect(fs.existsSync(path.join(exportDir, 'embeddings.jsonl'))).toBe(false);
     expect(result.embeddingCount).toBe(0);
     expect(result.files).not.toContain(path.join(exportDir, 'embeddings.jsonl'));


### PR DESCRIPTION
Closes #51

## What's new

### New export formats
- **JSONL** — entries.jsonl: one full entry per line (id, content, source, type, category, created_at, tags), ready for LLM fine-tuning pipelines
- **Markdown bundle** — markdown/ subfolder: one .md per entry with YAML frontmatter (id, created_at, tags, category), index.md linking all entries by date, markdown/themes/<name>.md per theme with description and entry links
- **Vector DB copy** — ectors/ subfolder: recursive copy of the LanceDB store for portability

### Format selection modal
Replaces the old fire-and-go Export button with a modal dialog letting the user choose which formats to include. Defaults: JSON, JSONL, flat Markdown, Markdown bundle. Optional (off by default): Embeddings JSONL, Vector DB copy.

### API change
unExport(destDir, { formats[] }) replaces { includeEmbeddings }. Valid format keys: json, jsonl, markdown, markdownBundle, embeddings, ectorDb. Default is all formats.

## Tests
All 186 tests pass.