### PR TITLE
feat: interactive knowledge graph — force-directed canvas visualisation (#57)

### DIFF
--- a/src/backend/db/graph.js
+++ b/src/backend/db/graph.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { openDb } = require('./connection');
+
+/**
+ * Build graph data for the knowledge graph view.
+ *
+ * Nodes  — one per theme, with label and entry count.
+ * Edges  — one per pair of themes that share ≥1 entry; weight = shared count.
+ *
+ * @returns {Promise<{ nodes: object[], edges: object[] }>}
+ */
+async function getGraphData() {
+  const db = await openDb();
+
+  const themes = db.prepare(`
+    SELECT t.id,
+           COALESCE(t.user_name, t.name) AS label,
+           COUNT(te.entry_id)            AS entry_count
+    FROM   themes t
+    LEFT JOIN theme_entries te ON te.theme_id = t.id
+    GROUP  BY t.id
+    ORDER  BY entry_count DESC
+  `).all();
+
+  if (themes.length === 0) return { nodes: [], edges: [] };
+
+  // All theme_entries rows — used to compute pairwise overlap
+  const teRows = db.prepare('SELECT theme_id, entry_id FROM theme_entries').all();
+
+  // Build theme → entry-id Set map
+  const themeToEntries = Object.create(null);
+  teRows.forEach(({ theme_id, entry_id }) => {
+    if (!themeToEntries[theme_id]) themeToEntries[theme_id] = new Set();
+    themeToEntries[theme_id].add(entry_id);
+  });
+
+  // Pairwise overlap edges (O(n²) over themes, which are few)
+  const edges = [];
+  for (let i = 0; i < themes.length; i++) {
+    for (let j = i + 1; j < themes.length; j++) {
+      const a = themeToEntries[themes[i].id] || new Set();
+      const b = themeToEntries[themes[j].id] || new Set();
+      let shared = 0;
+      a.forEach((e) => { if (b.has(e)) shared++; });
+      if (shared > 0) {
+        edges.push({ source: themes[i].id, target: themes[j].id, weight: shared });
+      }
+    }
+  }
+
+  const nodes = themes.map((t) => ({
+    id:         t.id,
+    label:      t.label || `Theme ${t.id.slice(0, 6)}`,
+    entryCount: t.entry_count,
+  }));
+
+  return { nodes, edges };
+}
+
+module.exports = { getGraphData };

--- a/src/frontend/graph.js
+++ b/src/frontend/graph.js
@@ -1,0 +1,531 @@
+'use strict';
+/* global window, document, requestAnimationFrame, cancelAnimationFrame */
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const REPULSION      = 4000;   // Coulomb repulsion between all pairs
+const SPRING_LEN     = 160;    // Ideal edge length (px)
+const SPRING_K       = 0.04;   // Spring stiffness
+const GRAVITY        = 0.008;  // Pull toward canvas centre
+const DAMPING        = 0.82;   // Velocity damping per tick
+const MIN_RADIUS     = 14;
+const MAX_RADIUS     = 44;
+const TICK_THRESHOLD = 0.15;   // Stop simulation when max velocity < this
+const MAX_TICKS      = 600;    // Hard cap to prevent infinite loops
+
+// ── Colour palette (brand-aligned) ─────────────────────────────────────────
+
+const PALETTE = [
+  '#2AA6A1', '#5FD4E6', '#6A8FA8', '#4DB6AC', '#80CBC4',
+  '#26A69A', '#4DD0E1', '#4FC3F7', '#29B6F6', '#26C6DA',
+  '#80DEEA', '#4CAF50', '#81C784', '#AED581', '#DCE775',
+  '#FFD54F', '#FFB74D', '#FF8A65', '#A1887F', '#90A4AE',
+];
+
+function paletteColor(id) {
+  let h = 5381;
+  for (let i = 0; i < id.length; i++) {
+    h = ((h << 5) + h) ^ id.charCodeAt(i);
+    h = h & 0x7fffffff;
+  }
+  return PALETTE[h % PALETTE.length];
+}
+
+// ── Graph state ─────────────────────────────────────────────────────────────
+
+let _canvas    = null;
+let _ctx       = null;
+let _nodes     = [];   // { id, label, entryCount, x, y, vx, vy, r, color }
+let _edges     = [];   // { sourceIdx, targetIdx, weight, alpha }
+let _rafId     = null;
+let _tickCount = 0;
+
+// Viewport transform
+let _scale  = 1;
+let _tx     = 0;   // translation x
+let _ty     = 0;   // translation y
+
+// Interaction state
+let _draggingNode = null;
+let _draggingBg   = false;
+let _dragStart    = { x: 0, y: 0 };
+let _tooltip      = null;
+
+// Navigation callback — called with theme id when user clicks a node
+let _onNavigate = null;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Initialise the graph inside `container`.
+ * @param {HTMLElement} container
+ * @param {Function}    onNavigate  (themeId) => void
+ */
+function graphInit(container, onNavigate) {
+  _onNavigate = onNavigate;
+
+  // Create canvas
+  _canvas = document.createElement('canvas');
+  _canvas.className = 'graph-canvas';
+  container.appendChild(_canvas);
+
+  // Create tooltip element
+  _tooltip = document.createElement('div');
+  _tooltip.className = 'graph-tooltip hidden';
+  container.appendChild(_tooltip);
+
+  _ctx = _canvas.getContext('2d');
+
+  _bindEvents();
+  _resizeCanvas();
+  window.addEventListener('resize', _resizeCanvas);
+}
+
+/**
+ * Load graph data and start the simulation.
+ * @param {{ nodes: object[], edges: object[] }} data
+ */
+function graphLoad(data) {
+  _stopSim();
+  _initNodes(data.nodes);
+  _initEdges(data.edges);
+  _resetViewport();
+  _startSim();
+}
+
+/** Clean up — call when the view is unmounted. */
+function graphDestroy() {
+  _stopSim();
+  window.removeEventListener('resize', _resizeCanvas);
+  if (_canvas) {
+    _unbindEvents();
+    _canvas.remove();
+    _canvas = null;
+  }
+  if (_tooltip) {
+    _tooltip.remove();
+    _tooltip = null;
+  }
+  _nodes = [];
+  _edges = [];
+  _onNavigate = null;
+}
+
+// ── Initialisation helpers ───────────────────────────────────────────────────
+
+function _initNodes(rawNodes) {
+  if (!rawNodes || rawNodes.length === 0) { _nodes = []; return; }
+
+  const maxCount = Math.max(...rawNodes.map((n) => n.entryCount || 0), 1);
+  const W = _canvas ? _canvas.width  : 800;
+  const H = _canvas ? _canvas.height : 600;
+
+  _nodes = rawNodes.map((n) => {
+    const t = Math.sqrt((n.entryCount || 0) / maxCount);
+    const r = MIN_RADIUS + t * (MAX_RADIUS - MIN_RADIUS);
+    return {
+      id:         n.id,
+      label:      n.label,
+      entryCount: n.entryCount || 0,
+      x:          W / 2 + (Math.random() - 0.5) * Math.min(W, H) * 0.5,
+      y:          H / 2 + (Math.random() - 0.5) * Math.min(W, H) * 0.5,
+      vx:         0,
+      vy:         0,
+      r,
+      color:      paletteColor(n.id),
+    };
+  });
+}
+
+function _initEdges(rawEdges) {
+  if (!rawEdges || rawEdges.length === 0) { _edges = []; return; }
+
+  const idxMap = Object.create(null);
+  _nodes.forEach((n, i) => { idxMap[n.id] = i; });
+
+  const maxW = Math.max(...rawEdges.map((e) => e.weight || 1), 1);
+
+  _edges = rawEdges
+    .filter((e) => idxMap[e.source] !== undefined && idxMap[e.target] !== undefined)
+    .map((e) => ({
+      sourceIdx: idxMap[e.source],
+      targetIdx: idxMap[e.target],
+      weight:    e.weight || 1,
+      alpha:     0.2 + 0.6 * ((e.weight || 1) / maxW),
+    }));
+}
+
+// ── Viewport ─────────────────────────────────────────────────────────────────
+
+function _resetViewport() {
+  _scale = 1;
+  if (_canvas) {
+    _tx = _canvas.width  / 2;
+    _ty = _canvas.height / 2;
+  }
+}
+
+function _resizeCanvas() {
+  if (!_canvas) return;
+  const parent = _canvas.parentElement;
+  if (!parent) return;
+  const rect = parent.getBoundingClientRect();
+  _canvas.width  = rect.width  || 800;
+  _canvas.height = rect.height || 600;
+  _render();
+}
+
+// ── Simulation ───────────────────────────────────────────────────────────────
+
+function _startSim() {
+  _tickCount = 0;
+  function loop() {
+    _tick();
+    _render();
+    _tickCount++;
+    const maxV = _nodes.reduce((m, n) => Math.max(m, Math.abs(n.vx), Math.abs(n.vy)), 0);
+    if (maxV > TICK_THRESHOLD && _tickCount < MAX_TICKS) {
+      _rafId = requestAnimationFrame(loop);
+    } else {
+      _rafId = null;
+      _render(); // final render
+    }
+  }
+  _rafId = requestAnimationFrame(loop);
+}
+
+function _stopSim() {
+  if (_rafId !== null) {
+    cancelAnimationFrame(_rafId);
+    _rafId = null;
+  }
+}
+
+function _resumeSim() {
+  if (_rafId !== null) return; // already running
+  _tickCount = 0;
+  _startSim();
+}
+
+function _tick() {
+  const n = _nodes;
+  if (n.length === 0) return;
+
+  const W = _canvas.width  / _scale;
+  const H = _canvas.height / _scale;
+
+  // Centre of mass in graph space (approximate gravity target)
+  const cx = -_tx / _scale + _canvas.width  / 2 / _scale;
+  const cy = -_ty / _scale + _canvas.height / 2 / _scale;
+
+  // Zero forces
+  const fx = new Float64Array(n.length);
+  const fy = new Float64Array(n.length);
+
+  // Repulsion (pairwise)
+  for (let i = 0; i < n.length; i++) {
+    for (let j = i + 1; j < n.length; j++) {
+      const dx = n[j].x - n[i].x;
+      const dy = n[j].y - n[i].y;
+      const d2 = dx * dx + dy * dy + 1;
+      const f  = REPULSION / d2;
+      const nx = dx / Math.sqrt(d2);
+      const ny = dy / Math.sqrt(d2);
+      fx[i] -= f * nx;
+      fy[i] -= f * ny;
+      fx[j] += f * nx;
+      fy[j] += f * ny;
+    }
+  }
+
+  // Spring attraction along edges
+  _edges.forEach(({ sourceIdx, targetIdx }) => {
+    const a = n[sourceIdx];
+    const b = n[targetIdx];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    const stretch = dist - SPRING_LEN;
+    const f = SPRING_K * stretch;
+    fx[sourceIdx] += f * (dx / dist);
+    fy[sourceIdx] += f * (dy / dist);
+    fx[targetIdx] -= f * (dx / dist);
+    fy[targetIdx] -= f * (dy / dist);
+  });
+
+  // Gravity toward canvas centre
+  n.forEach((node, i) => {
+    fx[i] += GRAVITY * (cx - node.x);
+    fy[i] += GRAVITY * (cy - node.y);
+  });
+
+  // Integrate + damp
+  n.forEach((node, i) => {
+    if (node === _draggingNode) return; // frozen during drag
+    node.vx = (node.vx + fx[i]) * DAMPING;
+    node.vy = (node.vy + fy[i]) * DAMPING;
+    node.x += node.vx;
+    node.y += node.vy;
+  });
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+function _render() {
+  if (!_ctx || !_canvas) return;
+  const ctx = _ctx;
+  const W = _canvas.width;
+  const H = _canvas.height;
+
+  ctx.clearRect(0, 0, W, H);
+
+  ctx.save();
+  ctx.translate(_tx, _ty);
+  ctx.scale(_scale, _scale);
+
+  // Edges
+  _edges.forEach(({ sourceIdx, targetIdx, alpha, weight }) => {
+    const a = _nodes[sourceIdx];
+    const b = _nodes[targetIdx];
+    if (!a || !b) return;
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    const isDark = document.body.classList.contains('theme-light') ? false : true;
+    ctx.strokeStyle = isDark
+      ? `rgba(95, 212, 230, ${alpha * 0.6})`
+      : `rgba(28, 42, 58, ${alpha * 0.5})`;
+    ctx.lineWidth = Math.max(0.5, Math.min(4, weight * 0.4)) / _scale;
+    ctx.stroke();
+  });
+
+  // Nodes
+  _nodes.forEach((node) => {
+    // Shadow glow
+    ctx.shadowBlur  = node === _draggingNode ? 18 : 8;
+    ctx.shadowColor = node.color;
+
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2);
+    ctx.fillStyle = node.color;
+    ctx.fill();
+
+    ctx.shadowBlur = 0;
+
+    // Border
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2);
+    const isDark = !document.body.classList.contains('theme-light');
+    ctx.strokeStyle = isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.2)';
+    ctx.lineWidth = 1.5 / _scale;
+    ctx.stroke();
+
+    // Label (always shown for nodes with r >= 20; small nodes only on hover)
+    const showLabel = node.r * _scale >= 20;
+    if (showLabel) {
+      const fontSize = Math.max(9, Math.min(13, node.r * 0.55));
+      ctx.font      = `500 ${fontSize}px Inter, system-ui, sans-serif`;
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.shadowBlur   = 3;
+      ctx.shadowColor  = 'rgba(0,0,0,0.7)';
+
+      // Truncate label to fit inside node
+      const maxW = node.r * 1.6;
+      let text = node.label;
+      while (ctx.measureText(text).width > maxW && text.length > 3) {
+        text = text.slice(0, -1);
+      }
+      if (text !== node.label) text = text.trim() + '…';
+      ctx.fillText(text, node.x, node.y);
+      ctx.shadowBlur = 0;
+    }
+  });
+
+  ctx.restore();
+
+  // Empty-state message
+  if (_nodes.length === 0) {
+    ctx.font      = '16px Inter, system-ui, sans-serif';
+    ctx.fillStyle = 'rgba(128,128,128,0.7)';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('No themes yet — capture some thoughts and run clustering', W / 2, H / 2);
+  }
+}
+
+// ── Event binding ────────────────────────────────────────────────────────────
+
+function _bindEvents() {
+  _canvas.addEventListener('mousedown',  _onMouseDown);
+  _canvas.addEventListener('mousemove',  _onMouseMove);
+  _canvas.addEventListener('mouseup',    _onMouseUp);
+  _canvas.addEventListener('mouseleave', _onMouseLeave);
+  _canvas.addEventListener('wheel',      _onWheel,      { passive: false });
+  _canvas.addEventListener('click',      _onClick);
+  _canvas.addEventListener('dblclick',   _onDblClick);
+}
+
+function _unbindEvents() {
+  if (!_canvas) return;
+  _canvas.removeEventListener('mousedown',  _onMouseDown);
+  _canvas.removeEventListener('mousemove',  _onMouseMove);
+  _canvas.removeEventListener('mouseup',    _onMouseUp);
+  _canvas.removeEventListener('mouseleave', _onMouseLeave);
+  _canvas.removeEventListener('wheel',      _onWheel);
+  _canvas.removeEventListener('click',      _onClick);
+  _canvas.removeEventListener('dblclick',   _onDblClick);
+}
+
+// Convert canvas pixel coords to graph coords
+function _toGraph(px, py) {
+  return {
+    x: (px - _tx) / _scale,
+    y: (py - _ty) / _scale,
+  };
+}
+
+function _hitNode(px, py) {
+  const g = _toGraph(px, py);
+  for (let i = _nodes.length - 1; i >= 0; i--) {
+    const n = _nodes[i];
+    const dx = g.x - n.x;
+    const dy = g.y - n.y;
+    if (dx * dx + dy * dy <= n.r * n.r) return n;
+  }
+  return null;
+}
+
+function _onMouseDown(e) {
+  const rect = _canvas.getBoundingClientRect();
+  const px = e.clientX - rect.left;
+  const py = e.clientY - rect.top;
+  const hit = _hitNode(px, py);
+  if (hit) {
+    _draggingNode = hit;
+    _canvas.style.cursor = 'grabbing';
+    _resumeSim();
+  } else {
+    _draggingBg = true;
+    _dragStart  = { x: e.clientX - _tx, y: e.clientY - _ty };
+    _canvas.style.cursor = 'grabbing';
+  }
+}
+
+function _onMouseMove(e) {
+  const rect = _canvas.getBoundingClientRect();
+  const px = e.clientX - rect.left;
+  const py = e.clientY - rect.top;
+
+  if (_draggingNode) {
+    const g = _toGraph(px, py);
+    _draggingNode.x  = g.x;
+    _draggingNode.y  = g.y;
+    _draggingNode.vx = 0;
+    _draggingNode.vy = 0;
+    _render();
+    _hideTooltip();
+    return;
+  }
+
+  if (_draggingBg) {
+    _tx = e.clientX - _dragStart.x;
+    _ty = e.clientY - _dragStart.y;
+    _render();
+    return;
+  }
+
+  // Hover tooltip
+  const hit = _hitNode(px, py);
+  if (hit) {
+    _canvas.style.cursor = 'pointer';
+    _showTooltip(hit, e.clientX, e.clientY);
+  } else {
+    _canvas.style.cursor = '';
+    _hideTooltip();
+  }
+}
+
+function _onMouseUp() {
+  if (_draggingNode) {
+    _draggingNode.vx = 0;
+    _draggingNode.vy = 0;
+    _draggingNode = null;
+  }
+  _draggingBg = false;
+  _canvas.style.cursor = '';
+}
+
+function _onMouseLeave() {
+  _onMouseUp();
+  _hideTooltip();
+}
+
+function _onWheel(e) {
+  e.preventDefault();
+  const rect  = _canvas.getBoundingClientRect();
+  const px    = e.clientX - rect.left;
+  const py    = e.clientY - rect.top;
+  const delta = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+  const newScale = Math.min(4, Math.max(0.2, _scale * delta));
+  // Zoom toward cursor
+  _tx = px - (px - _tx) * (newScale / _scale);
+  _ty = py - (py - _ty) * (newScale / _scale);
+  _scale = newScale;
+  _render();
+}
+
+// Single click — navigate to themes view for this node
+function _onClick(e) {
+  if (_draggingBg) return; // was a pan
+  const rect = _canvas.getBoundingClientRect();
+  const px = e.clientX - rect.left;
+  const py = e.clientY - rect.top;
+  const hit = _hitNode(px, py);
+  if (hit && _onNavigate) _onNavigate(hit.id);
+}
+
+// Double-click background — reset zoom
+function _onDblClick(e) {
+  const rect = _canvas.getBoundingClientRect();
+  const px = e.clientX - rect.left;
+  const py = e.clientY - rect.top;
+  if (!_hitNode(px, py)) {
+    _resetViewport();
+    _render();
+  }
+}
+
+// ── Tooltip ──────────────────────────────────────────────────────────────────
+
+function _showTooltip(node, cx, cy) {
+  if (!_tooltip) return;
+  _tooltip.innerHTML =
+    `<strong>${_escHtml(node.label)}</strong>` +
+    `<span class="graph-tooltip-count">${node.entryCount} entr${node.entryCount === 1 ? 'y' : 'ies'}</span>` +
+    `<span class="graph-tooltip-hint">Click to open in Themes</span>`;
+
+  const rect   = _canvas.getBoundingClientRect();
+  const left   = cx - rect.left + 12;
+  const top    = cy - rect.top  - 8;
+  _tooltip.style.left = `${left}px`;
+  _tooltip.style.top  = `${top}px`;
+  _tooltip.classList.remove('hidden');
+}
+
+function _hideTooltip() {
+  if (_tooltip) _tooltip.classList.add('hidden');
+}
+
+function _escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── Export ───────────────────────────────────────────────────────────────────
+
+window.graphView = { graphInit, graphLoad, graphDestroy };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -388,11 +388,13 @@
 
         <!-- ── View: Graph ───────────────────────────────────────── -->
         <div id="view-graph" class="view">
