### PR TITLE
feat: priority dashboard UI, signal feature flag, on-demand recompute

### DIFF
--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -28,6 +28,7 @@ const DEFAULTS = {
     clustering:    300,  // seconds between clustering runs (also triggers theming)
     contradiction: 900,  // seconds between contradiction scan runs
   },
+  signalsEnabled: true,   // enable LLM entry signal classification (Pass 3)
   theme: 'dark',          // 'dark' | 'light'
 };
 

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -298,10 +298,77 @@
 
         <!-- ── View: Priorities ──────────────────────────────────── -->
         <div id="view-priorities" class="view">
-          <div class="view-placeholder">
-            <div class="vp-icon">&#9650;</div>
-            <div class="vp-title">Priorities</div>
-            <div class="vp-desc">Energy, value, obligation, and motivation scoring — coming in 0.7.x</div>
+          <!-- Left column: ranked theme list -->
+          <div id="pri-list-col">
+            <div id="pri-list-header">
+              <span class="pri-list-title">Priorities</span>
+              <span id="pri-list-count"></span>
+              <button id="btn-pri-recompute" class="btn-sm" title="Recompute now">↻</button>
+            </div>
+            <div id="pri-list"></div>
+          </div>
+          <!-- Right column: theme detail + scores -->
+          <div id="pri-detail-col">
+            <div id="pri-detail-placeholder">
+              <div class="vp-icon">&#9650;</div>
+              <div class="vp-title">No theme selected</div>
+              <div class="vp-desc">Select a theme to view its EVOM scores and signals</div>
+            </div>
+            <div id="pri-detail-content" style="display:none">
+              <div id="pri-detail-header">
+                <div id="pri-detail-name"></div>
+                <div id="pri-detail-priority-badge"></div>
+              </div>
+              <!-- EVOM score bars -->
+              <div id="pri-evom-bars">
+                <div class="pri-score-row">
+                  <span class="pri-score-label">Energy</span>
+                  <div class="pri-score-bar-wrap"><div class="pri-score-bar pri-bar-e" id="pri-bar-e"></div></div>
+                  <span class="pri-score-val" id="pri-val-e"></span>
+                </div>
+                <div class="pri-score-row">
+                  <span class="pri-score-label">Value</span>
+                  <div class="pri-score-bar-wrap"><div class="pri-score-bar pri-bar-v" id="pri-bar-v"></div></div>
+                  <span class="pri-score-val" id="pri-val-v"></span>
+                </div>
+                <div class="pri-score-row">
+                  <span class="pri-score-label">Obligation</span>
+                  <div class="pri-score-bar-wrap"><div class="pri-score-bar pri-bar-o" id="pri-bar-o"></div></div>
+                  <span class="pri-score-val" id="pri-val-o"></span>
+                </div>
+                <div class="pri-score-row">
+                  <span class="pri-score-label">Motivation</span>
+                  <div class="pri-score-bar-wrap"><div class="pri-score-bar pri-bar-m" id="pri-bar-m"></div></div>
+                  <span class="pri-score-val" id="pri-val-m"></span>
+                </div>
+              </div>
+              <!-- Quadrant: Energy × Value -->
+              <div id="pri-quadrant-wrap">
+                <div id="pri-quadrant-title">Energy × Value quadrant</div>
+                <div id="pri-quadrant">
+                  <div class="pri-q-label pri-q-label-tl">High E, Low V</div>
+                  <div class="pri-q-label pri-q-label-tr">High E, High V</div>
+                  <div class="pri-q-label pri-q-label-bl">Low E, Low V</div>
+                  <div class="pri-q-label pri-q-label-br">Low V, High V</div>
+                  <div id="pri-quadrant-dots"></div>
+                </div>
+              </div>
+              <!-- Signal stats -->
+              <div id="pri-signal-stats">
+                <div class="pri-stat-row">
+                  <span class="pri-stat-label">Open loops</span>
+                  <span class="pri-stat-val" id="pri-open-loops"></span>
+                </div>
+                <div class="pri-stat-row">
+                  <span class="pri-stat-label">Entries (30 d)</span>
+                  <span class="pri-stat-val" id="pri-entries-count"></span>
+                </div>
+                <div class="pri-stat-row">
+                  <span class="pri-stat-label">Computed</span>
+                  <span class="pri-stat-val" id="pri-computed-at"></span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2237,9 +2237,8 @@ html, body {
 
 /* ── Priorities view ──────────────────────────────────────────────────── */
 #view-priorities {
-  display: flex;
-  flex: 1;
-  min-height: 0;
+  flex-direction: row;
+  overflow: hidden;
 }
 
 /* Left column */

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2234,3 +2234,288 @@ html, body {
   background: var(--cortex-teal);
   color: #fff;
 }
