### PR TITLE
feat: light/dark theme toggle (Appearance tab)

### DIFF
--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -16,7 +16,7 @@ const config = require('../config');
 
 const SETTINGS_PATH = config.settings.path;
 
-/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string, tagSuggestionFormat: string, tagSimilarityThreshold: number, workerIntervals: object }} */
+/** @type {{ embeddingModel: string, llmModel: string, captureHotkey: string, tagSuggestionFormat: string, tagSimilarityThreshold: number, workerIntervals: object, theme: string }} */
 const DEFAULTS = {
   embeddingModel:         config.ollama.embeddingModel,
   llmModel:               config.ollama.llmModel,
@@ -28,6 +28,7 @@ const DEFAULTS = {
     clustering:    300,  // seconds between clustering runs (also triggers theming)
     contradiction: 900,  // seconds between contradiction scan runs
   },
+  theme: 'dark',          // 'dark' | 'light'
 };
 
 /**

--- a/src/frontend/capture-preload.js
+++ b/src/frontend/capture-preload.js
@@ -15,4 +15,7 @@ contextBridge.exposeInMainWorld('capture', {
 
   /** Close the popup without saving. */
   close: () => ipcRenderer.send('capture:close'),
+
+  /** Read persisted settings. */
+  getSettings: () => ipcRenderer.invoke('settings:get'),
 });

--- a/src/frontend/capture.html
+++ b/src/frontend/capture.html
@@ -27,6 +27,15 @@
       --font:         'Inter', system-ui, sans-serif;
     }
 
+    [data-theme="dark"] {
+      --ink:    #E8EFF5;
+      --slate:  #7a9ab5;
+      --fog:    #2a3d52;
+      --cloud:  #192534;
+      --white:  #1f2f40;
+      --neuro-blue: #0F1923;
+    }
+
     html, body {
       width: 100%;
       height: 100%;

--- a/src/frontend/capture.js
+++ b/src/frontend/capture.js
@@ -343,3 +343,8 @@ function hideError() {
 }
 
 contentEl.focus();
+
+// Apply persisted theme
+window.capture.getSettings().then((s) => {
+  document.documentElement.setAttribute('data-theme', (s && s.theme) || 'dark');
+});

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -398,8 +398,9 @@
         <button class="settings-tab active" data-tab="models" role="tab" aria-selected="true">Models</button>
         <button class="settings-tab" data-tab="tags"    role="tab" aria-selected="false">Tags</button>
         <button class="settings-tab" data-tab="hotkey"  role="tab" aria-selected="false">Hotkey</button>
-        <button class="settings-tab" data-tab="worker"  role="tab" aria-selected="false">Worker</button>
-        <button class="settings-tab" data-tab="data"    role="tab" aria-selected="false">Data</button>
+        <button class="settings-tab" data-tab="worker"     role="tab" aria-selected="false">Worker</button>
+        <button class="settings-tab" data-tab="appearance" role="tab" aria-selected="false">Appearance</button>
+        <button class="settings-tab" data-tab="data"       role="tab" aria-selected="false">Data</button>
       </div>
 
       <!-- Models panel -->
@@ -472,6 +473,18 @@
         <div class="settings-field">
           <label>Activity log <button id="btn-refresh-worker-log" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
           <div id="worker-log-panel" class="worker-log-panel"><span class="worker-log-empty">No tasks recorded yet.</span></div>
+        </div>
+      </div>
+
+      <!-- Appearance panel -->
+      <div class="settings-panel hidden" id="settings-tab-appearance">
+        <p class="settings-panel-desc">Choose your preferred colour scheme.</p>
+        <div class="settings-field">
+          <label>Colour scheme</label>
+          <div class="theme-toggle-group" id="theme-toggle-group">
+            <button class="theme-toggle-btn active" data-theme-value="dark">Dark</button>
+            <button class="theme-toggle-btn" data-theme-value="light">Light</button>
+          </div>
         </div>
       </div>
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -26,11 +26,19 @@
   --surface2:     #E4ECF3;
   --border:       #C5D4E0;
   --text:         #1A2C3D;
-  --text-muted:   #4A6A85;
-  --text-dim:     #8AAABF;
+  --text-muted:   #3A5A78;
+  --text-dim:     #5A7A95;
   --neuro-blue:   #DDEAF4;
   --synapse-gold: #A07820;
 }