-          <div class="view-placeholder">
-            <div class="vp-icon">&#11041;</div>
-            <div class="vp-title">Graph</div>
-            <div class="vp-desc">Knowledge graph and semantic cluster visualisation — coming in 0.6.x</div>
+          <div id="graph-toolbar">
+            <span id="graph-title">Knowledge Graph</span>
+            <span id="graph-node-count" class="graph-toolbar-sub"></span>
+            <button id="btn-graph-refresh" class="btn-sm" title="Reload graph data">↻ Refresh</button>
+            <button id="btn-graph-reset"   class="btn-sm btn-secondary" title="Reset zoom and layout">Reset</button>
           </div>
+          <div id="graph-container"></div>
         </div>
 
         <!-- ── View: Explore (Cognitive Dashboard) ──────────────── -->
@@ -691,6 +693,7 @@
     </div>
   </div>
 
+  <script src="graph.js"></script>
   <script src="library.js"></script>
 </body>
 </html>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2605,6 +2605,92 @@ html, body {
 .pri-spark-leg-e::before { background: var(--cortex-teal); }
 .pri-spark-leg-p::before { background: var(--neuro-blue); border-top: 1px dashed var(--neuro-blue); height: 0; }
 
+/* ── Knowledge Graph ────────────────────────────────────────────────────────── */
+
+#view-graph {
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+#graph-toolbar {
+  display:         flex;
+  align-items:     center;
+  gap:             10px;
+  padding:         8px 16px;
+  border-bottom:   1px solid var(--border);
+  flex-shrink:     0;
+  background:      var(--bg-secondary);
+}
+
+#graph-title {
+  font-size:   14px;
+  font-weight: 600;
+  color:       var(--text-primary);
+}
+
+.graph-toolbar-sub {
+  font-size:  12px;
+  color:      var(--text-muted);
+  flex:       1;
+}
+
+#graph-container {
+  flex:     1;
+  position: relative;
+  overflow: hidden;
+}
+
+.graph-canvas {
+  display:  block;
+  width:    100%;
+  height:   100%;
+  cursor:   default;
+}
+
+/* Tooltip */
+.graph-tooltip {
+  position:         absolute;
+  background:       var(--bg-secondary);
+  border:           1px solid var(--border);
+  border-radius:    6px;
+  padding:          8px 12px;
+  pointer-events:   none;
+  z-index:          20;
+  max-width:        220px;
+  box-shadow:       0 4px 16px rgba(0,0,0,0.35);
+  display:          flex;
+  flex-direction:   column;
+  gap:              2px;
+}
+
+.graph-tooltip.hidden { display: none; }
+
+.graph-tooltip strong {
+  font-size:   13px;
+  font-weight: 600;
+  color:       var(--text-primary);
+  white-space: nowrap;
+  overflow:    hidden;
+  text-overflow: ellipsis;
+}
+
+.graph-tooltip-count {
+  font-size: 11px;
+  color:     var(--text-muted);
+}
+
+.graph-tooltip-hint {
+  font-size:  10px;
+  color:      var(--cortex-teal);
+  margin-top: 2px;
+}
+
+/* Light-theme overrides */
+body.theme-light .graph-tooltip {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+}
+
 /* ── Cognitive Dashboard ───────────────────────────────────────────────────── */
 
 #view-explore {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -71,6 +71,12 @@ const heatmapMonths   = document.getElementById('heatmap-months');
 const filterBar    = document.getElementById('filter-bar');
 const categoryList = document.getElementById('category-list');
 