+
+/* ── Priorities view ──────────────────────────────────────────────────── */
+#view-priorities {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Left column */
+#pri-list-col {
+  width: 260px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+}
+#pri-list-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.pri-list-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+#pri-list-count {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+#pri-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+/* Theme row in list */
+.pri-theme-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background 0.1s;
+}
+.pri-theme-row:hover { background: var(--surface2); }
+.pri-theme-row.active {
+  background: var(--surface2);
+  border-left-color: var(--neuro-blue);
+}
+.pri-theme-info { flex: 1; min-width: 0; }
+.pri-theme-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pri-theme-subtitle {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+.pri-rank-badge {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--neuro-blue);
+  min-width: 20px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Priority mini-bar in list */
+.pri-mini-bar-wrap {
+  width: 50px;
+  height: 4px;
+  background: var(--surface2);
+  border-radius: 2px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.pri-mini-bar {
+  height: 100%;
+  background: var(--neuro-blue);
+  border-radius: 2px;
+  transition: width 0.3s;
+}
+
+/* Right column */
+#pri-detail-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#pri-detail-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-dim);
+  user-select: none;
+}
+#pri-detail-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+#pri-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+#pri-detail-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+#pri-detail-priority-badge {
+  font-size: 12px;
+  font-weight: 700;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: var(--neuro-blue);
+  color: #fff;
+}
+
+/* EVOM score bars */
+#pri-evom-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.pri-score-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.pri-score-label {
+  width: 80px;
+  font-size: 12px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.pri-score-bar-wrap {
+  flex: 1;
+  height: 8px;
+  background: var(--surface2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.pri-score-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+.pri-bar-e { background: var(--cortex-teal); }
+.pri-bar-v { background: var(--synapse-gold); }
+.pri-bar-o { background: #e07a5f; }
+.pri-bar-m { background: #81b29a; }
+.pri-score-val {
+  width: 34px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Quadrant chart */
+#pri-quadrant-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+#pri-quadrant-title {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+#pri-quadrant {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+/* axis lines */
+#pri-quadrant::before {
+  content: '';
+  position: absolute;
+  left: 50%; top: 0; bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+#pri-quadrant::after {
+  content: '';
+  position: absolute;
+  top: 50%; left: 0; right: 0;
+  height: 1px;
+  background: var(--border);
+}
+.pri-q-label {
+  position: absolute;
+  font-size: 9px;
+  color: var(--text-dim);
+  padding: 4px 6px;
+}
+.pri-q-label-tl { top: 4px; left: 4px; }
+.pri-q-label-tr { top: 4px; right: 4px; }
+.pri-q-label-bl { bottom: 4px; left: 4px; }
+.pri-q-label-br { bottom: 4px; right: 4px; }
+#pri-quadrant-dots { position: absolute; inset: 0; }
+.pri-q-dot {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--neuro-blue);
+  transform: translate(-50%, -50%);
+  opacity: 0.7;
+  cursor: default;
+}
+.pri-q-dot.pri-q-dot-active {
+  background: var(--synapse-gold);
+  opacity: 1;
+  width: 10px;
+  height: 10px;
+  z-index: 1;
+}
+
+/* Signal stats */
+#pri-signal-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 0;
+  border-top: 1px solid var(--border);
+}
+.pri-stat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pri-stat-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  width: 100px;
+}
+.pri-stat-val {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* No-data state */
+.pri-no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 10px;
+  color: var(--text-dim);
+  font-size: 13px;
+  padding: 40px 20px;
+  text-align: center;
+}
+

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1248,6 +1248,9 @@ window.neurologue.onEntriesUpdated(async () => {
   }
 });
 window.neurologue.onThemesUpdated(() => loadThemesView());
