### PR TITLE
feat: notes maintenance — delete entry, delete theme, IPC error visibility (#99)

### DIFF
--- a/src/backend/db/themes.js
+++ b/src/backend/db/themes.js
@@ -117,12 +117,15 @@ async function getThemeWeeklyActivity(themeId, weeks = 12) {
 }
 
 /**
- * Delete a theme by ID.
+ * Delete a theme by ID, including all its entry assignments.
  * @param {string} id
  */
 async function deleteTheme(id) {
   const db = await openDb();
-  db.prepare('DELETE FROM themes WHERE id = ?').run(id);
+  db.transaction(() => {
+    db.prepare('DELETE FROM theme_entries WHERE theme_id = ?').run(id);
+    db.prepare('DELETE FROM themes WHERE id = ?').run(id);
+  })();
 }
 
 /**

--- a/src/backend/vector/store.js
+++ b/src/backend/vector/store.js
@@ -54,12 +54,15 @@ async function upsertVector(entryId, vector, modelName) {
 async function searchNearest(queryVector, topN = 10) {
   if (!_table) throw new Error('Vector store not initialised. Call initVectorStore() first.');
 
-  const results = await _table
+  const raw = await _table
     .search(Array.from(queryVector))
     .limit(topN)
     .execute();
 
-  return results;
+  // LanceDB 0.17+ may return an Arrow Table rather than a plain array
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw.toArray === 'function') return raw.toArray();
+  return Array.from(raw);
 }
 
 /**

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -180,6 +180,7 @@
             <div id="detail-footer-read">
               <button id="btn-edit" class="btn-secondary">Edit</button>
               <button id="btn-history" class="btn-secondary">History</button>
+              <button id="btn-delete-entry" class="btn-danger">Delete</button>
             </div>
             <div id="detail-footer-history" style="display:none">
               <button id="btn-history-back" class="btn-secondary">← Back</button>
@@ -219,6 +220,7 @@
                 <div id="themes-detail-name-row">
                   <div id="themes-detail-name"></div>
                   <button id="themes-btn-rename" class="btn-icon-sm" title="Rename theme">✎</button>
+                  <button id="themes-btn-delete" class="btn-icon-sm btn-icon-danger" title="Delete theme">🗑</button>
                 </div>
                 <!-- Inline rename form (hidden by default) -->
                 <div id="themes-rename-form">

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -863,6 +863,19 @@ html, body {
 .btn-secondary:hover { border-color: var(--cortex-teal); color: var(--text); }
 .btn-secondary.active { border-color: var(--cortex-teal); color: var(--cortex-teal); }
 
+.btn-danger {
+  background: transparent;
+  border: 1px solid var(--danger);
+  color: var(--danger);
+  border-radius: var(--radius);
+  font-size: 12px;
+  padding: 4px 12px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.1s, color 0.1s;
+}
+.btn-danger:hover { background: var(--danger); color: #fff; }
+
 /* ── Edit toolbar ──────────────────────────────────────────────────────── */
 #edit-toolbar {
   display: flex;
@@ -1214,6 +1227,8 @@ html, body {
   line-height: 1;
 }
 .btn-icon-sm:hover { border-color: var(--border); color: var(--text); }
+.btn-icon-danger { color: var(--danger); }
+.btn-icon-danger:hover { border-color: var(--danger); color: var(--danger); }
 
 #themes-rename-form {
   display: none;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1049,6 +1049,23 @@ document.getElementById('btn-history-export').addEventListener('click', async ()
 
 // ── Export modal ────────────────────────────────────────────────────────────
 
+// Delete entry
+document.getElementById('btn-delete-entry').addEventListener('click', async () => {
+  if (!_state.selectedId) return;
+  const confirmed = confirm('Delete this note permanently? This cannot be undone.');
+  if (!confirmed) return;
+  const id = _state.selectedId;
+  const result = await window.neurologue.deleteEntry(id);
+  if (!result.ok) { alert(`Delete failed: ${result.error}`); return; }
+  _state.selectedId = null;
+  await loadEntries();
+  await loadTags();
+  await loadCategories();
+  // Clear detail panel
+  document.getElementById('detail-placeholder').removeAttribute('hidden');
+  document.getElementById('detail-content').setAttribute('hidden', '');
+});
+
 let _exportToastTimer = null;
 
 function showToast(message, type = 'success') {
@@ -2142,6 +2159,20 @@ themesRenameCancel.addEventListener('click', closeRenameForm);
 themesRenameInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter')  saveRename();
   if (e.key === 'Escape') closeRenameForm();
+});
+
+document.getElementById('themes-btn-delete').addEventListener('click', async () => {
+  if (!_themesActiveId) return;
+  const name = themesDetailName.textContent || 'this theme';
+  const confirmed = confirm(`Delete theme "${name}"?\n\nThe entries will not be deleted, but theme assignments will be removed.`);
+  if (!confirmed) return;
+  const result = await window.neurologue.deleteTheme(_themesActiveId);
+  if (!result.ok) { alert(`Delete failed: ${result.error}`); return; }
+  _themesActiveId = null;
+  // Hide detail panel and reload list
+  themesDetailCont.style.display = 'none';
+  themesDetailPh.style.display   = '';
+  await loadThemesView();
 });
 
 // ── Contradictions view controller ──────────────────────────────────────────

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -633,8 +633,8 @@ async function _loadSimilarEntries(entryId) {
       card.addEventListener('click', () => selectEntry(entry.id));
       similarList.appendChild(card);
     });