+// ── Graph DOM refs ─────────────────────────────────────────────────────────
+const graphContainer   = document.getElementById('graph-container');
+const graphNodeCount   = document.getElementById('graph-node-count');
+const btnGraphRefresh  = document.getElementById('btn-graph-refresh');
+const btnGraphReset    = document.getElementById('btn-graph-reset');
+
 // ── Utilities ──────────────────────────────────────────────────────────────
 
 function formatDate(dateStr) {
@@ -1908,6 +1914,9 @@ function activateView(viewId) {
   if (viewId === 'contradictions') loadContradictionsView();
   if (viewId === 'priorities')     loadPrioritiesView();
   if (viewId === 'explore')        loadDashboardView();
+  if (viewId === 'graph')          loadGraphView();
+  // Destroy graph renderer when leaving the graph view
+  if (viewId !== 'graph')          _destroyGraphIfActive();
 }
 
 navItems.forEach(btn => {
@@ -2539,6 +2548,56 @@ btnPriRecompute.addEventListener('click', async () => {
     btnPriRecompute.disabled = false;
     btnPriRecompute.textContent = '↻';
   }
+});
+
+// ── Knowledge Graph view controller ─────────────────────────────────────────
+
+let _graphInitialised = false;
+
+function _destroyGraphIfActive() {
+  if (_graphInitialised) {
+    window.graphView.graphDestroy();
+    _graphInitialised = false;
+  }
+}
+
+async function loadGraphView() {
+  // Initialise the renderer once
+  if (!_graphInitialised) {
+    window.graphView.graphInit(graphContainer, (themeId) => {
+      // Navigate to Themes view and select the clicked theme
+      activateView('themes');
+      selectThemeView(themeId);
+    });
+    _graphInitialised = true;
+  }
+
+  graphNodeCount.textContent = 'Loading…';
+  btnGraphRefresh.disabled   = true;
+
+  try {
+    const data = await window.neurologue.getGraphData();
+    window.graphView.graphLoad(data);
+    const n = data.nodes.length;
+    const e = data.edges.length;
+    graphNodeCount.textContent = `${n} theme${n !== 1 ? 's' : ''}, ${e} connection${e !== 1 ? 's' : ''}`;
+  } catch (err) {
+    graphNodeCount.textContent = 'Failed to load graph';
+    console.error('[graph] loadGraphView error:', err);
+  } finally {
+    btnGraphRefresh.disabled = false;
+  }
+}
+
+btnGraphRefresh.addEventListener('click', () => {
+  _destroyGraphIfActive();
+  loadGraphView();
+});
+
+btnGraphReset.addEventListener('click', () => {
+  // Re-run the simulation from new random positions
+  _destroyGraphIfActive();
+  loadGraphView();
 });
 
 // ── Cognitive Dashboard view controller ─────────────────────────────────────

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -60,6 +60,9 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Dashboard ────────────────────────────────────────────────────────────
   getDashboardSummary: () => ipcRenderer.invoke('dashboard:summary'),
 
+  // ── Graph ─────────────────────────────────────────────────────────────────
+  getGraphData: () => ipcRenderer.invoke('graph:data'),
+
   // ── Contradictions ───────────────────────────────────────────────────────
   listContradictions:   (opts) => ipcRenderer.invoke('contradictions:list', opts),
   resolveContradiction: (id, notes) => ipcRenderer.invoke('contradictions:resolve', { id, notes }),

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setW
 const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
 const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
+const { getGraphData } = require('./backend/db/graph');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -338,6 +339,10 @@ ipcMain.handle('contradictions:scan', async () => {
 // ── Dashboard IPC ──────────────────────────────────────────────────────────────
 
 handle('dashboard:summary', async () => getDashboardSummary());
+
+// ── Graph IPC ─────────────────────────────────────────────────────────────────
+
+handle('graph:data', async () => getGraphData());
 
 // ── Priorities IPC ───────────────────────────────────────────────────────────
 

--- a/tests/unit/db/graph.test.js
+++ b/tests/unit/db/graph.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+const { randomUUID } = require('crypto');
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-graph-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+async function seedEntry(content = 'Test entry') {
+  const { createEntry } = require('../../../src/backend/db/entries');
+  return createEntry({ content });
+}
+
+async function seedTheme(name = 'Test Theme') {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db  = await openDb();
+  const id  = randomUUID();
+  db.prepare('INSERT INTO themes (id, name) VALUES (?, ?)').run(id, name);
+  return id;
+}
+
+async function linkEntryToTheme(entryId, themeId, score = 0.9) {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  db.prepare(
+    'INSERT INTO theme_entries (theme_id, entry_id, score) VALUES (?, ?, ?)'
+  ).run(themeId, entryId, score);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('getGraphData', () => {
+  test('returns empty nodes and edges for an empty database', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const { nodes, edges } = await getGraphData();
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+
+  test('returns a node per theme with correct fields', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const e = await seedEntry('Hello graph');
+    const t = await seedTheme('Alpha Theme');
+    await linkEntryToTheme(e.id, t);
+
+    const { nodes, edges } = await getGraphData();
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0];
+    expect(node.id).toBe(t);
+    expect(node.label).toBe('Alpha Theme');
+    expect(node.entryCount).toBe(1);
+  });
+
+  test('uses user_name as label when set', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const { openDb } = require('../../../src/backend/db/connection');
+    const t = await seedTheme('LLM Name');
+    const db = await openDb();
+    db.prepare('UPDATE themes SET user_name = ? WHERE id = ?').run('My Custom Name', t);
+
+    const { nodes } = await getGraphData();
+    const node = nodes.find((n) => n.id === t);
+    expect(node.label).toBe('My Custom Name');
+  });
+
+  test('reports zero edges when themes share no entries', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const e1 = await seedEntry('Entry for theme A');
+    const e2 = await seedEntry('Entry for theme B');
+    const t1 = await seedTheme('Theme A');
+    const t2 = await seedTheme('Theme B');
+    await linkEntryToTheme(e1.id, t1);
+    await linkEntryToTheme(e2.id, t2);
+
+    const { edges } = await getGraphData();
+    expect(edges).toHaveLength(0);
+  });
+
+  test('creates an edge when two themes share an entry', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const shared = await seedEntry('Shared entry');
+    const t1 = await seedTheme('Theme A');
+    const t2 = await seedTheme('Theme B');
+    await linkEntryToTheme(shared.id, t1);
+    await linkEntryToTheme(shared.id, t2);
+
+    const { edges } = await getGraphData();
+    expect(edges).toHaveLength(1);
+    const edge = edges[0];
+    // source/target are theme ids (order depends on iteration, both valid)
+    expect([edge.source, edge.target]).toContain(t1);
+    expect([edge.source, edge.target]).toContain(t2);
+    expect(edge.weight).toBe(1);
+  });
+
+  test('edge weight reflects number of shared entries', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const e1 = await seedEntry('Shared entry 1');
+    const e2 = await seedEntry('Shared entry 2');
+    const t1 = await seedTheme('Theme X');
+    const t2 = await seedTheme('Theme Y');
+    await linkEntryToTheme(e1.id, t1);
+    await linkEntryToTheme(e1.id, t2);
+    await linkEntryToTheme(e2.id, t1);
+    await linkEntryToTheme(e2.id, t2);
+
+    const { edges } = await getGraphData();
+    expect(edges).toHaveLength(1);
+    expect(edges[0].weight).toBe(2);
+  });
+
+  test('nodes are ordered by entry count descending', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    const t1 = await seedTheme('Small Theme');
+    const t2 = await seedTheme('Large Theme');
+    // Give t2 more entries
+    for (let i = 0; i < 5; i++) {
+      const e = await seedEntry(`Entry ${i}`);
+      await linkEntryToTheme(e.id, t2);
+    }
+    const e = await seedEntry('Single entry');
+    await linkEntryToTheme(e.id, t1);
+
+    const { nodes } = await getGraphData();
+    expect(nodes[0].id).toBe(t2);
+    expect(nodes[0].entryCount).toBe(5);
+    expect(nodes[1].id).toBe(t1);
+    expect(nodes[1].entryCount).toBe(1);
+  });
+
+  test('handles themes with no entries', async () => {
+    const { getGraphData } = require('../../../src/backend/db/graph');
+    await seedTheme('Empty Theme');
+
+    const { nodes, edges } = await getGraphData();
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].entryCount).toBe(0);
+    expect(edges).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #57

Implements the **Knowledge Graph** view: a force-directed canvas visualisation of themes and their relationships.

## What's included

### Backend
- `src/backend/db/graph.js` — `getGraphData()` queries all themes and computes pairwise entry-overlap edges (weight = number of shared entries)
- `src/main.js` — `graph:data` IPC handler
- `src/frontend/preload.js` — `getGraphData()` exposed to renderer

### Frontend (no external dependencies — pure Canvas API)
- `src/frontend/graph.js` — Force-directed simulation and renderer:
  - **Nodes**: one circle per theme; radius scales with entry count (sqrt mapping, bounded 14–44 px); colour deterministically derived from theme ID using a 20-colour palette
  - **Edges**: drawn between theme pairs with at least 1 shared entry; line thickness and opacity scale with shared count
  - **Forces**: pairwise Coulomb repulsion, Hooke spring attraction, centroid gravity, velocity damping
  - **Simulation** runs on requestAnimationFrame until velocity drops below threshold or 600 ticks, then stops
  - **Interaction**: click node → navigate to Themes view and select that theme; hover tooltip showing name and entry count; drag node to reposition; mouse-wheel zoom; drag-to-pan; double-click background resets zoom
- `src/frontend/index.html` — replaced placeholder with toolbar + canvas container; added graph.js script
- `src/frontend/library.js` — `loadGraphView()` controller; wired into `activateView()`; renderer is destroyed when switching away from the Graph view
- `src/frontend/library.css` — graph toolbar, canvas, and tooltip styles

### Tests
- `tests/unit/db/graph.test.js` — 8 tests: empty DB, node fields, user_name label override, isolated themes produce no edges, shared-entry edge, edge weight, descending entry-count order, themes with zero entries

## Acceptance criteria
- [x] Force-directed graph
- [x] Click to explore (navigate to Themes view)
- [x] Theme clusters
- [x] 240/240 tests pass
