### PR TITLE
feat: memory replay (#58)

### DIFF
--- a/src/backend/db/replay.js
+++ b/src/backend/db/replay.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const { openDb } = require('./connection');
+
+// ── Month snapshot ────────────────────────────────────────────────────────────
+
+/**
+ * Return a snapshot of cognitive activity for a specific calendar month.
+ *
+ * @param {number} year   e.g. 2026
+ * @param {number} month  1-indexed, e.g. 5 for May
+ * @returns {Promise<{
+ *   year: number,
+ *   month: number,
+ *   entryCount: number,
+ *   topThemes: { id: string, display_name: string, entryCount: number }[],
+ *   entries: { id: string, content: string, created_at: string, category: string|null }[],
+ * }>}
+ */
+async function getMonthSnapshot(year, month) {
+  const db = await openDb();
+  const mm   = String(month).padStart(2, '0');
+  const from = `${year}-${mm}-01`;
+  // Last day of month via SQLite's date arithmetic
+  const to   = `${year}-${mm}-01`;
+
+  const entries = db.prepare(`
+    SELECT id, content, created_at,
+           COALESCE(user_category, category) AS category
+    FROM   entries
+    WHERE  DATE(created_at) >= DATE(?)
+      AND  DATE(created_at) <  DATE(?, '+1 month')
+    ORDER  BY created_at ASC
+  `).all(from, to);
+
+  const entryIds = entries.map((e) => e.id);
+
+  let topThemes = [];
+  if (entryIds.length > 0) {
+    // For each theme, count how many of its entries fall in this month
+    topThemes = db.prepare(`
+      SELECT t.id,
+             COALESCE(t.user_name, t.name) AS display_name,
+             COUNT(te.entry_id)            AS entry_count
+      FROM   theme_entries te
+      JOIN   themes t ON t.id = te.theme_id
+      JOIN   entries e ON e.id = te.entry_id
+      WHERE  DATE(e.created_at) >= DATE(?)
+        AND  DATE(e.created_at) <  DATE(?, '+1 month')
+      GROUP  BY t.id
+      ORDER  BY entry_count DESC
+      LIMIT  10
+    `).all(from, to);
+  }
+
+  return {
+    year,
+    month,
+    entryCount: entries.length,
+    topThemes,
+    entries,
+  };
+}
+
+// ── Period comparison ─────────────────────────────────────────────────────────
+
+/**
+ * Compare the most active themes between two arbitrary date periods.
+ *
+ * Each period is defined by ISO date strings [from, to) (exclusive end).
+ *
+ * Returns:
+ *  {
+ *    period1: { from, to, themes: [{ id, display_name, entryCount }] },
+ *    period2: { from, to, themes: [{ id, display_name, entryCount }] },
+ *    gained:  themes present in period2 but not in period1 (new or returned)
+ *    lost:    themes present in period1 but not in period2 (faded or dropped)
+ *    common:  themes present in both periods
+ *  }
+ *
+ * @param {string} from1
+ * @param {string} to1
+ * @param {string} from2
+ * @param {string} to2
+ * @returns {Promise<object>}
+ */
+async function comparePeriods(from1, to1, from2, to2) {
+  const db = await openDb();
+
+  function queryThemes(from, to) {
+    return db.prepare(`
+      SELECT t.id,
+             COALESCE(t.user_name, t.name) AS display_name,
+             COUNT(te.entry_id)            AS entry_count
+      FROM   theme_entries te
+      JOIN   themes t ON t.id = te.theme_id
+      JOIN   entries e ON e.id = te.entry_id
+      WHERE  DATE(e.created_at) >= DATE(?)
+        AND  DATE(e.created_at) <  DATE(?)
+      GROUP  BY t.id
+      ORDER  BY entry_count DESC
+      LIMIT  20
+    `).all(from, to);
+  }
+
+  const themes1 = queryThemes(from1, to1);
+  const themes2 = queryThemes(from2, to2);
+
+  const ids1 = new Set(themes1.map((t) => t.id));
+  const ids2 = new Set(themes2.map((t) => t.id));
+
+  const gained = themes2.filter((t) => !ids1.has(t.id));
+  const lost   = themes1.filter((t) => !ids2.has(t.id));
+  const common = themes1.filter((t) => ids2.has(t.id));
+
+  return {
+    period1: { from: from1, to: to1, themes: themes1 },
+    period2: { from: from2, to: to2, themes: themes2 },
+    gained,
+    lost,
+    common,
+  };
+}
+
+// ── Abandoned ideas ───────────────────────────────────────────────────────────
+
+/**
+ * Return entries that look like abandoned ideas:
+ *  - category is 'Idea', 'Question', or 'Decision' (user or LLM)
+ *  - created more than `olderThanDays` days ago
+ *  - belong only to themes whose last activity was also more than `olderThanDays` ago,
+ *    OR belong to no theme at all
+ *
+ * @param {number} [olderThanDays=30]
+ * @param {number} [limit=50]
+ * @returns {Promise<{ id: string, content: string, created_at: string, category: string }[]>}
+ */
+async function getAbandonedIdeas(olderThanDays = 30, limit = 50) {
+  const db = await openDb();
+
+  const rows = db.prepare(`
+    SELECT e.id,
+           e.content,
+           e.created_at,
+           COALESCE(e.user_category, e.category) AS category
+    FROM   entries e
+    WHERE  COALESCE(e.user_category, e.category) IN ('Idea', 'Question', 'Decision')
+      AND  julianday('now') - julianday(e.created_at) > ?
+      AND  e.id NOT IN (
+             -- exclude entries that belong to a theme with recent activity (<= olderThanDays)
+             SELECT te.entry_id
+             FROM   theme_entries te
+             JOIN   (
+               SELECT theme_id, MAX(e2.created_at) AS last_active
+               FROM   theme_entries te2
+               JOIN   entries e2 ON e2.id = te2.entry_id
+               GROUP  BY theme_id
+             ) la ON la.theme_id = te.theme_id
+             WHERE  julianday('now') - julianday(la.last_active) <= ?
+           )
+    ORDER  BY e.created_at ASC
+    LIMIT  ?
+  `).all(olderThanDays, olderThanDays, limit);
+
+  return rows;
+}
+
+// ── Available months ──────────────────────────────────────────────────────────
+
+/**
+ * Return all year-month pairs for which there is at least one entry.
+ * Ordered newest-first.
+ * @returns {Promise<{ year: number, month: number, count: number }[]>}
+ */
+async function listActiveMonths() {
+  const db = await openDb();
+  const rows = db.prepare(`
+    SELECT strftime('%Y', created_at) AS year,
+           strftime('%m', created_at) AS month,
+           COUNT(*)                   AS count
+    FROM   entries
+    GROUP  BY year, month
+    ORDER  BY year DESC, month DESC
+  `).all();
+  return rows.map((r) => ({
+    year:  parseInt(r.year, 10),
+    month: parseInt(r.month, 10),
+    count: r.count,
+  }));
+}
+
+module.exports = { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -56,6 +56,10 @@
           <span class="nav-icon">&#8635;</span>
           <span class="nav-label">Dashboard</span>
         </button>
+        <button class="nav-item" data-view="replay" title="Memory Replay">
+          <span class="nav-icon">&#9711;</span>
+          <span class="nav-label">Replay</span>
+        </button>
       </nav>
 
       <!-- ── View container ────────────────────────────────────────── -->
@@ -462,6 +466,99 @@
 
           </div><!-- /#dash-body -->
         </div>
+
+        <!-- ── View: Memory Replay ──────────────────────────────────── -->
+        <div id="view-replay" class="view">
+
+          <!-- Toolbar with tab switcher -->
+          <div id="replay-toolbar">
+            <span id="replay-title">Memory Replay</span>
+            <div id="replay-tabs">
+              <button class="replay-tab active" data-tab="month">Month view</button>
+              <button class="replay-tab" data-tab="compare">Compare periods</button>
+              <button class="replay-tab" data-tab="abandoned">Abandoned ideas</button>
+            </div>
+          </div>
+
+          <!-- ── Tab: Month view ──────────────────────────── -->
+          <div id="replay-tab-month" class="replay-tab-panel">
+            <div id="replay-month-controls">
+              <label class="replay-ctrl-label" for="replay-month-select">Pick a month</label>
+              <select id="replay-month-select"></select>
+            </div>
+            <div id="replay-month-body">
+              <div id="replay-month-placeholder" class="replay-placeholder">
+                Select a month above to replay your thoughts from that period.
+              </div>
+              <div id="replay-month-content" style="display:none">
+                <div id="replay-month-header">
+                  <span id="replay-month-heading"></span>
+                  <span id="replay-month-entry-count" class="replay-count-badge"></span>
+                </div>
+                <div id="replay-month-two-col">
+                  <div class="replay-col">
+                    <div class="replay-section-title">Top themes</div>
+                    <div id="replay-month-themes"></div>
+                  </div>
+                  <div class="replay-col">
+                    <div class="replay-section-title">Entries from this month</div>
+                    <div id="replay-month-entries"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Tab: Compare periods ─────────────────────── -->
+          <div id="replay-tab-compare" class="replay-tab-panel" style="display:none">
+            <div id="replay-compare-controls">
+              <div class="replay-compare-period">
+                <label class="replay-ctrl-label">Period A</label>
+                <select id="replay-compare-from1"></select>
+                <span class="replay-ctrl-sep">→</span>
+                <select id="replay-compare-to1"></select>
+              </div>
+              <div class="replay-ctrl-vs">vs</div>
+              <div class="replay-compare-period">
+                <label class="replay-ctrl-label">Period B</label>
+                <select id="replay-compare-from2"></select>
+                <span class="replay-ctrl-sep">→</span>
+                <select id="replay-compare-to2"></select>
+              </div>
+              <button id="btn-replay-compare" class="btn-sm">Compare</button>
+            </div>
+            <div id="replay-compare-body">
+              <div id="replay-compare-placeholder" class="replay-placeholder">
+                Choose two periods and click Compare to see what changed.
+              </div>
+              <div id="replay-compare-content" style="display:none">
+                <div id="replay-compare-three-col">
+                  <div class="replay-col">
+                    <div class="replay-section-title replay-section-lost">Faded themes <span class="replay-diff-hint">(in A, not in B)</span></div>
+                    <div id="replay-compare-lost"></div>
+                  </div>
+                  <div class="replay-col">
+                    <div class="replay-section-title">In both periods</div>
+                    <div id="replay-compare-common"></div>
+                  </div>
+                  <div class="replay-col">
+                    <div class="replay-section-title replay-section-gained">New themes <span class="replay-diff-hint">(in B, not in A)</span></div>
+                    <div id="replay-compare-gained"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ── Tab: Abandoned ideas ─────────────────────── -->
+          <div id="replay-tab-abandoned" class="replay-tab-panel" style="display:none">
+            <div id="replay-abandoned-desc" class="replay-placeholder">
+              Ideas, questions, and decisions you captured more than 30 days ago that haven't been revisited.
+            </div>
+            <div id="replay-abandoned-list"></div>
+          </div>
+
+        </div><!-- /#view-replay -->
 
       </div><!-- /#view-container -->
     </div><!-- /#shell -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2878,3 +2878,268 @@ body.theme-light .graph-tooltip {
   padding: 4px 0;
 }
 
+/* ── Memory Replay ────────────────────────────────────────────────────────── */
+
+#view-replay {
+  flex-direction: column;
+  overflow:       hidden;
+}
+
+#replay-toolbar {
+  display:        flex;
+  align-items:    center;
+  gap:            12px;
+  padding:        8px 16px;
+  border-bottom:  1px solid var(--border);
+  flex-shrink:    0;
+  background:     var(--bg-secondary);
+  flex-wrap:      wrap;
+}
+
+#replay-title {
+  font-size:   14px;
+  font-weight: 600;
+  color:       var(--text-primary);
+  white-space: nowrap;
+}
+
+#replay-tabs {
+  display:    flex;
+  gap:        4px;
+}
+
+.replay-tab {
+  padding:       5px 14px;
+  border:        1px solid var(--border);
+  border-radius: 4px;
+  background:    transparent;
+  color:         var(--text-secondary);
+  font-size:     12px;
+  cursor:        pointer;
+  white-space:   nowrap;
+}
+
+.replay-tab:hover { background: var(--bg-hover); }
+
+.replay-tab.active {
+  background: var(--cortex-teal);
+  color:      #fff;
+  border-color: var(--cortex-teal);
+}
+
+/* Tab panels */
+.replay-tab-panel {
+  flex:     1;
+  overflow: hidden;
+  display:  flex;
+  flex-direction: column;
+}
+
+/* Controls row (month select / compare pickers) */
+#replay-month-controls,
+#replay-compare-controls {
+  display:     flex;
+  align-items: center;
+  gap:         10px;
+  padding:     10px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap:   wrap;
+}
+
+.replay-ctrl-label {
+  font-size:   12px;
+  color:       var(--text-secondary);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.replay-ctrl-sep {
+  font-size: 12px;
+  color:     var(--text-dim);
+}
+
+.replay-ctrl-vs {
+  font-size:   13px;
+  font-weight: 700;
+  color:       var(--cortex-teal);
+  padding:     0 4px;
+}
+
+.replay-compare-period {
+  display:     flex;
+  align-items: center;
+  gap:         6px;
+}
+
+/* Month / period body */
+#replay-month-body,
+#replay-compare-body {
+  flex:     1;
+  overflow: auto;
+  padding:  12px 16px;
+}
+
+.replay-placeholder {
+  font-size: 13px;
+  color:     var(--text-dim);
+  padding:   16px 0;
+}
+
+#replay-month-header {
+  display:     flex;
+  align-items: baseline;
+  gap:         10px;
+  margin-bottom: 12px;
+}
+
+#replay-month-heading {
+  font-size:   18px;
+  font-weight: 700;
+  color:       var(--text-primary);
+}
+
+.replay-count-badge {
+  font-size:   12px;
+  color:       var(--text-muted);
+}
+
+#replay-month-two-col,
+#replay-compare-three-col {
+  display: grid;
+  gap:     16px;
+}
+
+#replay-month-two-col {
+  grid-template-columns: 240px 1fr;
+}
+
+#replay-compare-three-col {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.replay-col {
+  min-width: 0;
+}
+
+.replay-section-title {
+  font-size:     11px;
+  font-weight:   600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color:         var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.replay-section-lost   { color: var(--error-color, #e57373); }
+.replay-section-gained { color: var(--cortex-teal); }
+
+.replay-diff-hint {
+  font-size:      10px;
+  font-weight:    400;
+  text-transform: none;
+  letter-spacing: 0;
+  opacity:        0.75;
+}
+
+/* Theme chip */
+.replay-theme-chip {
+  display:         flex;
+  justify-content: space-between;
+  align-items:     center;
+  padding:         6px 10px;
+  margin-bottom:   4px;
+  border-radius:   6px;
+  background:      var(--bg-card);
+  border:          1px solid var(--border);
+  cursor:          pointer;
+  gap:             8px;
+}
+
+.replay-theme-chip:hover { background: var(--bg-hover); }
+
+.replay-theme-name {
+  font-size:  13px;
+  color:      var(--text-primary);
+  min-width:  0;
+  overflow:   hidden;
+  text-overflow: ellipsis;
+  white-space:   nowrap;
+}
+
+.replay-theme-count {
+  font-size:  11px;
+  color:      var(--cortex-teal);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Entry card */
+.replay-entry-card {
+  padding:       8px 10px;
+  margin-bottom: 4px;
+  border-radius: 6px;
+  background:    var(--bg-card);
+  border:        1px solid var(--border);
+  cursor:        pointer;
+}
+
+.replay-entry-card:hover { background: var(--bg-hover); }
+
+.replay-entry-meta {
+  display:     flex;
+  align-items: center;
+  gap:         6px;
+  margin-bottom: 4px;
+}
+
+.replay-entry-date {
+  font-size: 11px;
+  color:     var(--text-dim);
+}
+
+.replay-entry-cat {
+  font-size:     10px;
+  padding:       1px 6px;
+  border-radius: 10px;
+  background:    var(--bg-secondary);
+  color:         var(--cortex-teal);
+  border:        1px solid var(--border);
+}
+
+.replay-entry-text {
+  font-size:   13px;
+  color:       var(--text-primary);
+  line-height: 1.4;
+  word-break:  break-word;
+}
+
+/* Abandoned ideas panel */
+#replay-tab-abandoned {
+  overflow: auto;
+  padding:  12px 16px;
+}
+
+#replay-abandoned-desc {
+  margin-bottom: 12px;
+}
+
+.replay-abandoned-card {
+  border-left: 3px solid var(--warning-color, #ffb74d);
+}
+
+/* Loading / empty states */
+.replay-loading {
+  font-size: 12px;
+  color:     var(--text-dim);
+  padding:   8px 0;
+}
+
+.replay-empty {
+  font-size: 12px;
+  color:     var(--text-dim);
+  padding:   6px 0;
+  font-style: italic;
+}
+
+

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2935,6 +2935,22 @@ body.theme-light .graph-tooltip {
   flex-direction: column;
 }
 
+/* Selects inside the replay view */
+#view-replay select {
+  background:        var(--surface2);
+  border:            1px solid var(--border);
+  border-radius:     4px;
+  color:             var(--text);
+  font-size:         13px;
+  font-family:       inherit;
+  padding:           5px 10px;
+  cursor:            pointer;
+  outline:           none;
+}
+#view-replay select:hover  { border-color: var(--cortex-teal); }
+#view-replay select:focus  { border-color: var(--cortex-teal); }
+#view-replay select option { background: var(--surface2); color: var(--text); }
+
 /* Controls row (month select / compare pickers) */
 #replay-month-controls,
 #replay-compare-controls {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -77,6 +77,26 @@ const graphNodeCount   = document.getElementById('graph-node-count');
 const btnGraphRefresh  = document.getElementById('btn-graph-refresh');
 const btnGraphReset    = document.getElementById('btn-graph-reset');
 
+// ── Replay DOM refs ─────────────────────────────────────────────────────────
+const replayMonthSelect    = document.getElementById('replay-month-select');
+const replayMonthPh        = document.getElementById('replay-month-placeholder');
+const replayMonthContent   = document.getElementById('replay-month-content');
+const replayMonthHeading   = document.getElementById('replay-month-heading');
+const replayMonthCount     = document.getElementById('replay-month-entry-count');
+const replayMonthThemes    = document.getElementById('replay-month-themes');
+const replayMonthEntries   = document.getElementById('replay-month-entries');
+const replayCompareFrom1   = document.getElementById('replay-compare-from1');
+const replayCompareTo1     = document.getElementById('replay-compare-to1');
+const replayCompareFrom2   = document.getElementById('replay-compare-from2');
+const replayCompareTo2     = document.getElementById('replay-compare-to2');
+const btnReplayCompare     = document.getElementById('btn-replay-compare');
+const replayComparePh      = document.getElementById('replay-compare-placeholder');
+const replayCompareContent = document.getElementById('replay-compare-content');
+const replayCompareLost    = document.getElementById('replay-compare-lost');
+const replayCompareCommon  = document.getElementById('replay-compare-common');
+const replayCompareGained  = document.getElementById('replay-compare-gained');
+const replayAbandonedList  = document.getElementById('replay-abandoned-list');
+
 // ── Utilities ──────────────────────────────────────────────────────────────
 
 function formatDate(dateStr) {
@@ -1915,6 +1935,7 @@ function activateView(viewId) {
   if (viewId === 'priorities')     loadPrioritiesView();
   if (viewId === 'explore')        loadDashboardView();
   if (viewId === 'graph')          loadGraphView();
+  if (viewId === 'replay')         loadReplayView();
   // Destroy graph renderer when leaving the graph view
   if (viewId !== 'graph')          _destroyGraphIfActive();
 }
@@ -2740,6 +2761,241 @@ async function loadDashboardView() {
 }
 
 btnDashRefresh.addEventListener('click', loadDashboardView);
+
+// ── Memory Replay view controller ────────────────────────────────────────────
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+let _replayMonths    = [];  // cached list of active months
+let _replayTabActive = 'month';
+let _replayLoaded    = false;
+
+function _monthLabel(year, month) {
+  return `${MONTH_NAMES[month - 1]} ${year}`;
+}
+
+function _monthValue(year, month) {
+  return `${year}-${String(month).padStart(2, '0')}`;
+}
+
+/** Switch between month / compare / abandoned tabs */
+function _activateReplayTab(tabId) {
+  _replayTabActive = tabId;
+  document.querySelectorAll('.replay-tab').forEach((b) => {
+    b.classList.toggle('active', b.dataset.tab === tabId);
+  });
+  document.querySelectorAll('.replay-tab-panel').forEach((p) => {
+    p.style.display = p.id === `replay-tab-${tabId}` ? '' : 'none';
+  });
+
+  if (tabId === 'abandoned' && !replayAbandonedList.childElementCount) {
+    _loadAbandonedIdeas();
+  }
+}
+
+function _populateMonthSelects() {
+  const opts = _replayMonths.map((m) =>
+    `<option value="${_monthValue(m.year, m.month)}">${_monthLabel(m.year, m.month)} (${m.count})</option>`
+  ).join('');
+
+  replayMonthSelect.innerHTML  = opts || '<option value="">— no entries yet —</option>';
+
+  // Populate all four compare selects
+  [replayCompareFrom1, replayCompareTo1, replayCompareFrom2, replayCompareTo2].forEach((sel) => {
+    sel.innerHTML = opts || '<option value="">—</option>';
+  });
+
+  // Default: compare last two months if available
+  if (_replayMonths.length >= 2) {
+    replayCompareFrom1.value = _monthValue(_replayMonths[1].year, _replayMonths[1].month);
+    replayCompareTo1.value   = _monthValue(_replayMonths[1].year, _replayMonths[1].month);
+    replayCompareFrom2.value = _monthValue(_replayMonths[0].year, _replayMonths[0].month);
+    replayCompareTo2.value   = _monthValue(_replayMonths[0].year, _replayMonths[0].month);
+  }
+}
+
+async function _loadMonthSnapshot() {
+  const val = replayMonthSelect.value;
+  if (!val) return;
+  const [year, month] = val.split('-').map(Number);
+  replayMonthPh.style.display    = 'none';
+  replayMonthContent.style.display = '';
+  replayMonthThemes.innerHTML  = '<div class="replay-loading">Loading…</div>';
+  replayMonthEntries.innerHTML = '';
+
+  try {
+    const snap = await window.neurologue.getMonthSnapshot(year, month);
+    replayMonthHeading.textContent = _monthLabel(year, month);
+    replayMonthCount.textContent   = `${snap.entryCount} entr${snap.entryCount === 1 ? 'y' : 'ies'}`;
+
+    // Top themes
+    replayMonthThemes.innerHTML = '';
+    if (snap.topThemes.length === 0) {
+      replayMonthThemes.innerHTML = '<div class="replay-empty">No themes were active this month</div>';
+    } else {
+      snap.topThemes.forEach((t) => {
+        const el = document.createElement('div');
+        el.className = 'replay-theme-chip';
+        el.innerHTML = `<span class="replay-theme-name">${_escHtml(t.display_name)}</span><span class="replay-theme-count">${t.entry_count}</span>`;
+        el.title = `View "${t.display_name}" in Themes`;
+        el.addEventListener('click', () => {
+          activateView('themes');
+          selectThemeView(t.id);
+        });
+        replayMonthThemes.appendChild(el);
+      });
+    }
+
+    // Entries
+    replayMonthEntries.innerHTML = '';
+    if (snap.entries.length === 0) {
+      replayMonthEntries.innerHTML = '<div class="replay-empty">No entries this month</div>';
+    } else {
+      snap.entries.forEach((e) => {
+        const el = document.createElement('div');
+        el.className = 'replay-entry-card';
+        const date = new Date(e.created_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+        el.innerHTML =
+          `<div class="replay-entry-meta"><span class="replay-entry-date">${date}</span>${e.category ? `<span class="replay-entry-cat">${_escHtml(e.category)}</span>` : ''}</div>` +
+          `<div class="replay-entry-text">${_escHtml(_truncate(e.content, 120))}</div>`;
+        el.title = e.content;
+        el.addEventListener('click', () => {
+          activateView('library');
+          selectEntry(e.id);
+        });
+        replayMonthEntries.appendChild(el);
+      });
+    }
+  } catch (err) {
+    console.error('[replay] _loadMonthSnapshot failed:', err);
+    replayMonthThemes.innerHTML = '<div class="replay-empty">Error loading snapshot</div>';
+  }
+}
+
+async function _loadComparePeriods() {
+  const from1 = replayCompareFrom1.value;
+  const to1   = replayCompareTo1.value;
+  const from2 = replayCompareFrom2.value;
+  const to2   = replayCompareTo2.value;
+  if (!from1 || !to1 || !from2 || !to2) return;
+
+  replayComparePh.style.display    = 'none';
+  replayCompareContent.style.display = '';
+  replayCompareLost.innerHTML   = '<div class="replay-loading">Loading…</div>';
+  replayCompareCommon.innerHTML = '';
+  replayCompareGained.innerHTML = '';
+
+  // Periods are month-values (YYYY-MM); build ISO date range [first of month, first of next month)
+  function periodRange(val) {
+    const [y, m] = val.split('-').map(Number);
+    const from = `${y}-${String(m).padStart(2, '0')}-01`;
+    const next = m === 12 ? `${y + 1}-01-01` : `${y}-${String(m + 1).padStart(2, '0')}-01`;
+    return { from, to: next };
+  }
+
+  const p1 = periodRange(from1 < to1 ? from1 : to1);
+  const p2 = periodRange(from2 > to2 ? from2 : to2);
+  // Extend p1 end to end-of-to1 month, p2 start to start-of-from2 month
+  const p1From = periodRange(from1 < to1 ? from1 : to1).from;
+  const p1To   = periodRange(from1 < to1 ? to1 : from1).to;
+  const p2From = periodRange(from2 < to2 ? from2 : to2).from;
+  const p2To   = periodRange(from2 < to2 ? to2 : from2).to;
+
+  try {
+    const result = await window.neurologue.comparePeriods(p1From, p1To, p2From, p2To);
+
+    function renderThemeList(el, themes) {
+      el.innerHTML = '';
+      if (themes.length === 0) {
+        el.innerHTML = '<div class="replay-empty">—</div>';
+        return;
+      }
+      themes.forEach((t) => {
+        const chip = document.createElement('div');
+        chip.className = 'replay-theme-chip';
+        chip.innerHTML = `<span class="replay-theme-name">${_escHtml(t.display_name)}</span><span class="replay-theme-count">${t.entry_count}</span>`;
+        chip.addEventListener('click', () => {
+          activateView('themes');
+          selectThemeView(t.id);
+        });
+        el.appendChild(chip);
+      });
+    }
+
+    renderThemeList(replayCompareLost,   result.lost);
+    renderThemeList(replayCompareCommon, result.common);
+    renderThemeList(replayCompareGained, result.gained);
+  } catch (err) {
+    console.error('[replay] _loadComparePeriods failed:', err);
+    replayCompareLost.innerHTML = '<div class="replay-empty">Error loading comparison</div>';
+  }
+}
+
+async function _loadAbandonedIdeas() {
+  replayAbandonedList.innerHTML = '<div class="replay-loading">Loading…</div>';
+  try {
+    const ideas = await window.neurologue.getAbandonedIdeas();
+    replayAbandonedList.innerHTML = '';
+    if (ideas.length === 0) {
+      replayAbandonedList.innerHTML = '<div class="replay-empty" style="margin:16px">No abandoned ideas found — great, you\'re keeping up!</div>';
+      return;
+    }
+    ideas.forEach((e) => {
+      const el = document.createElement('div');
+      el.className = 'replay-entry-card replay-abandoned-card';
+      const date = new Date(e.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+      el.innerHTML =
+        `<div class="replay-entry-meta"><span class="replay-entry-date">${date}</span>${e.category ? `<span class="replay-entry-cat">${_escHtml(e.category)}</span>` : ''}</div>` +
+        `<div class="replay-entry-text">${_escHtml(_truncate(e.content, 140))}</div>`;
+      el.title = e.content;
+      el.addEventListener('click', () => {
+        activateView('library');
+        selectEntry(e.id);
+      });
+      replayAbandonedList.appendChild(el);
+    });
+  } catch (err) {
+    console.error('[replay] _loadAbandonedIdeas failed:', err);
+    replayAbandonedList.innerHTML = '<div class="replay-empty">Error loading abandoned ideas</div>';
+  }
+}
+
+async function loadReplayView() {
+  // Load months list once per session (re-load each time view activates for freshness)
+  try {
+    _replayMonths = await window.neurologue.listActiveMonths();
+    _populateMonthSelects();
+
+    // Auto-load most recent month
+    if (_replayMonths.length > 0 && replayMonthSelect.value) {
+      await _loadMonthSnapshot();
+    }
+  } catch (err) {
+    console.error('[replay] loadReplayView failed:', err);
+  }
+}
+
+// Tab click handlers
+document.querySelectorAll('.replay-tab').forEach((btn) => {
+  btn.addEventListener('click', () => _activateReplayTab(btn.dataset.tab));
+});
+
+// Month select change
+replayMonthSelect.addEventListener('change', _loadMonthSnapshot);
+
+// Compare button
+btnReplayCompare.addEventListener('click', _loadComparePeriods);
+
+function _escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 // ── Init ────────────────────────────────────────────────────────────
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -63,6 +63,12 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Graph ─────────────────────────────────────────────────────────────────
   getGraphData: () => ipcRenderer.invoke('graph:data'),
 
+  // ── Memory Replay ─────────────────────────────────────────────────────────
+  listActiveMonths:   ()                          => ipcRenderer.invoke('replay:active-months'),
+  getMonthSnapshot:   (year, month)               => ipcRenderer.invoke('replay:month-snapshot',  { year, month }),
+  comparePeriods:     (from1, to1, from2, to2)    => ipcRenderer.invoke('replay:compare-periods', { from1, to1, from2, to2 }),
+  getAbandonedIdeas:  ()                          => ipcRenderer.invoke('replay:abandoned-ideas'),
+
   // ── Contradictions ───────────────────────────────────────────────────────
   listContradictions:   (opts) => ipcRenderer.invoke('contradictions:list', opts),
   resolveContradiction: (id, notes) => ipcRenderer.invoke('contradictions:resolve', { id, notes }),

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = 
 const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 const { getGraphData } = require('./backend/db/graph');
+const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -343,6 +344,13 @@ handle('dashboard:summary', async () => getDashboardSummary());
 // ── Graph IPC ─────────────────────────────────────────────────────────────────
 
 handle('graph:data', async () => getGraphData());
+
+// ── Replay IPC ────────────────────────────────────────────────────────────────
+
+handle('replay:active-months',  async () => listActiveMonths());
+handle('replay:month-snapshot', async (_e, { year, month }) => getMonthSnapshot(year, month));
+handle('replay:compare-periods', async (_e, { from1, to1, from2, to2 }) => comparePeriods(from1, to1, from2, to2));
+handle('replay:abandoned-ideas', async () => getAbandonedIdeas());
 
 // ── Priorities IPC ───────────────────────────────────────────────────────────
 

--- a/tests/unit/db/replay.test.js
+++ b/tests/unit/db/replay.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+const { randomUUID } = require('crypto');
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-replay-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+async function seedEntryAt(content, createdAt, category = null) {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  const id = randomUUID();
+  db.prepare(
+    'INSERT INTO entries (id, content, source, type, metadata, created_at, category) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(id, content, 'manual', 'note', '{}', createdAt, category);
+  return { id, content, created_at: createdAt, category };
+}
+
+async function seedTheme(name = 'Test Theme') {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  const id = randomUUID();
+  db.prepare('INSERT INTO themes (id, name) VALUES (?, ?)').run(id, name);
+  return id;
+}
+
+async function linkEntryToTheme(entryId, themeId) {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  db.prepare(
+    'INSERT INTO theme_entries (theme_id, entry_id, score) VALUES (?, ?, ?)'
+  ).run(themeId, entryId, 0.9);
+}
+
+// ── listActiveMonths ──────────────────────────────────────────────────────────
+
+describe('listActiveMonths', () => {
+  test('returns empty array when no entries exist', async () => {
+    const { listActiveMonths } = require('../../../src/backend/db/replay');
+    const months = await listActiveMonths();
+    expect(months).toEqual([]);
+  });
+
+  test('returns one month entry for a single entry', async () => {
+    const { listActiveMonths } = require('../../../src/backend/db/replay');
+    await seedEntryAt('Hello', '2026-03-15 10:00:00');
+    const months = await listActiveMonths();
+    expect(months).toHaveLength(1);
+    expect(months[0]).toMatchObject({ year: 2026, month: 3, count: 1 });
+  });
+
+  test('groups multiple entries in the same month together', async () => {
+    const { listActiveMonths } = require('../../../src/backend/db/replay');
+    await seedEntryAt('A', '2026-03-01 10:00:00');
+    await seedEntryAt('B', '2026-03-20 10:00:00');
+    const months = await listActiveMonths();
+    expect(months).toHaveLength(1);
+    expect(months[0].count).toBe(2);
+  });
+
+  test('returns months in descending order (newest first)', async () => {
+    const { listActiveMonths } = require('../../../src/backend/db/replay');
+    await seedEntryAt('A', '2026-01-15 10:00:00');
+    await seedEntryAt('B', '2026-03-15 10:00:00');
+    const months = await listActiveMonths();
+    expect(months[0].month).toBe(3);
+    expect(months[1].month).toBe(1);
+  });
+});
+
+// ── getMonthSnapshot ──────────────────────────────────────────────────────────
+
+describe('getMonthSnapshot', () => {
+  test('returns zero entries for a month with no data', async () => {
+    const { getMonthSnapshot } = require('../../../src/backend/db/replay');
+    const snap = await getMonthSnapshot(2026, 1);
+    expect(snap.entryCount).toBe(0);
+    expect(snap.entries).toEqual([]);
+    expect(snap.topThemes).toEqual([]);
+  });
+
+  test('returns only entries from the requested month', async () => {
+    const { getMonthSnapshot } = require('../../../src/backend/db/replay');
+    await seedEntryAt('March entry', '2026-03-10 10:00:00');
+    await seedEntryAt('April entry', '2026-04-05 10:00:00');
+    const snap = await getMonthSnapshot(2026, 3);
+    expect(snap.entryCount).toBe(1);
+    expect(snap.entries[0].content).toBe('March entry');
+  });
+
+  test('includes top themes active in that month', async () => {
+    const { getMonthSnapshot } = require('../../../src/backend/db/replay');
+    const e  = await seedEntryAt('Entry', '2026-03-10 10:00:00');
+    const t  = await seedTheme('March Theme');
+    await linkEntryToTheme(e.id, t);
+    const snap = await getMonthSnapshot(2026, 3);
+    expect(snap.topThemes).toHaveLength(1);
+    expect(snap.topThemes[0].display_name).toBe('March Theme');
+  });
+
+  test('does not include themes with no entries in that month', async () => {
+    const { getMonthSnapshot } = require('../../../src/backend/db/replay');
+    await seedTheme('Orphan Theme'); // no entries
+    const snap = await getMonthSnapshot(2026, 3);
+    expect(snap.topThemes).toHaveLength(0);
+  });
+});
+
+// ── comparePeriods ────────────────────────────────────────────────────────────
+
+describe('comparePeriods', () => {
+  test('returns empty sets for periods with no entries', async () => {
+    const { comparePeriods } = require('../../../src/backend/db/replay');
+    const result = await comparePeriods('2026-01-01', '2026-02-01', '2026-02-01', '2026-03-01');
+    expect(result.period1.themes).toEqual([]);
+    expect(result.period2.themes).toEqual([]);
+    expect(result.gained).toEqual([]);
+    expect(result.lost).toEqual([]);
+    expect(result.common).toEqual([]);
+  });
+
+  test('identifies themes gained in period 2', async () => {
+    const { comparePeriods } = require('../../../src/backend/db/replay');
+    const e  = await seedEntryAt('New idea', '2026-02-15 10:00:00');
+    const t  = await seedTheme('New Theme');
+    await linkEntryToTheme(e.id, t);
+    const result = await comparePeriods('2026-01-01', '2026-02-01', '2026-02-01', '2026-03-01');
+    expect(result.gained).toHaveLength(1);
+    expect(result.gained[0].id).toBe(t);
+    expect(result.lost).toHaveLength(0);
+  });
+
+  test('identifies themes lost from period 1', async () => {
+    const { comparePeriods } = require('../../../src/backend/db/replay');
+    const e  = await seedEntryAt('Old idea', '2026-01-15 10:00:00');
+    const t  = await seedTheme('Old Theme');
+    await linkEntryToTheme(e.id, t);
+    const result = await comparePeriods('2026-01-01', '2026-02-01', '2026-02-01', '2026-03-01');
+    expect(result.lost).toHaveLength(1);
+    expect(result.lost[0].id).toBe(t);
+    expect(result.gained).toHaveLength(0);
+  });
+
+  test('identifies themes common to both periods', async () => {
+    const { comparePeriods } = require('../../../src/backend/db/replay');
+    const e1 = await seedEntryAt('January', '2026-01-15 10:00:00');
+    const e2 = await seedEntryAt('February', '2026-02-15 10:00:00');
+    const t  = await seedTheme('Persistent Theme');
+    await linkEntryToTheme(e1.id, t);
+    await linkEntryToTheme(e2.id, t);
+    const result = await comparePeriods('2026-01-01', '2026-02-01', '2026-02-01', '2026-03-01');
+    expect(result.common).toHaveLength(1);
+    expect(result.common[0].id).toBe(t);
+    expect(result.lost).toHaveLength(0);
+    expect(result.gained).toHaveLength(0);
+  });
+});
+
+// ── getAbandonedIdeas ─────────────────────────────────────────────────────────
+
+describe('getAbandonedIdeas', () => {
+  test('returns empty array when there are no ideas', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    const ideas = await getAbandonedIdeas();
+    expect(ideas).toEqual([]);
+  });
+
+  test('returns old idea-category entries', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    // Entry created 60 days ago with category Idea
+    await seedEntryAt('Old idea', '2026-03-16 10:00:00', 'Idea'); // 60 days before May 15
+    const ideas = await getAbandonedIdeas(30);
+    expect(ideas).toHaveLength(1);
+    expect(ideas[0].content).toBe('Old idea');
+  });
+
+  test('does not return recent entries (within threshold)', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    // Entry created 5 days ago — should NOT be returned
+    await seedEntryAt('Recent idea', '2026-05-10 10:00:00', 'Idea');
+    const ideas = await getAbandonedIdeas(30);
+    expect(ideas).toHaveLength(0);
+  });
+
+  test('does not return non-idea categories', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    await seedEntryAt('Old task', '2026-03-16 10:00:00', 'Task');
+    await seedEntryAt('Old thought', '2026-03-16 10:00:00', 'Thought');
+    const ideas = await getAbandonedIdeas(30);
+    expect(ideas).toHaveLength(0);
+  });
+
+  test('includes Question and Decision categories', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    await seedEntryAt('Old question', '2026-03-16 10:00:00', 'Question');
+    await seedEntryAt('Old decision', '2026-03-16 10:00:00', 'Decision');
+    const ideas = await getAbandonedIdeas(30);
+    expect(ideas).toHaveLength(2);
+  });
+
+  test('excludes entries belonging to recently-active themes', async () => {
+    const { getAbandonedIdeas } = require('../../../src/backend/db/replay');
+    const e = await seedEntryAt('Old idea in active theme', '2026-03-16 10:00:00', 'Idea');
+    const t = await seedTheme('Active Theme');
+    await linkEntryToTheme(e.id, t);
+    // Add a recent entry to the same theme (makes it active)
+    const recent = await seedEntryAt('Recent in same theme', '2026-05-10 10:00:00');
+    await linkEntryToTheme(recent.id, t);
+    const ideas = await getAbandonedIdeas(30);
+    // e should be excluded because its theme has recent activity
+    expect(ideas.find((i) => i.id === e.id)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements the Memory Replay view (issue #58).

## What's included

**Backend** (src/backend/db/replay.js)
- listActiveMonths() — calendar months with entry counts, newest-first
- getMonthSnapshot(year, month) — entry count, top themes, entry list for a given month
- comparePeriods(from1, to1, from2, to2) — themes gained / lost / common between two date ranges
- getAbandonedIdeas(days, limit) — ideas/questions/decisions older than threshold not in recently-active themes

**IPC / Preload** — four new channels exposed to the renderer

**Frontend**
- New nav item (Memory Replay)
- Three-tab view: Month view · Compare periods · Abandoned ideas
- Month view: pick a month → top themes + entry list
- Compare: choose two periods → faded / common / new themes side-by-side
- Abandoned ideas: scrollable list of stale idea-type entries

**Tests** — 	ests/unit/db/replay.test.js, 18 tests

Closes #58