+
+/* Category badge light-theme overrides — pale tinted backgrounds */
+[data-theme="light"] .category-badge[data-cat="Task"]     { background: #d6f0e2; border-color: #7dcda5; color: #1a6640; }
+[data-theme="light"] .category-badge[data-cat="Thought"]  { background: #d6e8f7; border-color: #7ab5dc; color: #1a4a70; }
+[data-theme="light"] .category-badge[data-cat="Reminder"] { background: #fde8d2; border-color: #e0a06a; color: #7a3a10; }
+[data-theme="light"] .category-badge[data-cat="Idea"]     { background: #fdf0d2; border-color: #d4b050; color: #6a4a08; }
+[data-theme="light"] .category-badge[data-cat="Question"] { background: #ece0f7; border-color: #b090d8; color: #4a2080; }
+[data-theme="light"] .category-badge[data-cat="Decision"] { background: #fadddd; border-color: #e09090; color: #7a1a1a; }
 
 html, body {
   height: 100%;

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -19,6 +19,19 @@
   --detail-w:     360px;
 }
 
+/* ── Light theme overrides ────────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg:           #F0F4F8;
+  --surface:      #FFFFFF;
+  --surface2:     #E4ECF3;
+  --border:       #C5D4E0;
+  --text:         #1A2C3D;
+  --text-muted:   #4A6A85;
+  --text-dim:     #8AAABF;
+  --neuro-blue:   #DDEAF4;
+  --synapse-gold: #A07820;
+}
+
 html, body {
   height: 100%;
   background: var(--bg);
@@ -2175,3 +2188,26 @@ html, body {
   outline: none;
 }
 .settings-number-input:focus { border-color: var(--cortex-teal); }
+
+/* ── Theme toggle ─────────────────────────────────────────────────────── */
+.theme-toggle-group {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-top: 4px;
+}
+.theme-toggle-btn {
+  padding: 6px 20px;
+  background: var(--surface2);
+  border: none;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.theme-toggle-btn + .theme-toggle-btn { border-left: 1px solid var(--border); }
+.theme-toggle-btn.active {
+  background: var(--cortex-teal);
+  color: #fff;
+}

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1196,6 +1196,20 @@ statusErrorBadge.addEventListener('click', () => {
 });
 
 window.neurologue.onWorkerStatus(updateStatus);
+
+// ── Theme ───────────────────────────────────────────────────────────────────
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme || 'dark');
+  document.querySelectorAll('.theme-toggle-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.themeValue === (theme || 'dark'));
+  });
+}
+
+document.querySelectorAll('.theme-toggle-btn').forEach((btn) => {
+  btn.addEventListener('click', () => applyTheme(btn.dataset.themeValue));
+});
+
 window.neurologue.onEntriesUpdated(async () => {
   await loadEntries();
   await loadTags();
@@ -1463,6 +1477,9 @@ btnSettings.addEventListener('click', async () => {
   hotkeyDisplay.dataset.saved = currentHotkey;
   hotkeyDisplay.textContent   = formatAccelerator(currentHotkey);
 
+  // Populate appearance toggle
+  applyTheme(settings.theme || 'dark');
+
   // Populate worker interval inputs
   const wi = settings.workerIntervals || {};
   const inputEmbed  = document.getElementById('input-interval-embedding');
@@ -1502,11 +1519,15 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
     _pendingHotkey = null;
   }
 
+  const selectedTheme = document.querySelector('.theme-toggle-btn.active')?.dataset.themeValue || 'dark';
+  applyTheme(selectedTheme);
+
   await window.neurologue.saveSettings({
     embeddingModel: embedModel,
     llmModel,
     tagSuggestionFormat: tagFmt,
     tagSimilarityThreshold,
+    theme: selectedTheme,
     workerIntervals: {
       embedding:     parseInt(document.getElementById('input-interval-embedding').value, 10)    || 60,
       clustering:    parseInt(document.getElementById('input-interval-clustering').value, 10)   || 300,
@@ -2299,6 +2320,10 @@ btnScan.addEventListener('click', async () => {
 // ── Init ────────────────────────────────────────────────────────────
 
 (async () => {
+  // Apply persisted theme before first paint
+  const initSettings = await window.neurologue.getSettings();
+  applyTheme(initSettings.theme || 'dark');
+
   await loadTags();
   await loadCategories();
   await loadEntries();

--- a/tests/unit/settings.test.js
+++ b/tests/unit/settings.test.js
@@ -34,6 +34,7 @@ describe('getSettings', () => {
     const s = getSettings();
     expect(s.embeddingModel).toBe('nomic-embed-text');
     expect(s.llmModel).toBe('phi3:mini');
+    expect(s.theme).toBe('dark');
   });
 
   test('returns defaults merged with saved values', () => {


### PR DESCRIPTION
Closes #97. ## Changes: - src/backend/settings.js: added theme: dark default. - src/frontend/library.css: added [data-theme=light] CSS variable overrides. - src/frontend/index.html: added Appearance settings tab. - src/frontend/library.js: applyTheme helper; theme applied on init. - src/frontend/capture-preload.js: exposed getSettings. - src/frontend/capture.html: added [data-theme=dark] override block. - src/frontend/capture.js: applies persisted theme. - tests/unit/settings.test.js: asserts theme default is dark.