-  } catch {
-    // leave section hidden on error
+  } catch (err) {
+    showToast(`Similar entries failed: ${err && err.message ? err.message : err}`, 'error');
   }
 }
 
@@ -1213,6 +1213,11 @@ statusErrorBadge.addEventListener('click', () => {
 });
 
 window.neurologue.onWorkerStatus(updateStatus);
+
+// Surface unexpected main-process IPC errors as toasts so they are visible
+window.neurologue.onIpcError(({ channel, message }) => {
+  showToast(`Error (${channel}): ${message}`, 'error');
+});
 
 // ── Theme ───────────────────────────────────────────────────────────────────
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -29,9 +29,14 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Themes ───────────────────────────────────────────────────────────────
   listThemes: () => ipcRenderer.invoke('themes:list'),
   getTheme: (id) => ipcRenderer.invoke('themes:get', { id }),
-  renameTheme: (id, newName) => ipcRenderer.invoke('themes:rename', { id, newName }),
+  renameTheme:  (id, newName) => ipcRenderer.invoke('themes:rename', { id, newName }),
+  deleteTheme:  (id)          => ipcRenderer.invoke('themes:delete', { id }),
   triggerClustering: () => ipcRenderer.invoke('themes:cluster'),
   getThemeWeeklyActivity: (id, weeks) => ipcRenderer.invoke('themes:weekly-activity', { id, weeks }),
+
+  // ── Entry delete ─────────────────────────────────────────────────────────
+  deleteEntry:      (id)  => ipcRenderer.invoke('library:delete-entry', { id }),
+  bulkDeleteEntries: (ids) => ipcRenderer.invoke('library:bulk-delete-entries', { ids }),
   // ── Export ───────────────────────────────────────────────────────────────
   exportAll: (opts) => ipcRenderer.invoke('export:run', opts),
 
