### PR TITLE
feat: drift analysis (rising/falling/neglected themes)

### DIFF
--- a/src/backend/db/theme_metrics.js
+++ b/src/backend/db/theme_metrics.js
@@ -212,10 +212,64 @@ async function getLatestThemeMetrics(themeId) {
   ).get(themeId);
 }
 
+/**
+ * Classify the drift direction for a single theme based on its last two metric snapshots.
+ * Returns 'rising' | 'falling' | 'neglected' | 'stable'
+ *
+ * neglected = high obligation (>0.5) with low or falling energy
+ * rising    = energy or priority improved by >0.05 since last snapshot
+ * falling   = energy or priority dropped by >0.05 since last snapshot
+ * stable    = change within ±0.05
+ *
+ * @param {string} themeId
+ * @returns {Promise<string>}
+ */
+async function getDriftClassification(themeId) {
+  const db = await openDb();
+  const rows = db.prepare(
+    'SELECT * FROM theme_metrics WHERE theme_id = ? ORDER BY window_end DESC LIMIT 2'
+  ).all(themeId);
+
+  const latest = rows[0];
+  if (!latest) return 'stable';
+
+  // Neglected: high obligation with low or falling energy
+  if (latest.obligation_score > 0.5 && latest.energy_score < 0.3) return 'neglected';
+
+  if (rows.length < 2) return 'stable';
+  const prev = rows[1];
+  const dE = latest.energy_score   - prev.energy_score;
+  const dP = latest.priority_score - prev.priority_score;
+  if (latest.obligation_score > 0.5 && dE < -0.05) return 'neglected';
+  if (dE > 0.05 || dP > 0.05)  return 'rising';
+  if (dE < -0.05 || dP < -0.05) return 'falling';
+  return 'stable';
+}
+
+/**
+ * Return latest metrics for all themes augmented with a drift classification
+ * and an energy history array for sparkline rendering.
+ * @returns {Promise<Array>}
+ */
+async function listThemesWithDrift() {
+  const db = await openDb();
+  const latest = await listLatestThemeMetrics();
+  return Promise.all(latest.map(async (m) => {
+    const drift = await getDriftClassification(m.theme_id);
+    // Last 8 snapshots for sparkline (oldest → newest)
+    const history = db.prepare(
+      'SELECT energy_score, priority_score, computed_at FROM theme_metrics WHERE theme_id = ? ORDER BY computed_at ASC LIMIT 8'
+    ).all(m.theme_id);
+    return { ...m, drift, history };
+  }));
+}
+
 module.exports = {
   upsertThemeMetrics,
   listLatestThemeMetrics,
   getThemeMetricsHistory,
   getLatestThemeMetrics,
   recomputeAllThemeMetrics,
+  getDriftClassification,
+  listThemesWithDrift,
 };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -304,8 +304,7 @@
               <span class="pri-list-title">Priorities</span>
               <span id="pri-list-count"></span>
               <button id="btn-pri-recompute" class="btn-sm" title="Recompute now">↻</button>
-            </div>
-            <div id="pri-list"></div>
+            </div>            <div id="pri-neglected-banner" class="hidden"></div>            <div id="pri-list"></div>
           </div>
           <!-- Right column: theme detail + scores -->
           <div id="pri-detail-col">
@@ -317,6 +316,7 @@
             <div id="pri-detail-content" style="display:none">
               <div id="pri-detail-header">
                 <div id="pri-detail-name"></div>
+                <div id="pri-detail-drift-badge"></div>
                 <div id="pri-detail-priority-badge"></div>
               </div>
               <!-- EVOM score bars -->
@@ -340,6 +340,20 @@
                   <span class="pri-score-label">Motivation</span>
                   <div class="pri-score-bar-wrap"><div class="pri-score-bar pri-bar-m" id="pri-bar-m"></div></div>
                   <span class="pri-score-val" id="pri-val-m"></span>
