### PR TITLE
feat: cognitive dashboard with deep-link navigation (#56)

### DIFF
--- a/src/backend/db/dashboard.js
+++ b/src/backend/db/dashboard.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { openDb } = require('./connection');
+
+/**
+ * Aggregate all signals needed for the Cognitive Dashboard in a single call.
+ *
+ * Returns:
+ *  {
+ *    totalEntries:       number,
+ *    activeThemes:       [{ id, display_name, entry_count, last_active }]  (active last 7 d, max 8)
+ *    emergingThemes:     [{ id, display_name, entry_count, created_at }]   (formed last 7 d, max 5)
+ *    openLoopEntries:    [{ id, content, created_at }]                     (max 8)
+ *    openLoopCount:      number,
+ *    contradictionCount: number,
+ *    recentCaptures:     [{ id, content, created_at, category }]           (max 6)
+ *    thoughtDensity:     [{ day: 'YYYY-MM-DD', count: number }]            (last 14 days)
+ *    weeklyEntryCount:   number,
+ *  }
+ */
+async function getDashboardSummary() {
+  const db = await openDb();
+
+  const totalEntries = db.prepare('SELECT COUNT(*) AS n FROM entries').get().n;
+
+  // All themes, with most recent entry date, oldest entry date, and total entry count
+  const allThemes = db.prepare(`
+    SELECT t.id,
+           COALESCE(t.user_name, t.name) AS display_name,
+           COUNT(te.entry_id)            AS entry_count,
+           MAX(e.created_at)             AS last_active,
+           MIN(e.created_at)             AS first_active
+    FROM themes t
+    LEFT JOIN theme_entries te ON te.theme_id = t.id
+    LEFT JOIN entries e        ON e.id = te.entry_id
+    GROUP BY t.id
+    ORDER BY last_active DESC
+  `).all();
+
+  const sevenDaysAgo = new Date(Date.now() - 7 * 86400_000).toISOString();
+
+  // Active: had entry activity in the last 7 days
+  const activeThemes = allThemes
+    .filter((t) => t.last_active && t.last_active >= sevenDaysAgo)
+    .slice(0, 8);
+
+  // Emerging: all entries are from within the last 7 days (first entry is recent)
+  const emergingThemes = allThemes
+    .filter((t) => t.first_active && t.first_active >= sevenDaysAgo)
+    .slice(0, 5);
+
+  // Open loops from entry_signals
+  const openLoopEntries = db.prepare(`
+    SELECT e.id, e.content, e.created_at
+    FROM entry_signals es
+    JOIN entries e ON e.id = es.entry_id
+    WHERE es.open_loop_flag = 1
+    ORDER BY e.created_at DESC
+    LIMIT 8
+  `).all();
+
+  const openLoopCount = db.prepare(
+    'SELECT COUNT(*) AS n FROM entry_signals WHERE open_loop_flag = 1'
+  ).get().n;
+
+  const contradictionCount = db.prepare(
+    "SELECT COUNT(*) AS n FROM contradictions WHERE status = 'active'"
+  ).get().n;
+
+  const recentCaptures = db.prepare(`
+    SELECT id, content, created_at, COALESCE(user_category, category) AS category
+    FROM entries
+    ORDER BY created_at DESC
+    LIMIT 6
+  `).all();
+
+  const thoughtDensity = db.prepare(`
+    SELECT DATE(created_at) AS day, COUNT(*) AS count
+    FROM entries
+    WHERE created_at >= DATE('now', '-14 days')
+    GROUP BY DATE(created_at)
+    ORDER BY day ASC
+  `).all();
+
+  const weeklyEntryCount = db.prepare(`
+    SELECT COUNT(*) AS n FROM entries WHERE created_at >= DATE('now', '-7 days')
+  `).get().n;
+
+  return {
+    totalEntries,
+    activeThemes,
+    emergingThemes,
+    openLoopEntries,
+    openLoopCount,
+    contradictionCount,
+    recentCaptures,
+    thoughtDensity,
+    weeklyEntryCount,
+  };
+}
+
+module.exports = { getDashboardSummary };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -52,9 +52,9 @@
           <span class="nav-icon">&#11041;</span>
           <span class="nav-label">Graph</span>
         </button>
-        <button class="nav-item" data-view="explore" title="Explore">
+        <button class="nav-item" data-view="explore" title="Dashboard">
           <span class="nav-icon">&#8635;</span>
-          <span class="nav-label">Explore</span>
+          <span class="nav-label">Dashboard</span>
         </button>
       </nav>
 
@@ -395,13 +395,70 @@
           </div>
         </div>
 
-        <!-- ── View: Explore ─────────────────────────────────────── -->
+        <!-- ── View: Explore (Cognitive Dashboard) ──────────────── -->
         <div id="view-explore" class="view">
-          <div class="view-placeholder">
-            <div class="vp-icon">&#8635;</div>
-            <div class="vp-title">Explore</div>
-            <div class="vp-desc">Cognitive dashboard, memory replay, and agentic queries — coming in 0.6.x</div>
+          <div id="dash-header">
+            <span id="dash-title">Dashboard</span>
+            <button id="btn-dash-refresh" class="btn-sm" title="Refresh">↻</button>
           </div>
+          <div id="dash-body">
+
+            <!-- Row 1: stat cards -->
+            <div id="dash-stats-row">
+              <div class="dash-stat-card" id="dash-stat-entries">
+                <div class="dash-stat-num" id="dash-num-entries">—</div>
+                <div class="dash-stat-label">Total notes</div>
+              </div>
+              <div class="dash-stat-card" id="dash-stat-week">
+                <div class="dash-stat-num" id="dash-num-week">—</div>
+                <div class="dash-stat-label">This week</div>
+              </div>
+              <div class="dash-stat-card" id="dash-stat-loops">
+                <div class="dash-stat-num" id="dash-num-loops">—</div>
+                <div class="dash-stat-label">Open loops</div>
+              </div>
+              <div class="dash-stat-card" id="dash-stat-contradictions">
+                <div class="dash-stat-num" id="dash-num-contradictions">—</div>
+                <div class="dash-stat-label">Conflicts</div>
+              </div>
+            </div>
+
+            <!-- Row 2: thought density sparkbar -->
+            <div class="dash-section">
+              <div class="dash-section-title">Thought density <span class="dash-section-sub">last 14 days</span></div>
+              <div id="dash-density-chart"></div>
+            </div>
+
+            <!-- Row 3: two columns -->
+            <div id="dash-two-col">
+
+              <!-- Left: active + emerging themes -->
+              <div class="dash-col">
+                <div class="dash-section">
+                  <div class="dash-section-title">Active themes <span class="dash-section-sub" id="dash-active-count"></span></div>
+                  <div id="dash-active-themes"></div>
+                </div>
+                <div class="dash-section">
+                  <div class="dash-section-title">Emerging themes <span class="dash-section-sub" id="dash-emerging-count"></span></div>
+                  <div id="dash-emerging-themes"></div>
+                </div>
+              </div>
+
+              <!-- Right: open loops + recent captures -->
+              <div class="dash-col">
+                <div class="dash-section">
+                  <div class="dash-section-title">Open loops <span class="dash-section-sub" id="dash-loops-count"></span></div>
+                  <div id="dash-open-loops"></div>
+                </div>
+                <div class="dash-section">
+                  <div class="dash-section-title">Recent captures</div>
+                  <div id="dash-recent-captures"></div>
+                </div>
+              </div>
+
+            </div><!-- /#dash-two-col -->
+
+          </div><!-- /#dash-body -->
         </div>
 
       </div><!-- /#view-container -->

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -405,19 +405,19 @@
 
             <!-- Row 1: stat cards -->
             <div id="dash-stats-row">
-              <div class="dash-stat-card" id="dash-stat-entries">
+              <div class="dash-stat-card dash-stat-link" id="dash-stat-entries" title="Go to Library">
                 <div class="dash-stat-num" id="dash-num-entries">—</div>
                 <div class="dash-stat-label">Total notes</div>
               </div>
-              <div class="dash-stat-card" id="dash-stat-week">
+              <div class="dash-stat-card dash-stat-link" id="dash-stat-week" title="Go to Library">
                 <div class="dash-stat-num" id="dash-num-week">—</div>
                 <div class="dash-stat-label">This week</div>
               </div>
-              <div class="dash-stat-card" id="dash-stat-loops">
+              <div class="dash-stat-card dash-stat-link" id="dash-stat-loops" title="Go to open loops">
                 <div class="dash-stat-num" id="dash-num-loops">—</div>
                 <div class="dash-stat-label">Open loops</div>
               </div>
-              <div class="dash-stat-card" id="dash-stat-contradictions">
+              <div class="dash-stat-card dash-stat-link" id="dash-stat-contradictions" title="Go to Conflicts">
                 <div class="dash-stat-num" id="dash-num-contradictions">—</div>
                 <div class="dash-stat-label">Conflicts</div>
               </div>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2605,3 +2605,179 @@ html, body {
 .pri-spark-leg-e::before { background: var(--cortex-teal); }
 .pri-spark-leg-p::before { background: var(--neuro-blue); border-top: 1px dashed var(--neuro-blue); height: 0; }
 
+/* ── Cognitive Dashboard ───────────────────────────────────────────────────── */
+
+#view-explore {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#dash-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+#dash-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+}
+
+#dash-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 18px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* Stat cards row */
+#dash-stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.dash-stat-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  text-align: center;
+}
+.dash-stat-num {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.1;
+}
+.dash-stat-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+#dash-stat-loops     .dash-stat-num { color: var(--cortex-teal); }
+#dash-stat-contradictions .dash-stat-num { color: #c0513a; }
+
+/* Section */
+.dash-section {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.dash-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+.dash-section-sub {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  margin-left: 4px;
+}
+
+/* Thought density bar chart */
+#dash-density-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 36px;
+}
+.dash-density-bar {
+  flex: 1;
+  background: var(--cortex-teal);
+  border-radius: 2px 2px 0 0;
+  min-height: 2px;
+  opacity: 0.75;
+  transition: opacity 0.15s;
+}
+.dash-density-bar:hover { opacity: 1; }
+
+/* Two column layout */
+#dash-two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.dash-col {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Theme chips */
+.dash-theme-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+}
+.dash-theme-chip:last-child { border-bottom: none; }
+.dash-theme-chip:hover { color: var(--cortex-teal); }
+.dash-theme-entry-count {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-left: auto;
+}
+.dash-emerging-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cortex-teal);
+  flex-shrink: 0;
+}
+
+/* Open loop items */
+.dash-loop-item {
+  font-size: 12px;
+  color: var(--text);
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dash-loop-item:last-child { border-bottom: none; }
+
+/* Recent capture items */
+.dash-capture-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text);
+}
+.dash-capture-item:last-child { border-bottom: none; }
+.dash-capture-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dash-capture-cat {
+  font-size: 10px;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.dash-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 4px 0;
+}
+

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2608,7 +2608,6 @@ html, body {
 /* ── Cognitive Dashboard ───────────────────────────────────────────────────── */
 
 #view-explore {
-  display: flex;
   flex-direction: column;
   overflow: hidden;
 }