@@ -73,5 +78,6 @@ contextBridge.exposeInMainWorld('neurologue', {
   checkOllamaInstalled: ()    => ipcRenderer.invoke('ollama:check-installed'),
   pullModel:           (name) => ipcRenderer.invoke('ollama:pull-model', { name }),
   onPullProgress:      (cb)   => { ipcRenderer.on('ollama:pull-progress', (_e, d) => cb(d)); },
+  onIpcError:          (cb)   => { ipcRenderer.on('app:ipc-error', (_e, d) => cb(d)); },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,15 +3,14 @@
 const { app, BrowserWindow, globalShortcut, ipcMain, shell } = require('electron');
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
-const { initVectorStore } = require('./backend/vector/store');
-const { createEntry, listEntries, updateEntry, getEntryRevisions, updateEntryCategory, getActivityByDay } = require('./backend/db/entries');
+const { initVectorStore, searchNearest, deleteVector } = require('./backend/vector/store');
+const { createEntry, listEntries, updateEntry, deleteEntry, getEntryRevisions, updateEntryCategory, getActivityByDay } = require('./backend/db/entries');
 const { setTagsForEntry, listTags, listTagsWithCounts, renameTag, deleteTag, mergeTag, findSimilarTags } = require('./backend/db/tags');
 const { searchEntriesText, listEntriesByTag, getEntryWithTags, listEntriesWithTags, listEntriesFiltered, listCategoriesWithCounts } = require('./backend/db/search');
-const { searchNearest } = require('./backend/vector/store');
 const { getEmbedding } = require('./backend/db/embeddings');
 const { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, suggestTags } = require('./worker/ollama');
 const { getSettings, saveSettings } = require('./backend/settings');
-const { listThemes, getThemeById, renameTheme, getThemeWeeklyActivity } = require('./backend/db/themes');
+const { listThemes, getThemeById, renameTheme, deleteTheme, getThemeWeeklyActivity } = require('./backend/db/themes');
 const { listContradictions, resolveContradiction, dismissContradiction } = require('./backend/db/contradictions');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
@@ -25,6 +24,27 @@ async function initialise() {
 }
 
 let _mainWindow = null;
+
+/**
+ * Wrap an IPC handler so that unhandled rejections are forwarded to the
+ * renderer as a toast notification rather than silently disappearing.
+ * @param {string} channel
+ * @param {Function} fn
+ */
+function handle(channel, fn) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    try {
+      return await fn(event, ...args);
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      console.error(`[IPC] ${channel} threw:`, err);
+      if (_mainWindow && !_mainWindow.isDestroyed()) {
+        _mainWindow.webContents.send('app:ipc-error', { channel, message: msg });
+      }
+      throw err; // still reject so the renderer's own catch can handle it
+    }
+  });
+}
 
 function createMainWindow() {
   _mainWindow = new BrowserWindow({
@@ -74,7 +94,7 @@ ipcMain.handle('library:search-text', async (_event, { query, tag, category, lim
 ipcMain.handle('library:list-categories', async () => listCategoriesWithCounts());
 
 // Semantic search — requires Ollama to be running
-ipcMain.handle('library:search-semantic', async (_event, { query, topN = 10 }) => {
+handle('library:search-semantic', async (_event, { query, topN = 10 }) => {
   const available = await isOllamaAvailable();
   if (!available) return { ok: false, reason: 'ollama_unavailable', results: [] };
   const queryVector = await generateEmbedding(query);
@@ -90,7 +110,7 @@ ipcMain.handle('library:search-semantic', async (_event, { query, topN = 10 }) =
 });
 
 // Semantic neighbours — find entries similar to a given entry (no Ollama needed)
-ipcMain.handle('library:similar-entries', async (_event, { id, topN = 8 }) => {
+handle('library:similar-entries', async (_event, { id, topN = 8 }) => {
   const emb = await getEmbedding(id);
   if (!emb) return { ok: false, reason: 'no_embedding', results: [] };
   // topN + 1 so we can exclude the source entry itself
@@ -125,6 +145,31 @@ ipcMain.handle('library:set-category', async (_event, { id, category }) => {
   if (!id) return { ok: false, error: 'Invalid input' };
   const entry = await updateEntryCategory(id, category || null, 'user');
   return entry ? { ok: true, entry } : { ok: false, error: 'Entry not found' };
+});
+
+// Delete a single entry (SQLite rows + LanceDB vector)
+ipcMain.handle('library:delete-entry', async (_event, { id }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  await deleteEntry(id);
+  await deleteVector(id).catch(() => {}); // vector may not exist yet — ignore
+  return { ok: true };
+});
+
+// Delete multiple entries in one call
+ipcMain.handle('library:bulk-delete-entries', async (_event, { ids }) => {
+  if (!Array.isArray(ids) || ids.length === 0) return { ok: false, error: 'Invalid input' };
+  for (const id of ids) {
+    await deleteEntry(id);
+    await deleteVector(id).catch(() => {});
+  }
+  return { ok: true, deleted: ids.length };
+});
+
+// Delete a theme
+ipcMain.handle('library:delete-theme', async (_event, { id }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  await deleteTheme(id);
+  return { ok: true };
 });
 
 // List all tags (for sidebar)
@@ -248,6 +293,12 @@ ipcMain.handle('themes:get', async (_event, { id }) => {
 ipcMain.handle('themes:rename', async (_event, { id, newName }) => {
   if (!newName || !newName.trim()) throw new Error('Name cannot be empty');
   return renameTheme(id, newName.trim());
+});
+
+ipcMain.handle('themes:delete', async (_event, { id }) => {
+  if (!id) return { ok: false, error: 'Invalid input' };
+  await deleteTheme(id);
+  return { ok: true };
 });
 
 ipcMain.handle('themes:weekly-activity', async (_e, { id, weeks = 12 }) =>

--- a/tests/unit/db/themes.test.js
+++ b/tests/unit/db/themes.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+let tmpDir;
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-themes-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+describe('deleteTheme', () => {
+  test('removes the theme from the database', async () => {
+    const { openDb } = require('../../../src/backend/db/connection');
+    const { listThemes, deleteTheme } = require('../../../src/backend/db/themes');
+    const db = await openDb();
+
+    // Insert a theme directly
+    const id = 'test-theme-id';
+    db.prepare("INSERT INTO themes (id, name) VALUES (?, ?)").run(id, 'Test Theme');
+
+    await deleteTheme(id);
+
+    const themes = await listThemes();
+    expect(themes.find((t) => t.id === id)).toBeUndefined();
+  });
+
+  test('silently succeeds for a non-existent theme id', async () => {
+    const { deleteTheme } = require('../../../src/backend/db/themes');
+    await expect(deleteTheme('does-not-exist')).resolves.toBeUndefined();
+  });
+
+  test('removes associated theme_entries rows', async () => {
+    const { openDb } = require('../../../src/backend/db/connection');
+    const { createEntry } = require('../../../src/backend/db/entries');
+    const { deleteTheme } = require('../../../src/backend/db/themes');
+
+    const db = await openDb();
+    const themeId = 'theme-with-entries';
+    db.prepare("INSERT INTO themes (id, name) VALUES (?, ?)").run(themeId, 'Linked Theme');
+    const entry = await createEntry({ content: 'some entry' });
+    db.prepare("INSERT INTO theme_entries (theme_id, entry_id, score) VALUES (?, ?, ?)").run(themeId, entry.id, 0.9);
+
+    await deleteTheme(themeId);
+
+    const remaining = db.prepare("SELECT * FROM theme_entries WHERE theme_id = ?").all(themeId);
+    expect(remaining).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #99

## Changes
- Delete individual entry (SQLite + LanceDB vector) via Delete button in detail footer
- Delete theme via trash icon in themes detail header (clears detail pane immediately)
- IPC error wrapper `handle()` in main.js — unhandled throws forwarded to renderer as toast via `app:ipc-error`
- Fix LanceDB 0.17 `searchNearest` returning Arrow Table instead of plain array
- `onIpcError` exposed in preload; renderer shows toast on any IPC error

## Not included (future work)
- Bulk multi-select delete
- Bulk tag / theme assignment