+                </div>
+              </div>
+              <!-- Drift sparkline -->
+              <div id="pri-drift-wrap">
+                <div id="pri-drift-title">Energy &amp; priority over time</div>
+                <div id="pri-drift-neglect-alert" class="hidden">&#9888; Neglected obligation — high commitment, low energy</div>
+                <svg id="pri-sparkline" viewBox="0 0 200 50" preserveAspectRatio="none"
+                     xmlns="http://www.w3.org/2000/svg">
+                  <polyline id="pri-spark-energy"   fill="none" stroke-width="1.5"/>
+                  <polyline id="pri-spark-priority"  fill="none" stroke-width="1.5" stroke-dasharray="4 2"/>
+                </svg>
+                <div id="pri-spark-legend">
+                  <span class="pri-spark-leg pri-spark-leg-e">Energy</span>
+                  <span class="pri-spark-leg pri-spark-leg-p">Priority</span>
                 </div>
               </div>
               <!-- Quadrant: Energy × Value -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2518,3 +2518,90 @@ html, body {
   text-align: center;
 }
 
+/* ── Drift badges ─────────────────────────────────────────────────────── */
+.pri-drift-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+.pri-drift-rising    { background: rgba(129,178,154,0.25); color: #4a9970; }
+.pri-drift-falling   { background: rgba(224,122,95,0.20); color: #c0513a; }
+.pri-drift-neglected { background: rgba(255,190,0,0.20);  color: #9a7000; }
+.pri-drift-stable    { background: var(--surface2); color: var(--text-dim); }
+
+/* Drift badge in detail header */
+#pri-detail-drift-badge {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 20px;
+  flex-shrink: 0;
+}
+
+/* Neglected banner in list column */
+#pri-neglected-banner {
+  margin: 6px 10px;
+  padding: 7px 10px;
+  background: rgba(255,190,0,0.12);
+  border: 1px solid rgba(255,190,0,0.35);
+  border-radius: var(--radius);
+  font-size: 11px;
+  color: #9a7000;
+  line-height: 1.4;
+}
+#pri-neglected-banner.hidden { display: none; }
+
+/* ── Drift sparkline ──────────────────────────────────────────────────── */
+#pri-drift-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+#pri-drift-title {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+#pri-drift-neglect-alert {
+  font-size: 11px;
+  padding: 5px 8px;
+  background: rgba(255,190,0,0.12);
+  border: 1px solid rgba(255,190,0,0.35);
+  border-radius: var(--radius);
+  color: #9a7000;
+}
+#pri-drift-neglect-alert.hidden { display: none; }
+#pri-sparkline {
+  width: 100%;
+  height: 50px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  display: block;
+}
+#pri-spark-energy  { stroke: var(--cortex-teal); }
+#pri-spark-priority { stroke: var(--neuro-blue); }
+#pri-spark-legend {
+  display: flex;
+  gap: 14px;
+}
+.pri-spark-leg {
+  font-size: 10px;
+  color: var(--text-dim);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.pri-spark-leg::before {
+  content: '';
+  display: inline-block;
+  width: 16px;
+  height: 2px;
+  border-radius: 1px;
+}
+.pri-spark-leg-e::before { background: var(--cortex-teal); }
+.pri-spark-leg-p::before { background: var(--neuro-blue); border-top: 1px dashed var(--neuro-blue); height: 0; }
+

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -2360,40 +2360,69 @@ btnScan.addEventListener('click', async () => {
 
 // ── Priorities view controller ───────────────────────────────────────────────
 
-const priListEl       = document.getElementById('pri-list');
-const priListCountEl  = document.getElementById('pri-list-count');
-const priDetailPh     = document.getElementById('pri-detail-placeholder');
-const priDetailCont   = document.getElementById('pri-detail-content');
-const priDetailName   = document.getElementById('pri-detail-name');
-const priDetailBadge  = document.getElementById('pri-detail-priority-badge');
-const priBarE         = document.getElementById('pri-bar-e');
-const priBarV         = document.getElementById('pri-bar-v');
-const priBarO         = document.getElementById('pri-bar-o');
-const priBarM         = document.getElementById('pri-bar-m');
-const priValE         = document.getElementById('pri-val-e');
-const priValV         = document.getElementById('pri-val-v');
-const priValO         = document.getElementById('pri-val-o');
-const priValM         = document.getElementById('pri-val-m');
-const priQDots        = document.getElementById('pri-quadrant-dots');
-const priOpenLoops    = document.getElementById('pri-open-loops');
-const priEntriesCount = document.getElementById('pri-entries-count');
-const priComputedAt   = document.getElementById('pri-computed-at');
-const btnPriRecompute = document.getElementById('btn-pri-recompute');
+const priListEl           = document.getElementById('pri-list');
+const priListCountEl      = document.getElementById('pri-list-count');
+const priNeglectedBanner  = document.getElementById('pri-neglected-banner');
+const priDetailPh         = document.getElementById('pri-detail-placeholder');
+const priDetailCont       = document.getElementById('pri-detail-content');
+const priDetailName       = document.getElementById('pri-detail-name');
+const priDetailDriftBadge = document.getElementById('pri-detail-drift-badge');
+const priDetailBadge      = document.getElementById('pri-detail-priority-badge');
+const priBarE             = document.getElementById('pri-bar-e');
+const priBarV             = document.getElementById('pri-bar-v');
+const priBarO             = document.getElementById('pri-bar-o');
+const priBarM             = document.getElementById('pri-bar-m');
+const priValE             = document.getElementById('pri-val-e');
+const priValV             = document.getElementById('pri-val-v');
+const priValO             = document.getElementById('pri-val-o');
+const priValM             = document.getElementById('pri-val-m');
+const priQDots            = document.getElementById('pri-quadrant-dots');
+const priOpenLoops        = document.getElementById('pri-open-loops');
+const priEntriesCount     = document.getElementById('pri-entries-count');
+const priComputedAt       = document.getElementById('pri-computed-at');
+const btnPriRecompute     = document.getElementById('btn-pri-recompute');
+const priSparkEnergy      = document.getElementById('pri-spark-energy');
+const priSparkPriority    = document.getElementById('pri-spark-priority');
+const priDriftAlert       = document.getElementById('pri-drift-neglect-alert');
 
 let _priActiveId = null;
 let _priAllMetrics = [];
 
+const DRIFT_LABELS = { rising: '↑ Rising', falling: '↓ Falling', neglected: '⚠ Neglected', stable: '→ Stable' };
+const DRIFT_CLASSES = { rising: 'pri-drift-rising', falling: 'pri-drift-falling', neglected: 'pri-drift-neglected', stable: 'pri-drift-stable' };
+
 function _pct(v) { return `${Math.round((v || 0) * 100)}%`; }
+
+/** Render an SVG polyline points string from an array of 0–1 values into a 200×50 viewBox */
+function _sparkPoints(values) {
+  if (!values || values.length === 0) return '';
+  const w = 200; const h = 50; const pad = 4;
+  const xs = values.length === 1
+    ? [w / 2]
+    : values.map((_, i) => pad + (i / (values.length - 1)) * (w - pad * 2));
+  return values.map((v, i) => `${xs[i].toFixed(1)},${(pad + (1 - (v || 0)) * (h - pad * 2)).toFixed(1)}`).join(' ');
+}
 
 function _showPriDetail(metrics) {
   _priActiveId = metrics.theme_id;
   priDetailPh.style.display = 'none';
   priDetailCont.style.display = '';
 
-  priDetailName.textContent  = metrics.theme_name || 'Unnamed';
-  const pct = Math.round((metrics.priority_score || 0) * 100);
-  priDetailBadge.textContent = `Priority ${pct}`;
+  priDetailName.textContent = metrics.theme_name || 'Unnamed';
 
+  // Priority badge
+  const pct = Math.round((metrics.priority_score || 0) * 100);
+  priDetailBadge.textContent = `Priority ${pct}%`;
+
+  // Drift badge
+  const drift = metrics.drift || 'stable';
+  priDetailDriftBadge.textContent  = DRIFT_LABELS[drift] || drift;
+  priDetailDriftBadge.className    = `pri-drift-badge ${DRIFT_CLASSES[drift] || DRIFT_CLASSES.stable}`;
+
+  // Neglected alert
+  priDriftAlert.classList.toggle('hidden', drift !== 'neglected');
+
+  // EVOM bars
   priBarE.style.width = _pct(metrics.energy_score);
   priBarV.style.width = _pct(metrics.value_alignment_score);
   priBarO.style.width = _pct(metrics.obligation_score);
@@ -2403,12 +2432,16 @@ function _showPriDetail(metrics) {
   priValO.textContent = _pct(metrics.obligation_score);
   priValM.textContent = _pct(metrics.motivation_score);
 
+  // Drift sparkline
+  const history = metrics.history || [];
+  priSparkEnergy.setAttribute('points',   _sparkPoints(history.map((h) => h.energy_score)));
+  priSparkPriority.setAttribute('points', _sparkPoints(history.map((h) => h.priority_score)));
+
   // Quadrant dots — plot all themes; highlight selected
   priQDots.innerHTML = '';
   for (const m of _priAllMetrics) {
     const dot = document.createElement('div');
     dot.className = 'pri-q-dot' + (m.theme_id === metrics.theme_id ? ' pri-q-dot-active' : '');
-    // x = energy (left→right), y = value (bottom→top, so invert)
     const x = (m.energy_score || 0) * 100;
     const y = (1 - (m.value_alignment_score || 0)) * 100;
     dot.style.left = `${x}%`;
@@ -2441,6 +2474,15 @@ async function loadPrioritiesView() {
     _priAllMetrics = metrics;
     priListCountEl.textContent = metrics.length ? `(${metrics.length})` : '';
 
+    // Neglected banner
+    const neglected = metrics.filter((m) => m.drift === 'neglected');
+    if (neglected.length > 0) {
+      priNeglectedBanner.textContent = `⚠ ${neglected.length} neglected obligation${neglected.length > 1 ? 's' : ''}: ${neglected.map((m) => m.theme_name).join(', ')}`;
+      priNeglectedBanner.classList.remove('hidden');
+    } else {
+      priNeglectedBanner.classList.add('hidden');
+    }
+
     priListEl.innerHTML = '';
     if (metrics.length === 0) {
       priListEl.innerHTML = '<div class="pri-no-data">No priority data yet.<br>The worker computes scores after clustering.</div>';
@@ -2456,12 +2498,15 @@ async function loadPrioritiesView() {
       if (m.theme_id === _priActiveId) row.classList.add('active');
 
       const pct = Math.round((m.priority_score || 0) * 100);
+      const drift = m.drift || 'stable';
+      const driftIcon = { rising: '↑', falling: '↓', neglected: '⚠', stable: '' }[drift] || '';
       row.innerHTML = `
         <span class="pri-rank-badge">#${i + 1}</span>
         <div class="pri-theme-info">
           <div class="pri-theme-name">${m.theme_name || 'Unnamed'}</div>
           <div class="pri-theme-subtitle">${pct}% priority · ${m.entries_count ?? 0} entries</div>
         </div>
+        ${driftIcon ? `<span class="pri-drift-badge ${DRIFT_CLASSES[drift]}">${driftIcon}</span>` : ''}
         <div class="pri-mini-bar-wrap">
           <div class="pri-mini-bar" style="width:${pct}%"></div>
         </div>`;

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
-const { listLatestThemeMetrics, getThemeMetricsHistory } = require('./backend/db/theme_metrics');
+const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 // getOllamaStatus and getSettings imported above
 
@@ -337,7 +337,7 @@ ipcMain.handle('contradictions:scan', async () => {
 // ── Priorities IPC ───────────────────────────────────────────────────────────
 
 handle('priorities:list-metrics', async () => {
-  const metrics = await listLatestThemeMetrics();
+  const metrics = await listThemesWithDrift();
   // Enrich with theme name
   return Promise.all(metrics.map(async (m) => {
     const theme = await getThemeById(m.theme_id);

--- a/tests/unit/db/theme_metrics.test.js
+++ b/tests/unit/db/theme_metrics.test.js
@@ -121,3 +121,53 @@ describe('getThemeMetricsHistory', () => {
     expect(await getThemeMetricsHistory('no-such-theme')).toEqual([]);
   });
 });
+
+describe('getDriftClassification', () => {
+  test('returns stable when no history exists', async () => {
+    const { getDriftClassification } = require('../../../src/backend/db/theme_metrics');
+    expect(await getDriftClassification('no-theme')).toBe('stable');
+  });
+
+  test('returns stable when only one snapshot exists', async () => {
+    const { upsertThemeMetrics, getDriftClassification } = require('../../../src/backend/db/theme_metrics');
+    const themeId = await makeTheme();
+    await upsertThemeMetrics(baseMetrics(themeId));
+    expect(await getDriftClassification(themeId)).toBe('stable');
+  });
+
+  test('detects rising when energy improves by >0.05', async () => {
+    const { upsertThemeMetrics, getDriftClassification } = require('../../../src/backend/db/theme_metrics');
+    const themeId = await makeTheme();
+    await upsertThemeMetrics({ ...baseMetrics(themeId, 0), energy_score: 0.3, priority_score: 0.3 });
+    await upsertThemeMetrics({ ...baseMetrics(themeId, 5), energy_score: 0.5, priority_score: 0.5 });
+    expect(await getDriftClassification(themeId)).toBe('rising');
+  });
+
+  test('detects falling when energy drops by >0.05', async () => {
+    const { upsertThemeMetrics, getDriftClassification } = require('../../../src/backend/db/theme_metrics');
+    const themeId = await makeTheme();
+    await upsertThemeMetrics({ ...baseMetrics(themeId, 0), energy_score: 0.7, priority_score: 0.7 });
+    await upsertThemeMetrics({ ...baseMetrics(themeId, 5), energy_score: 0.4, priority_score: 0.4 });
+    expect(await getDriftClassification(themeId)).toBe('falling');
+  });
+
+  test('detects neglected when high obligation and low energy', async () => {
+    const { upsertThemeMetrics, getDriftClassification } = require('../../../src/backend/db/theme_metrics');
+    const themeId = await makeTheme();
+    await upsertThemeMetrics({ ...baseMetrics(themeId), obligation_score: 0.8, energy_score: 0.1, priority_score: 0.3 });
+    expect(await getDriftClassification(themeId)).toBe('neglected');
+  });
+});
+
+describe('listThemesWithDrift', () => {
+  test('includes drift and history for each theme', async () => {
+    const { upsertThemeMetrics, listThemesWithDrift } = require('../../../src/backend/db/theme_metrics');
+    const themeId = await makeTheme('Drift Theme');
+    await upsertThemeMetrics(baseMetrics(themeId));
+    const rows = await listThemesWithDrift();
+    const row = rows.find((r) => r.theme_id === themeId);
+    expect(row).toBeDefined();
+    expect(row.drift).toBeDefined();
+    expect(Array.isArray(row.history)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #79

## Changes
- **Backend**: getDriftClassification classifies each theme as rising/falling/neglected/stable based on energy + priority deltas across the last two metric windows; listThemesWithDrift enriches the latest metrics list with drift status and an 8-snapshot history array
- **IPC**: priorities:list-metrics now returns drift + history fields per theme
- **Frontend HTML**: added neglected banner, drift badge slot in detail header, sparkline SVG section with energy and priority polylines
- **Frontend CSS**: drift badge colour variants (rising/falling/neglected/stable), sparkline styles, neglected banner/alert styles
- **Frontend JS**: new DOM refs, _sparkPoints helper, drift badge rendering in _showPriDetail, sparkline rendering from history, neglected alert toggle, neglected-theme banner in list view, drift icon badges on list rows
- **Tests**: 6 new test cases for getDriftClassification (stable/rising/falling/neglected) and listThemesWithDrift — 226 tests total, all passing