@@ -2649,6 +2648,14 @@ html, body {
   border-radius: 8px;
   padding: 12px 14px;
   text-align: center;
+}
+.dash-stat-link {
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.dash-stat-link:hover {
+  border-color: var(--cortex-teal);
+  background: var(--surface3, var(--surface2));
 }
 .dash-stat-num {
   font-size: 26px;
@@ -2750,8 +2757,10 @@ html, body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
 }
 .dash-loop-item:last-child { border-bottom: none; }
+.dash-loop-item:hover { color: var(--cortex-teal); }
 
 /* Recent capture items */
 .dash-capture-item {
@@ -2762,8 +2771,10 @@ html, body {
   border-bottom: 1px solid var(--border);
   font-size: 12px;
   color: var(--text);
+  cursor: pointer;
 }
 .dash-capture-item:last-child { border-bottom: none; }
+.dash-capture-item:hover .dash-capture-text { color: var(--cortex-teal); }
 .dash-capture-text {
   flex: 1;
   white-space: nowrap;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -2562,21 +2562,38 @@ function _truncate(text, len = 72) {
   return text.length > len ? text.slice(0, len) + '…' : text;
 }
 
+/** Navigate to a view and then call an action once rendered */
+function _dashNavigate(viewId, action) {
+  activateView(viewId);
+  if (action) setTimeout(action, 160);
+}
+
 async function loadDashboardView() {
   try {
     const d = await window.neurologue.getDashboardSummary();
 
-    // Stat cards
+    // Stat cards — deep links
     dashNumEntries.textContent        = d.totalEntries ?? 0;
     dashNumWeek.textContent           = d.weeklyEntryCount ?? 0;
     dashNumLoops.textContent          = d.openLoopCount ?? 0;
     dashNumContradictions.textContent = d.contradictionCount ?? 0;
 
+    document.getElementById('dash-stat-entries').onclick =
+      () => _dashNavigate('library');
+    document.getElementById('dash-stat-week').onclick =
+      () => _dashNavigate('library');
+    document.getElementById('dash-stat-contradictions').onclick =
+      () => _dashNavigate('contradictions');
+    document.getElementById('dash-stat-loops').onclick = () => {
+      if (d.openLoopEntries.length > 0) {
+        _dashNavigate('library', () => selectEntry(d.openLoopEntries[0].id));
+      }
+    };
+
     // Thought density bar chart
     dashDensityChart.innerHTML = '';
     if (d.thoughtDensity && d.thoughtDensity.length > 0) {
       const maxCount = Math.max(...d.thoughtDensity.map((r) => r.count), 1);
-      // Fill all 14 slots (gaps = 0)
       const dayMap = Object.fromEntries(d.thoughtDensity.map((r) => [r.day, r.count]));
       for (let i = 13; i >= 0; i--) {
         const d2 = new Date(Date.now() - i * 86400000);
@@ -2590,7 +2607,7 @@ async function loadDashboardView() {
       }
     }
 
-    // Active themes
+    // Active themes — navigate to Themes and select
     dashActiveCount.textContent = d.activeThemes.length ? `(${d.activeThemes.length})` : '';
     dashActiveThemes.innerHTML = '';
     if (d.activeThemes.length === 0) {
@@ -2600,19 +2617,14 @@ async function loadDashboardView() {
         const el = document.createElement('div');
         el.className = 'dash-theme-chip';
         el.innerHTML = `<span>${t.display_name}</span><span class="dash-theme-entry-count">${t.entry_count} entries</span>`;
-        el.addEventListener('click', () => {
-          activateView('themes');
-          // Let themes view load then select this theme
-          setTimeout(() => {
-            const row = document.querySelector(`.theme-list-item[data-theme-id="${t.id}"]`);
-            if (row) row.click();
-          }, 150);
-        });
+        el.addEventListener('click', () =>
+          _dashNavigate('themes', () => selectThemeView(t.id))
+        );
         dashActiveThemes.appendChild(el);
       });
     }
 
-    // Emerging themes
+    // Emerging themes — navigate to Themes and select
     dashEmergingCount.textContent = d.emergingThemes.length ? `(${d.emergingThemes.length})` : '';
     dashEmergingThemes.innerHTML = '';
     if (d.emergingThemes.length === 0) {
@@ -2622,11 +2634,14 @@ async function loadDashboardView() {
         const el = document.createElement('div');
         el.className = 'dash-theme-chip';
         el.innerHTML = `<div class="dash-emerging-dot"></div><span>${t.display_name}</span><span class="dash-theme-entry-count">${t.entry_count} entries</span>`;
+        el.addEventListener('click', () =>
+          _dashNavigate('themes', () => selectThemeView(t.id))
+        );
         dashEmergingThemes.appendChild(el);
       });
     }
 
-    // Open loops
+    // Open loops — navigate to Library and select the entry
     dashLoopsCount.textContent = d.openLoopCount ? `(${d.openLoopCount})` : '';
     dashOpenLoops.innerHTML = '';
     if (d.openLoopEntries.length === 0) {
@@ -2637,11 +2652,14 @@ async function loadDashboardView() {
         el.className = 'dash-loop-item';
         el.textContent = _truncate(e.content, 80);
         el.title = e.content;
+        el.addEventListener('click', () =>
+          _dashNavigate('library', () => selectEntry(e.id))
+        );
         dashOpenLoops.appendChild(el);
       });
     }
 
-    // Recent captures
+    // Recent captures — navigate to Library and select the entry
     dashRecentCaptures.innerHTML = '';
     if (d.recentCaptures.length === 0) {
       dashRecentCaptures.innerHTML = '<div class="dash-empty">No notes yet</div>';
@@ -2651,6 +2669,9 @@ async function loadDashboardView() {
         el.className = 'dash-capture-item';
         el.innerHTML = `<span class="dash-capture-text">${_truncate(e.content, 60)}</span>${e.category ? `<span class="dash-capture-cat">${e.category}</span>` : ''}`;
         el.title = e.content;
+        el.addEventListener('click', () =>
+          _dashNavigate('library', () => selectEntry(e.id))
+        );
         dashRecentCaptures.appendChild(el);
       });
     }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1907,6 +1907,7 @@ function activateView(viewId) {
   if (viewId === 'themes')         loadThemesView();
   if (viewId === 'contradictions') loadContradictionsView();
   if (viewId === 'priorities')     loadPrioritiesView();
+  if (viewId === 'explore')        loadDashboardView();
 }
 
 navItems.forEach(btn => {
@@ -2539,6 +2540,126 @@ btnPriRecompute.addEventListener('click', async () => {
     btnPriRecompute.textContent = '↻';
   }
 });
+
+// ── Cognitive Dashboard view controller ─────────────────────────────────────
+
+const dashNumEntries       = document.getElementById('dash-num-entries');
+const dashNumWeek          = document.getElementById('dash-num-week');
+const dashNumLoops         = document.getElementById('dash-num-loops');
+const dashNumContradictions = document.getElementById('dash-num-contradictions');
+const dashDensityChart     = document.getElementById('dash-density-chart');
+const dashActiveThemes     = document.getElementById('dash-active-themes');
+const dashActiveCount      = document.getElementById('dash-active-count');
+const dashEmergingThemes   = document.getElementById('dash-emerging-themes');
+const dashEmergingCount    = document.getElementById('dash-emerging-count');
+const dashOpenLoops        = document.getElementById('dash-open-loops');
+const dashLoopsCount       = document.getElementById('dash-loops-count');
+const dashRecentCaptures   = document.getElementById('dash-recent-captures');
+const btnDashRefresh       = document.getElementById('btn-dash-refresh');
+
+function _truncate(text, len = 72) {
+  if (!text) return '—';
+  return text.length > len ? text.slice(0, len) + '…' : text;
+}
+
+async function loadDashboardView() {
+  try {
+    const d = await window.neurologue.getDashboardSummary();
+
+    // Stat cards
+    dashNumEntries.textContent        = d.totalEntries ?? 0;
+    dashNumWeek.textContent           = d.weeklyEntryCount ?? 0;
+    dashNumLoops.textContent          = d.openLoopCount ?? 0;
+    dashNumContradictions.textContent = d.contradictionCount ?? 0;
+
+    // Thought density bar chart
+    dashDensityChart.innerHTML = '';
+    if (d.thoughtDensity && d.thoughtDensity.length > 0) {
+      const maxCount = Math.max(...d.thoughtDensity.map((r) => r.count), 1);
+      // Fill all 14 slots (gaps = 0)
+      const dayMap = Object.fromEntries(d.thoughtDensity.map((r) => [r.day, r.count]));
+      for (let i = 13; i >= 0; i--) {
+        const d2 = new Date(Date.now() - i * 86400000);
+        const key = d2.toISOString().slice(0, 10);
+        const count = dayMap[key] || 0;
+        const bar = document.createElement('div');
+        bar.className = 'dash-density-bar';
+        bar.style.height = `${Math.max(4, Math.round((count / maxCount) * 36))}px`;
+        bar.title = `${key}: ${count} note${count !== 1 ? 's' : ''}`;
+        dashDensityChart.appendChild(bar);
+      }
+    }
+
+    // Active themes
+    dashActiveCount.textContent = d.activeThemes.length ? `(${d.activeThemes.length})` : '';
+    dashActiveThemes.innerHTML = '';
+    if (d.activeThemes.length === 0) {
+      dashActiveThemes.innerHTML = '<div class="dash-empty">No recent theme activity</div>';
+    } else {
+      d.activeThemes.forEach((t) => {
+        const el = document.createElement('div');
+        el.className = 'dash-theme-chip';
+        el.innerHTML = `<span>${t.display_name}</span><span class="dash-theme-entry-count">${t.entry_count} entries</span>`;
+        el.addEventListener('click', () => {
+          activateView('themes');
+          // Let themes view load then select this theme
+          setTimeout(() => {
+            const row = document.querySelector(`.theme-list-item[data-theme-id="${t.id}"]`);
+            if (row) row.click();
+          }, 150);
+        });
+        dashActiveThemes.appendChild(el);
+      });
+    }
+
+    // Emerging themes
+    dashEmergingCount.textContent = d.emergingThemes.length ? `(${d.emergingThemes.length})` : '';
+    dashEmergingThemes.innerHTML = '';
+    if (d.emergingThemes.length === 0) {
+      dashEmergingThemes.innerHTML = '<div class="dash-empty">No new themes this week</div>';
+    } else {
+      d.emergingThemes.forEach((t) => {
+        const el = document.createElement('div');
+        el.className = 'dash-theme-chip';
+        el.innerHTML = `<div class="dash-emerging-dot"></div><span>${t.display_name}</span><span class="dash-theme-entry-count">${t.entry_count} entries</span>`;
+        dashEmergingThemes.appendChild(el);
+      });
+    }
+
+    // Open loops
+    dashLoopsCount.textContent = d.openLoopCount ? `(${d.openLoopCount})` : '';
+    dashOpenLoops.innerHTML = '';
+    if (d.openLoopEntries.length === 0) {
+      dashOpenLoops.innerHTML = '<div class="dash-empty">No open loops detected</div>';
+    } else {
+      d.openLoopEntries.forEach((e) => {
+        const el = document.createElement('div');
+        el.className = 'dash-loop-item';
+        el.textContent = _truncate(e.content, 80);
+        el.title = e.content;
+        dashOpenLoops.appendChild(el);
+      });
+    }
+
+    // Recent captures
+    dashRecentCaptures.innerHTML = '';
+    if (d.recentCaptures.length === 0) {
+      dashRecentCaptures.innerHTML = '<div class="dash-empty">No notes yet</div>';
+    } else {
+      d.recentCaptures.forEach((e) => {
+        const el = document.createElement('div');
+        el.className = 'dash-capture-item';
+        el.innerHTML = `<span class="dash-capture-text">${_truncate(e.content, 60)}</span>${e.category ? `<span class="dash-capture-cat">${e.category}</span>` : ''}`;
+        el.title = e.content;
+        dashRecentCaptures.appendChild(el);
+      });
+    }
+  } catch (err) {
+    console.error('[dashboard] loadDashboardView failed:', err);
+  }
+}
+
+btnDashRefresh.addEventListener('click', loadDashboardView);
 
 // ── Init ────────────────────────────────────────────────────────────
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -57,6 +57,9 @@ contextBridge.exposeInMainWorld('neurologue', {
   onWorkerTaskStarted:    (cb) => { ipcRenderer.on('worker:task-started',     (_e, d) => cb(d)); },
   onWorkerTaskCompleted:  (cb) => { ipcRenderer.on('worker:task-completed',   (_e, d) => cb(d)); },
 
+  // ── Dashboard ────────────────────────────────────────────────────────────
+  getDashboardSummary: () => ipcRenderer.invoke('dashboard:summary'),
+
   // ── Contradictions ───────────────────────────────────────────────────────
   listContradictions:   (opts) => ipcRenderer.invoke('contradictions:list', opts),
   resolveContradiction: (id, notes) => ipcRenderer.invoke('contradictions:resolve', { id, notes }),

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ const { runExport } = require('./backend/export/runner');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
 const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
+const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 // getOllamaStatus and getSettings imported above
 
@@ -333,6 +334,10 @@ ipcMain.handle('contradictions:dismiss', async (_e, { id }) => {
 ipcMain.handle('contradictions:scan', async () => {
   return scanContradictions();
 });
+
+// ── Dashboard IPC ──────────────────────────────────────────────────────────────
+
+handle('dashboard:summary', async () => getDashboardSummary());
 
 // ── Priorities IPC ───────────────────────────────────────────────────────────
 

--- a/tests/unit/db/dashboard.test.js
+++ b/tests/unit/db/dashboard.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+let tmpDir;
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-dash-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+async function seedEntry(content = 'Hello world') {
+  const { createEntry } = require('../../../src/backend/db/entries');
+  return createEntry({ content });
+}
+
+async function seedTheme(name = 'Test Theme') {
+  const { randomUUID } = require('crypto');
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  const id = randomUUID();
+  db.prepare('INSERT INTO themes (id, name) VALUES (?, ?)').run(id, name);
+  return id;
+}
+
+describe('getDashboardSummary', () => {
+  test('returns zeros for an empty database', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    const summary = await getDashboardSummary();
+    expect(summary.totalEntries).toBe(0);
+    expect(summary.weeklyEntryCount).toBe(0);
+    expect(summary.openLoopCount).toBe(0);
+    expect(summary.contradictionCount).toBe(0);
+    expect(summary.recentCaptures).toEqual([]);
+    expect(summary.thoughtDensity).toEqual([]);
+    expect(summary.activeThemes).toEqual([]);
+    expect(summary.emergingThemes).toEqual([]);
+    expect(summary.openLoopEntries).toEqual([]);
+  });
+
+  test('counts total entries and recent captures', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    await seedEntry('Entry one');
+    await seedEntry('Entry two');
+    const summary = await getDashboardSummary();
+    expect(summary.totalEntries).toBe(2);
+    expect(summary.recentCaptures).toHaveLength(2);
+    expect(summary.weeklyEntryCount).toBe(2);
+  });
+
+  test('counts active contradictions', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    const e1 = await seedEntry('Contradiction A');
+    const e2 = await seedEntry('Contradiction B');
+    const { randomUUID } = require('crypto');
+    const { openDb } = require('../../../src/backend/db/connection');
+    const db = await openDb();
+    // canonical order: lexicographically smaller id first
+    const [a, b] = [e1.id, e2.id].sort();
+    db.prepare(
+      "INSERT INTO contradictions (id, entry_a_id, entry_b_id, status) VALUES (?, ?, ?, 'active')"
+    ).run(randomUUID(), a, b);
+    const summary = await getDashboardSummary();
+    expect(summary.contradictionCount).toBe(1);
+  });
+
+  test('counts open loops from entry_signals', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    const entry = await seedEntry('I need to finish this task…');
+    const themeId = await seedTheme();
+    const { upsertEntrySignals } = require('../../../src/backend/db/entry_signals');
+    await upsertEntrySignals({
+      entry_id: entry.id,
+      theme_id: themeId,
+      length_tokens: 8,
+      sentiment_score: 0.1,
+      emotional_intensity: 0.3,
+      obligation_flag: 1,
+      motivation_flag: 0,
+      value_reference_flag: 0,
+      open_loop_flag: 1,
+    });
+    const summary = await getDashboardSummary();
+    expect(summary.openLoopCount).toBe(1);
+    expect(summary.openLoopEntries).toHaveLength(1);
+    expect(summary.openLoopEntries[0].id).toBe(entry.id);
+  });
+
+  test('identifies emerging themes (first entry today)', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    const entry = await seedEntry('New theme entry');
+    const themeId = await seedTheme('Brand New Theme');
+    const { openDb } = require('../../../src/backend/db/connection');
+    const db = await openDb();
+    db.prepare('INSERT INTO theme_entries (theme_id, entry_id, score) VALUES (?, ?, ?)').run(themeId, entry.id, 1.0);
+    const summary = await getDashboardSummary();
+    expect(summary.emergingThemes.length).toBeGreaterThanOrEqual(1);
+    const found = summary.emergingThemes.find((t) => t.id === themeId);
+    expect(found).toBeDefined();
+    expect(found.display_name).toBe('Brand New Theme');
+  });
+
+  test('returns correct shape for all fields', async () => {
+    const { getDashboardSummary } = require('../../../src/backend/db/dashboard');
+    const summary = await getDashboardSummary();
+    expect(summary).toMatchObject({
+      totalEntries:       expect.any(Number),
+      weeklyEntryCount:   expect.any(Number),
+      openLoopCount:      expect.any(Number),
+      contradictionCount: expect.any(Number),
+      recentCaptures:     expect.any(Array),
+      thoughtDensity:     expect.any(Array),
+      activeThemes:       expect.any(Array),
+      emergingThemes:     expect.any(Array),
+      openLoopEntries:    expect.any(Array),
+    });
+  });
+});


### PR DESCRIPTION
Closes #56

## Changes
- Cognitive dashboard view with stat cards, thought density chart, active/emerging themes, open loops, and recent captures
- All dashboard items deep-link: stat cards route to Library/Contradictions, theme chips select the theme in Themes view, loop/capture items open the entry in Library
- Fixed theme click selector to use `selectThemeView()`
- Backend: `getDashboardSummary()` aggregates all signals in one DB call
- IPC: `dashboard:summary` handler + preload API
- 6 unit tests for `getDashboardSummary`