+window.neurologue.onThemesUpdated(() => {
+  if (document.getElementById('view-priorities').classList.contains('active-view')) loadPrioritiesView();
+});
 window.neurologue.onContradictionsUpdated(() => loadContradictionsView());
 
 // ── Setup + settings modals ────────────────────────────────────────
@@ -1903,6 +1906,7 @@ function activateView(viewId) {
 
   if (viewId === 'themes')         loadThemesView();
   if (viewId === 'contradictions') loadContradictionsView();
+  if (viewId === 'priorities')     loadPrioritiesView();
 }
 
 navItems.forEach(btn => {
@@ -2351,6 +2355,143 @@ btnScan.addEventListener('click', async () => {
       btnScan.disabled = false;
       btnScan.textContent = 'Scan now';
     }, 2500);
+  }
+});
+
+// ── Priorities view controller ───────────────────────────────────────────────
+
+const priListEl       = document.getElementById('pri-list');
+const priListCountEl  = document.getElementById('pri-list-count');
+const priDetailPh     = document.getElementById('pri-detail-placeholder');
+const priDetailCont   = document.getElementById('pri-detail-content');
+const priDetailName   = document.getElementById('pri-detail-name');
+const priDetailBadge  = document.getElementById('pri-detail-priority-badge');
+const priBarE         = document.getElementById('pri-bar-e');
+const priBarV         = document.getElementById('pri-bar-v');
+const priBarO         = document.getElementById('pri-bar-o');
+const priBarM         = document.getElementById('pri-bar-m');
+const priValE         = document.getElementById('pri-val-e');
+const priValV         = document.getElementById('pri-val-v');
+const priValO         = document.getElementById('pri-val-o');
+const priValM         = document.getElementById('pri-val-m');
+const priQDots        = document.getElementById('pri-quadrant-dots');
+const priOpenLoops    = document.getElementById('pri-open-loops');
+const priEntriesCount = document.getElementById('pri-entries-count');
+const priComputedAt   = document.getElementById('pri-computed-at');
+const btnPriRecompute = document.getElementById('btn-pri-recompute');
+
+let _priActiveId = null;
+let _priAllMetrics = [];
+
+function _pct(v) { return `${Math.round((v || 0) * 100)}%`; }
+
+function _showPriDetail(metrics) {
+  _priActiveId = metrics.theme_id;
+  priDetailPh.style.display = 'none';
+  priDetailCont.style.display = '';
+
+  priDetailName.textContent  = metrics.theme_name || 'Unnamed';
+  const pct = Math.round((metrics.priority_score || 0) * 100);
+  priDetailBadge.textContent = `Priority ${pct}`;
+
+  priBarE.style.width = _pct(metrics.energy_score);
+  priBarV.style.width = _pct(metrics.value_alignment_score);
+  priBarO.style.width = _pct(metrics.obligation_score);
+  priBarM.style.width = _pct(metrics.motivation_score);
+  priValE.textContent = _pct(metrics.energy_score);
+  priValV.textContent = _pct(metrics.value_alignment_score);
+  priValO.textContent = _pct(metrics.obligation_score);
+  priValM.textContent = _pct(metrics.motivation_score);
+
+  // Quadrant dots — plot all themes; highlight selected
+  priQDots.innerHTML = '';
+  for (const m of _priAllMetrics) {
+    const dot = document.createElement('div');
+    dot.className = 'pri-q-dot' + (m.theme_id === metrics.theme_id ? ' pri-q-dot-active' : '');
+    // x = energy (left→right), y = value (bottom→top, so invert)
+    const x = (m.energy_score || 0) * 100;
+    const y = (1 - (m.value_alignment_score || 0)) * 100;
+    dot.style.left = `${x}%`;
+    dot.style.top  = `${y}%`;
+    dot.title = m.theme_name || 'Unnamed';
+    dot.addEventListener('click', () => _selectPriTheme(m.theme_id));
+    priQDots.appendChild(dot);
+  }
+
+  priOpenLoops.textContent    = metrics.open_loops_count ?? '—';
+  priEntriesCount.textContent = metrics.entries_count ?? '—';
+  priComputedAt.textContent   = metrics.computed_at
+    ? new Date(metrics.computed_at).toLocaleString()
+    : '—';
+
+  // Highlight active row
+  priListEl.querySelectorAll('.pri-theme-row').forEach((row) => {
+    row.classList.toggle('active', row.dataset.themeId === metrics.theme_id);
+  });
+}
+
+function _selectPriTheme(themeId) {
+  const m = _priAllMetrics.find((x) => x.theme_id === themeId);
+  if (m) _showPriDetail(m);
+}
+
+async function loadPrioritiesView() {
+  try {
+    const metrics = await window.neurologue.listPriorityMetrics();
+    _priAllMetrics = metrics;
+    priListCountEl.textContent = metrics.length ? `(${metrics.length})` : '';
+
+    priListEl.innerHTML = '';
+    if (metrics.length === 0) {
+      priListEl.innerHTML = '<div class="pri-no-data">No priority data yet.<br>The worker computes scores after clustering.</div>';
+      priDetailPh.style.display = '';
+      priDetailCont.style.display = 'none';
+      return;
+    }
+
+    metrics.forEach((m, i) => {
+      const row = document.createElement('div');
+      row.className = 'pri-theme-row';
+      row.dataset.themeId = m.theme_id;
+      if (m.theme_id === _priActiveId) row.classList.add('active');
+
+      const pct = Math.round((m.priority_score || 0) * 100);
+      row.innerHTML = `
+        <span class="pri-rank-badge">#${i + 1}</span>
+        <div class="pri-theme-info">
+          <div class="pri-theme-name">${m.theme_name || 'Unnamed'}</div>
+          <div class="pri-theme-subtitle">${pct}% priority · ${m.entries_count ?? 0} entries</div>
+        </div>
+        <div class="pri-mini-bar-wrap">
+          <div class="pri-mini-bar" style="width:${pct}%"></div>
+        </div>`;
+      row.addEventListener('click', () => _showPriDetail(m));
+      priListEl.appendChild(row);
+    });
+
+    // Re-show active detail or auto-select first
+    const active = _priActiveId ? metrics.find((m) => m.theme_id === _priActiveId) : null;
+    if (active) {
+      _showPriDetail(active);
+    } else if (metrics.length > 0) {
+      _showPriDetail(metrics[0]);
+    }
+  } catch (err) {
+    console.error('[priorities-view] loadPrioritiesView failed:', err);
+  }
+}
+
+btnPriRecompute.addEventListener('click', async () => {
+  btnPriRecompute.disabled = true;
+  btnPriRecompute.textContent = '…';
+  try {
+    await window.neurologue.recomputePriorities();
+    await loadPrioritiesView();
+  } catch {
+    // error shown via IPC error toast
+  } finally {
+    btnPriRecompute.disabled = false;
+    btnPriRecompute.textContent = '↻';
   }
 });
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -63,6 +63,12 @@ contextBridge.exposeInMainWorld('neurologue', {
   dismissContradiction: (id) => ipcRenderer.invoke('contradictions:dismiss', { id }),
   scanContradictions:   () => ipcRenderer.invoke('contradictions:scan'),
 
+  // ── Priorities ───────────────────────────────────────────────────────────
+  listPriorityMetrics:     ()         => ipcRenderer.invoke('priorities:list-metrics'),
+  getPriorityEntrySignals: (themeId)  => ipcRenderer.invoke('priorities:get-entry-signals', { themeId }),
+  getPriorityHistory:      (themeId)  => ipcRenderer.invoke('priorities:get-history', { themeId }),
+  recomputePriorities:     ()         => ipcRenderer.invoke('priorities:recompute'),
+
   // ── Settings ─────────────────────────────────────────────────────────────
   getSettings:  ()        => ipcRenderer.invoke('settings:get'),
   saveSettings: (updates) => ipcRenderer.invoke('settings:save', updates),

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,9 @@ const { listContradictions, resolveContradiction, dismissContradiction } = requi
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
-const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions } = require('./worker/index');
+const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
+const { listLatestThemeMetrics, getThemeMetricsHistory } = require('./backend/db/theme_metrics');
+const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -330,6 +332,30 @@ ipcMain.handle('contradictions:dismiss', async (_e, { id }) => {
 
 ipcMain.handle('contradictions:scan', async () => {
   return scanContradictions();
+});
+
+// ── Priorities IPC ───────────────────────────────────────────────────────────
+
+handle('priorities:list-metrics', async () => {
+  const metrics = await listLatestThemeMetrics();
+  // Enrich with theme name
+  return Promise.all(metrics.map(async (m) => {
+    const theme = await getThemeById(m.theme_id);
+    return { ...m, theme_name: theme ? (theme.user_name || theme.name || 'Unnamed') : 'Deleted theme' };
+  }));
+});
+
+handle('priorities:get-entry-signals', async (_event, { themeId }) => {
+  return getSignalsByTheme(themeId);
+});
+
+handle('priorities:get-history', async (_event, { themeId }) => {
+  return getThemeMetricsHistory(themeId);
+});
+
+handle('priorities:recompute', async () => {
+  const n = await recomputeMetrics();
+  return { updated: n };
 });
 
 // ── Help IPC ─────────────────────────────────────────────────────────────────

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -201,6 +201,7 @@ async function processBatch() {
   }
 
   // ── Pass 3: compute entry signals for entries that have none yet ──────
+  if (!getSettings().signalsEnabled) return _push('worker:status', await _buildStatus(true));
   const signalIds = await listEntriesWithoutSignals(SIGNALS_BATCH_SIZE);
   const signalLog = _logStart('signals');
   if (signalIds.length > 0) {
@@ -470,4 +471,8 @@ async function scanContradictions() {
   return { checked, found };
 }
 
-module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus, getWorkerLog, clearWorkerLog, setWorkerIntervals, setMainWindow, getOllamaStatus, reindexAll, reindexEntry, scanContradictions };
+async function recomputeMetrics() {
+  return recomputeAllThemeMetrics();
+}
+
+module.exports = { startWorker, stopWorker, pauseWorker, resumeWorker, workerStatus, getWorkerLog, clearWorkerLog, setWorkerIntervals, setMainWindow, getOllamaStatus, reindexAll, reindexEntry, scanContradictions, recomputeMetrics };

--- a/tests/unit/settings.test.js
+++ b/tests/unit/settings.test.js
@@ -35,6 +35,7 @@ describe('getSettings', () => {
     expect(s.embeddingModel).toBe('nomic-embed-text');
     expect(s.llmModel).toBe('phi3:mini');
     expect(s.theme).toBe('dark');
+    expect(s.signalsEnabled).toBe(true);
   });
 
   test('returns defaults merged with saved values', () => {


### PR DESCRIPTION
## Summary

Closes #76, #77, #78

### #76 — Entry Signal Classification gaps
- Added \signalsEnabled: true\ default to settings — worker Pass 3 skips signal computation when disabled
- Settings test updated to assert the new default

### #77 — Priority Scoring Pipeline gaps
- Added \priorities:recompute\ IPC handler for on-demand recompute
- Exposed as \ecomputePriorities()\ in preload
- \ecomputeMetrics\ exported from worker/index.js

### #78 — Priority Dashboard UI
- Replaced priorities view placeholder with full two-column layout
- Ranked theme list with mini score bars and rank badge
- Detail panel: EVOM score bars, Energy×Value quadrant (all themes plotted), signal stats
- Recompute button triggers on-demand recompute and refreshes list
- Auto-refreshes when worker:themes-updated fires
- Fixed flex-direction row + overflow hidden so the two-column layout renders correctly