### PR TITLE
feat: agentic extensions (#59)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,7 +178,27 @@ Each roadmap item is written to be convertible into GitHub Issues.
   - Suggest focus areas for today
 
 ---
+## 0.10.x — AI Interaction & Integration
 
+### 0.10.1 Free-text chat with corpus
+- Chat input in the Agents view for free-text questions and instructions
+- LLM responses grounded in the user's corpus via semantic/recent-entry context
+- Streamed token-by-token output, same as existing agents
+- Conversation history maintained within the session
+
+### 0.10.2 Agentic note management via chat
+- Use natural language to create, search, and summarise notes
+- Intent detection classifies user message (create / search / summarise / general)
+- Destructive operations require explicit confirmation
+- Changes reflected immediately in the Library view
+
+### 0.10.3 MCP server for external tool integration
+- Local MCP server exposing Neurologue data and AI capabilities
+- Tools: `search_notes`, `list_themes`, `get_theme_entries`, `create_note`, `summarise_topic`, `run_agent`
+- Start/stop and port/token configuration from the Settings view
+- Enables integration with Claude Desktop, Cursor, VS Code, and other MCP-compatible clients
+
+---
 ## Issue Generation Guide (Optional)
 
 <!--

--- a/src/backend/agents/runner.js
+++ b/src/backend/agents/runner.js
@@ -157,6 +157,16 @@ function listAgents() {
   }));
 }
 
+// Shared cancellation flag — one agent runs at a time
+let _abortRequested = false;
+
+/**
+ * Signal the currently-running agent to stop after the next token.
+ */
+function abortAgent() {
+  _abortRequested = true;
+}
+
 /**
  * Run an agent, streaming the LLM response token-by-token.
  * @param {string}   agentId
@@ -167,8 +177,13 @@ async function runAgent(agentId, onToken) {
   const agent = AGENTS[agentId];
   if (!agent) throw new Error(`Unknown agent: "${agentId}"`);
 
+  _abortRequested = false;
+
   const prompt = await agent.buildPrompt();
-  await generateStream(prompt, onToken);
+  await generateStream(prompt, (token) => {
+    if (_abortRequested) return; // drop remaining tokens
+    onToken(token);
+  });
 }
 
-module.exports = { listAgents, runAgent };
+module.exports = { listAgents, runAgent, abortAgent };

--- a/src/backend/agents/runner.js
+++ b/src/backend/agents/runner.js
@@ -157,18 +157,22 @@ function listAgents() {
   }));
 }
 
-// Shared cancellation flag — one agent runs at a time
-let _abortRequested = false;
+// AbortController for the currently-running HTTP stream
+let _currentController = null;
 
 /**
- * Signal the currently-running agent to stop after the next token.
+ * Abort the currently-running agent stream immediately.
  */
 function abortAgent() {
-  _abortRequested = true;
+  if (_currentController) {
+    _currentController.abort();
+    _currentController = null;
+  }
 }
 
 /**
  * Run an agent, streaming the LLM response token-by-token.
+ * Aborts any in-flight run before starting a new one.
  * @param {string}   agentId
  * @param {function} onToken  Called with each text fragment as it arrives
  * @returns {Promise<void>}
@@ -177,13 +181,18 @@ async function runAgent(agentId, onToken) {
   const agent = AGENTS[agentId];
   if (!agent) throw new Error(`Unknown agent: "${agentId}"`);
 
-  _abortRequested = false;
+  // Cancel any previous stream before starting fresh
+  abortAgent();
 
-  const prompt = await agent.buildPrompt();
-  await generateStream(prompt, (token) => {
-    if (_abortRequested) return; // drop remaining tokens
-    onToken(token);
-  });
+  const controller = new AbortController();
+  _currentController = controller;
+
+  try {
+    const prompt = await agent.buildPrompt();
+    await generateStream(prompt, onToken, 180_000, controller.signal);
+  } finally {
+    if (_currentController === controller) _currentController = null;
+  }
 }
 
 module.exports = { listAgents, runAgent, abortAgent };

--- a/src/backend/agents/runner.js
+++ b/src/backend/agents/runner.js
@@ -1,0 +1,174 @@
+'use strict';
+
+/**
+ * Agent definitions and runner for Agentic Extensions (issue #59).
+ *
+ * Each agent:
+ *   1. Gathers structured context from the corpus via backend/db/agents.js
+ *   2. Builds an Ollama prompt
+ *   3. Streams the LLM response token-by-token via generateStream()
+ */
+
+const {
+  getWeekSummaryData,
+  getOpenTasksData,
+  getEmergingPrioritiesData,
+  getTodayFocusData,
+} = require('../db/agents');
+
+const { generateStream } = require('../../worker/ollama');
+
+// ── Agent definitions ────────────────────────────────────────────────────────
+
+const AGENTS = {
+  'week-summary': {
+    label:       'Summarise my week',
+    description: 'A narrative summary of everything you captured in the last 7 days.',
+    icon:        '📅',
+    async buildPrompt() {
+      const { entries, since } = await getWeekSummaryData();
+      if (entries.length === 0) {
+        return `You have no notes captured since ${since}. Nothing to summarise yet.`;
+      }
+      const lines = entries.map((e) => {
+        const date = e.created_at.slice(0, 10);
+        const cat  = e.category ? ` [${e.category}]` : '';
+        return `- ${date}${cat}: ${e.content.slice(0, 300)}`;
+      }).join('\n');
+
+      return (
+        `Here are all the notes I captured over the past 7 days (since ${since}):\n\n${lines}\n\n` +
+        'Write a concise, thoughtful summary (3-5 paragraphs) of what I was thinking about this week. ' +
+        'Identify key themes, any notable ideas or decisions, and patterns you notice. ' +
+        'Write in second person (e.g. "You spent time thinking about...", "A recurring theme was...").'
+      );
+    },
+  },
+
+  'open-tasks': {
+    label:       'Find open tasks',
+    description: 'All task-type notes, organised by apparent urgency.',
+    icon:        '✅',
+    async buildPrompt() {
+      const { tasks } = await getOpenTasksData();
+      if (tasks.length === 0) {
+        return 'There are no task-type notes in your library yet.';
+      }
+      const lines = tasks.map((t) => {
+        const date = t.created_at.slice(0, 10);
+        return `- (${date}) ${t.content.slice(0, 300)}`;
+      }).join('\n');
+
+      return (
+        `Here are all task-type notes from my knowledge library:\n\n${lines}\n\n` +
+        'Identify which tasks appear to be unresolved based on their wording. ' +
+        'Group them by theme or area if patterns emerge. ' +
+        'Note any that seem time-sensitive or high-priority. ' +
+        'Present the output as a clear, organised list.'
+      );
+    },
+  },
+
+  'emerging-priorities': {
+    label:       'Identify emerging priorities',
+    description: 'Themes gaining momentum in your recent captures.',
+    icon:        '📈',
+    async buildPrompt() {
+      const { themes, since } = await getEmergingPrioritiesData();
+      if (themes.length === 0) {
+        return 'Not enough theme activity to identify emerging priorities yet. Capture more notes and run clustering to build up your theme library.';
+      }
+      const lines = themes.map((t) => {
+        const trend =
+          t.recent_count > t.prev_count ? '↑ growing' :
+          t.recent_count < t.prev_count ? '↓ fading'  : '→ stable';
+        return `- "${t.display_name}": ${t.recent_count} entries this week, ${t.prev_count} the week before (${trend})`;
+      }).join('\n');
+
+      return (
+        `Here is the theme activity data from my knowledge library for the past two weeks (since ${since}):\n\n${lines}\n\n` +
+        'Based on this data, identify which themes are emerging as priorities. ' +
+        'Explain what the trends suggest about my current focus. ' +
+        'Highlight anything that seems to be gaining urgency or drifting away. ' +
+        'Write in second person.'
+      );
+    },
+  },
+
+  'focus-today': {
+    label:       'Suggest focus areas for today',
+    description: 'Personalised suggestions for where to direct your attention today.',
+    icon:        '🎯',
+    async buildPrompt() {
+      const { recentEntries, openTasks, topThemes } = await getTodayFocusData();
+
+      const parts = [];
+
+      if (topThemes.length > 0) {
+        parts.push(
+          'Active themes this week:\n' +
+          topThemes.map((t) => `- "${t.display_name}" (${t.recent_count} recent entries)`).join('\n')
+        );
+      }
+
+      if (openTasks.length > 0) {
+        parts.push(
+          'Open tasks:\n' +
+          openTasks.slice(0, 10).map((t) => `- ${t.content.slice(0, 200)}`).join('\n')
+        );
+      }
+
+      if (recentEntries.length > 0) {
+        parts.push(
+          'Recent captures:\n' +
+          recentEntries.slice(0, 15).map((e) => {
+            const cat = e.category ? ` [${e.category}]` : '';
+            return `- ${e.created_at.slice(0, 10)}${cat}: ${e.content.slice(0, 200)}`;
+          }).join('\n')
+        );
+      }
+
+      if (parts.length === 0) {
+        return 'Not enough recent data to suggest focus areas. Start by capturing some notes.';
+      }
+
+      return (
+        parts.join('\n\n') + '\n\n' +
+        'Based on this context from my knowledge library, suggest 3-5 specific focus areas for today. ' +
+        'For each suggestion, give a one-sentence rationale grounded in the data above. ' +
+        'Be concrete and actionable. Write in second person.'
+      );
+    },
+  },
+};
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Return the list of available agents.
+ * @returns {{ id: string, label: string, description: string, icon: string }[]}
+ */
+function listAgents() {
+  return Object.entries(AGENTS).map(([id, a]) => ({
+    id,
+    label:       a.label,
+    description: a.description,
+    icon:        a.icon,
+  }));
+}
+
+/**
+ * Run an agent, streaming the LLM response token-by-token.
+ * @param {string}   agentId
+ * @param {function} onToken  Called with each text fragment as it arrives
+ * @returns {Promise<void>}
+ */
+async function runAgent(agentId, onToken) {
+  const agent = AGENTS[agentId];
+  if (!agent) throw new Error(`Unknown agent: "${agentId}"`);
+
+  const prompt = await agent.buildPrompt();
+  await generateStream(prompt, onToken);
+}
+
+module.exports = { listAgents, runAgent };

--- a/src/backend/db/agents.js
+++ b/src/backend/db/agents.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * Data-gathering queries for the Agentic Extensions feature.
+ * Each function assembles the corpus context that an agent prompt will use.
+ */
+
+const { openDb } = require('./connection');
+
+const MAX_ENTRIES = 100;
+const MAX_TASKS   = 200;
+
+/**
+ * Return entries captured in the last 7 days.
+ * @returns {Promise<{ entries: object[], since: string }>}
+ */
+async function getWeekSummaryData() {
+  const db    = await openDb();
+  const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const entries = db.prepare(
+    `SELECT id, content, category, created_at
+       FROM entries
+      WHERE created_at >= ?
+      ORDER BY created_at ASC
+      LIMIT ?`
+  ).all(since, MAX_ENTRIES);
+
+  return { entries, since };
+}
+
+/**
+ * Return all task-category entries (no explicit "done" state in the schema,
+ * so we return all of them for the LLM to reason about).
+ * @returns {Promise<{ tasks: object[] }>}
+ */
+async function getOpenTasksData() {
+  const db = await openDb();
+
+  const tasks = db.prepare(
+    `SELECT id, content, created_at
+       FROM entries
+      WHERE category = 'Task'
+      ORDER BY created_at DESC
+      LIMIT ?`
+  ).all(MAX_TASKS);
+
+  return { tasks };
+}
+
+/**
+ * Return theme activity for the last two weeks so the LLM can spot momentum.
+ * @returns {Promise<{ themes: object[], since: string }>}
+ */
+async function getEmergingPrioritiesData() {
+  const db          = await openDb();
+  const twoWeeksAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const oneWeekAgo  = new Date(Date.now() -  7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const themes = db.prepare(
+    `SELECT t.id,
+            COALESCE(t.user_name, t.name) AS display_name,
+            COUNT(DISTINCT CASE WHEN e.created_at >= ? THEN e.id END)                      AS recent_count,
+            COUNT(DISTINCT CASE WHEN e.created_at >= ? AND e.created_at < ? THEN e.id END) AS prev_count,
+            COUNT(DISTINCT e.id) AS total_count
+       FROM themes t
+       JOIN theme_entries te ON te.theme_id = t.id
+       JOIN entries e ON e.id = te.entry_id
+      GROUP BY t.id
+     HAVING total_count > 0
+      ORDER BY recent_count DESC, total_count DESC
+      LIMIT 20`
+  ).all(oneWeekAgo, twoWeeksAgo, oneWeekAgo);
+
+  return { themes, since: twoWeeksAgo };
+}
+
+/**
+ * Return a mix of recent entries, open tasks, and active themes for a
+ * "focus today" agent prompt.
+ * @returns {Promise<{ recentEntries: object[], openTasks: object[], topThemes: object[] }>}
+ */
+async function getTodayFocusData() {
+  const db         = await openDb();
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const recentEntries = db.prepare(
+    `SELECT id, content, category, created_at
+       FROM entries
+      WHERE created_at >= ?
+      ORDER BY created_at DESC
+      LIMIT 30`
+  ).all(oneWeekAgo);
+
+  const openTasks = db.prepare(
+    `SELECT id, content, created_at
+       FROM entries
+      WHERE category = 'Task'
+      ORDER BY created_at DESC
+      LIMIT 20`
+  ).all();
+
+  const topThemes = db.prepare(
+    `SELECT t.id,
+            COALESCE(t.user_name, t.name) AS display_name,
+            COUNT(e.id) AS recent_count
+       FROM themes t
+       JOIN theme_entries te ON te.theme_id = t.id
+       JOIN entries e ON e.id = te.entry_id AND e.created_at >= ?
+      GROUP BY t.id
+      ORDER BY recent_count DESC
+      LIMIT 10`
+  ).all(oneWeekAgo);
+
+  return { recentEntries, openTasks, topThemes };
+}
+
+module.exports = {
+  getWeekSummaryData,
+  getOpenTasksData,
+  getEmergingPrioritiesData,
+  getTodayFocusData,
+};

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -579,6 +579,7 @@
                 <span id="agents-output-label"></span>
                 <div class="agents-output-actions">
                   <span id="agents-running-indicator" class="agents-running-indicator" style="display:none">&#9679; Running&hellip;</span>
+                  <button id="btn-agents-stop" class="btn-sm btn-agents-stop" style="display:none">&#9632; Stop</button>
                   <button id="btn-agents-clear" class="btn-sm">Clear</button>
                 </div>
               </div>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -60,6 +60,10 @@
           <span class="nav-icon">&#9711;</span>
           <span class="nav-label">Replay</span>
         </button>
+        <button class="nav-item" data-view="agents" title="Agents">
+          <span class="nav-icon">&#10022;</span>
+          <span class="nav-label">Agents</span>
+        </button>
       </nav>
 
       <!-- ── View container ────────────────────────────────────────── -->
@@ -559,6 +563,29 @@
           </div>
 
         </div><!-- /#view-replay -->
+
+        <!-- ── View: Agents ─────────────────────────────────────────────── -->
+        <div id="view-agents" class="view">
+          <div id="agents-toolbar">
+            <span id="agents-title">Agents</span>
+            <span class="agents-subtitle">Local AI agents that work on your corpus</span>
+          </div>
+          <div id="agents-body">
+            <div id="agents-grid">
+              <!-- Agent cards injected by library.js -->
+            </div>
+            <div id="agents-output-panel" style="display:none">
+              <div id="agents-output-header">
+                <span id="agents-output-label"></span>
+                <div class="agents-output-actions">
+                  <span id="agents-running-indicator" class="agents-running-indicator" style="display:none">&#9679; Running&hellip;</span>
+                  <button id="btn-agents-clear" class="btn-sm">Clear</button>
+                </div>
+              </div>
+              <div id="agents-output" class="agents-output-body"></div>
+            </div>
+          </div>
+        </div><!-- /#view-agents -->
 
       </div><!-- /#view-container -->
     </div><!-- /#shell -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3158,4 +3158,169 @@ body.theme-light .graph-tooltip {
   font-style: italic;
 }
 
+/* ── Agents view ──────────────────────────────────────────────────────────── */
+
+#view-agents {
+  flex-direction: column;
+  overflow:       hidden;
+}
+
+#agents-toolbar {
+  display:        flex;
+  align-items:    center;
+  gap:            12px;
+  padding:        8px 16px;
+  border-bottom:  1px solid var(--border);
+  flex-shrink:    0;
+  background:     var(--bg-secondary);
+}
+
+#agents-title {
+  font-size:   14px;
+  font-weight: 600;
+  color:       var(--text-primary);
+}
+
+.agents-subtitle {
+  font-size: 12px;
+  color:     var(--text-muted);
+}
+
+#agents-body {
+  flex:           1;
+  overflow:       auto;
+  padding:        16px;
+  display:        flex;
+  flex-direction: column;
+  gap:            20px;
+}
+
+/* Agent card grid */
+#agents-grid {
+  display:               grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap:                   12px;
+}
+
+.agent-card {
+  display:        flex;
+  flex-direction: column;
+  gap:            8px;
+  padding:        16px;
+  border-radius:  8px;
+  background:     var(--bg-card);
+  border:         1px solid var(--border);
+  cursor:         pointer;
+  transition:     border-color 0.15s, background 0.15s;
+}
+
+.agent-card:hover {
+  border-color: var(--cortex-teal);
+  background:   var(--bg-hover);
+}
+
+.agent-card.running {
+  border-color: var(--cortex-teal);
+  opacity:      0.7;
+  pointer-events: none;
+}
+
+.agent-card-header {
+  display:     flex;
+  align-items: center;
+  gap:         10px;
+}
+
+.agent-card-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.agent-card-label {
+  font-size:   14px;
+  font-weight: 600;
+  color:       var(--text-primary);
+}
+
+.agent-card-desc {
+  font-size:   12px;
+  color:       var(--text-muted);
+  line-height: 1.5;
+}
+
+.agent-card-footer {
+  margin-top: 4px;
+}
+
+.btn-agent-run {
+  padding:       5px 14px;
+  border:        1px solid var(--cortex-teal);
+  border-radius: 4px;
+  background:    transparent;
+  color:         var(--cortex-teal);
+  font-size:     12px;
+  font-weight:   500;
+  cursor:        pointer;
+  font-family:   inherit;
+}
+
+.btn-agent-run:hover {
+  background: var(--cortex-teal);
+  color:      #fff;
+}
+
+/* Output panel */
+#agents-output-panel {
+  border:        1px solid var(--border);
+  border-radius: 8px;
+  overflow:      hidden;
+  background:    var(--bg-card);
+}
+
+#agents-output-header {
+  display:         flex;
+  justify-content: space-between;
+  align-items:     center;
+  padding:         8px 14px;
+  border-bottom:   1px solid var(--border);
+  background:      var(--bg-secondary);
+  gap:             12px;
+}
+
+#agents-output-label {
+  font-size:   13px;
+  font-weight: 600;
+  color:       var(--text-primary);
+}
+
+.agents-output-actions {
+  display:     flex;
+  align-items: center;
+  gap:         10px;
+}
+
+.agents-running-indicator {
+  font-size: 12px;
+  color:     var(--cortex-teal);
+  animation: agents-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes agents-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+.agents-output-body {
+  padding:     16px;
+  font-size:   14px;
+  line-height: 1.65;
+  color:       var(--text-primary);
+  white-space: pre-wrap;
+  word-break:  break-word;
+  min-height:  80px;
+  max-height:  480px;
+  overflow-y:  auto;
+}
+
+
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3305,6 +3305,16 @@ body.theme-light .graph-tooltip {
   animation: agents-pulse 1.2s ease-in-out infinite;
 }
 
+.btn-agents-stop {
+  border-color: var(--error-color, #e57373);
+  color:        var(--error-color, #e57373);
+}
+
+.btn-agents-stop:hover {
+  background: var(--error-color, #e57373);
+  color:      #fff;
+}
+
 @keyframes agents-pulse {
   0%, 100% { opacity: 1; }
   50%       { opacity: 0.4; }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1936,6 +1936,7 @@ function activateView(viewId) {
   if (viewId === 'explore')        loadDashboardView();
   if (viewId === 'graph')          loadGraphView();
   if (viewId === 'replay')         loadReplayView();
+  if (viewId === 'agents')         loadAgentsView();
   // Destroy graph renderer when leaving the graph view
   if (viewId !== 'graph')          _destroyGraphIfActive();
 }
@@ -2988,6 +2989,81 @@ replayMonthSelect.addEventListener('change', _loadMonthSnapshot);
 
 // Compare button
 btnReplayCompare.addEventListener('click', _loadComparePeriods);
+
+// ── Agents view controller ─────────────────────────────────────────────────
+
+const agentsGrid          = document.getElementById('agents-grid');
+const agentsOutputPanel   = document.getElementById('agents-output-panel');
+const agentsOutputLabel   = document.getElementById('agents-output-label');
+const agentsRunningInd    = document.getElementById('agents-running-indicator');
+const agentsOutputBody    = document.getElementById('agents-output');
+const btnAgentsClear      = document.getElementById('btn-agents-clear');
+
+let _agentsLoaded = false;
+
+async function loadAgentsView() {
+  if (_agentsLoaded) return;
+  _agentsLoaded = true;
+
+  try {
+    const agents = await window.neurologue.listAgents();
+    agentsGrid.innerHTML = '';
+    agents.forEach((a) => {
+      const card = document.createElement('div');
+      card.className  = 'agent-card';
+      card.dataset.id = a.id;
+      card.innerHTML =
+        `<div class="agent-card-header">` +
+        `  <span class="agent-card-icon">${a.icon}</span>` +
+        `  <span class="agent-card-label">${_escHtml(a.label)}</span>` +
+        `</div>` +
+        `<div class="agent-card-desc">${_escHtml(a.description)}</div>` +
+        `<div class="agent-card-footer"><button class="btn-agent-run">Run</button></div>`;
+
+      card.querySelector('.btn-agent-run').addEventListener('click', () => _runAgent(a.id, a.label));
+      agentsGrid.appendChild(card);
+    });
+  } catch (err) {
+    console.error('[agents] loadAgentsView failed:', err);
+    agentsGrid.innerHTML = '<div style="color:var(--text-dim);font-size:13px">Could not load agents</div>';
+  }
+}
+
+async function _runAgent(agentId, label) {
+  // Mark the card as running
+  document.querySelectorAll('.agent-card').forEach((c) => {
+    c.classList.toggle('running', c.dataset.id === agentId);
+  });
+
+  agentsOutputPanel.style.display  = '';
+  agentsOutputLabel.textContent    = label;
+  agentsRunningInd.style.display   = '';
+  agentsOutputBody.textContent     = '';
+
+  // Scroll output into view
+  agentsOutputPanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+  try {
+    await window.neurologue.runAgent(agentId);
+  } catch (err) {
+    agentsOutputBody.textContent += `\n\n[Error: ${err.message}]`;
+  } finally {
+    agentsRunningInd.style.display = 'none';
+    document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
+  }
+}
+
+// Stream tokens into the output body
+window.neurologue.onAgentToken(({ token }) => {
+  agentsOutputBody.textContent += token;
+  // Keep the last line visible
+  agentsOutputBody.scrollTop = agentsOutputBody.scrollHeight;
+});
+
+btnAgentsClear.addEventListener('click', () => {
+  agentsOutputBody.textContent = '';
+  agentsOutputPanel.style.display = 'none';
+});
 
 function _escHtml(str) {
   return String(str)

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -2998,10 +2998,28 @@ const agentsOutputLabel   = document.getElementById('agents-output-label');
 const agentsRunningInd    = document.getElementById('agents-running-indicator');
 const agentsOutputBody    = document.getElementById('agents-output');
 const btnAgentsClear      = document.getElementById('btn-agents-clear');
+const btnAgentsStop       = document.getElementById('btn-agents-stop');
 
 let _agentsLoaded = false;
+let _agentsRunning = false;
+
+function _setAgentsRunning(running) {
+  _agentsRunning = running;
+  agentsRunningInd.style.display = running ? '' : 'none';
+  btnAgentsStop.style.display    = running ? '' : 'none';
+  document.querySelectorAll('.agent-card').forEach((c) => {
+    c.classList.toggle('running', running && c.classList.contains('running'));
+    c.querySelector('.btn-agent-run').disabled = running;
+  });
+}
 
 async function loadAgentsView() {
+  // Always reset indicator state when the view becomes active
+  if (!_agentsRunning) {
+    agentsRunningInd.style.display = 'none';
+    btnAgentsStop.style.display    = 'none';
+  }
+
   if (_agentsLoaded) return;
   _agentsLoaded = true;
 
@@ -3030,17 +3048,18 @@ async function loadAgentsView() {
 }
 
 async function _runAgent(agentId, label) {
-  // Mark the card as running
+  if (_agentsRunning) return;
+
+  // Mark the active card and show running state
   document.querySelectorAll('.agent-card').forEach((c) => {
     c.classList.toggle('running', c.dataset.id === agentId);
   });
 
-  agentsOutputPanel.style.display  = '';
-  agentsOutputLabel.textContent    = label;
-  agentsRunningInd.style.display   = '';
-  agentsOutputBody.textContent     = '';
+  agentsOutputPanel.style.display = '';
+  agentsOutputLabel.textContent   = label;
+  agentsOutputBody.textContent    = '';
+  _setAgentsRunning(true);
 
-  // Scroll output into view
   agentsOutputPanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
   try {
@@ -3048,7 +3067,7 @@ async function _runAgent(agentId, label) {
   } catch (err) {
     agentsOutputBody.textContent += `\n\n[Error: ${err.message}]`;
   } finally {
-    agentsRunningInd.style.display = 'none';
+    _setAgentsRunning(false);
     document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
   }
 }
@@ -3056,8 +3075,20 @@ async function _runAgent(agentId, label) {
 // Stream tokens into the output body
 window.neurologue.onAgentToken(({ token }) => {
   agentsOutputBody.textContent += token;
-  // Keep the last line visible
   agentsOutputBody.scrollTop = agentsOutputBody.scrollHeight;
+});
+
+// Agent done (via push event — more reliable than awaiting runAgent resolve)
+window.neurologue.onAgentDone(() => {
+  _setAgentsRunning(false);
+  document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
+});
+
+btnAgentsStop.addEventListener('click', async () => {
+  await window.neurologue.abortAgent();
+  _setAgentsRunning(false);
+  document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
+  agentsOutputBody.textContent += '\n\n[Stopped]';
 });
 
 btnAgentsClear.addEventListener('click', () => {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -3065,11 +3065,12 @@ async function _runAgent(agentId, label) {
   try {
     await window.neurologue.runAgent(agentId);
   } catch (err) {
+    // IPC error (not an abort) — reset state here since agent:done won't fire
     agentsOutputBody.textContent += `\n\n[Error: ${err.message}]`;
-  } finally {
     _setAgentsRunning(false);
     document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
   }
+  // Normal completion: state reset by onAgentDone
 }
 
 // Stream tokens into the output body
@@ -3085,10 +3086,10 @@ window.neurologue.onAgentDone(() => {
 });
 
 btnAgentsStop.addEventListener('click', async () => {
-  await window.neurologue.abortAgent();
-  _setAgentsRunning(false);
-  document.querySelectorAll('.agent-card.running').forEach((c) => c.classList.remove('running'));
+  // Show stopped message immediately, then abort — agent:done will clean up state
   agentsOutputBody.textContent += '\n\n[Stopped]';
+  agentsOutputBody.scrollTop = agentsOutputBody.scrollHeight;
+  window.neurologue.abortAgent(); // fire-and-forget; agent:done arrives shortly after
 });
 
 btnAgentsClear.addEventListener('click', () => {

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -66,7 +66,9 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Agents ────────────────────────────────────────────────────────────────
   listAgents:    ()        => ipcRenderer.invoke('agents:list'),
   runAgent:      (agentId) => ipcRenderer.invoke('agents:run', { agentId }),
+  abortAgent:    ()        => ipcRenderer.invoke('agents:abort'),
   onAgentToken:  (cb)      => { ipcRenderer.on('agent:token', (_e, d) => cb(d)); },
+  onAgentDone:   (cb)      => { ipcRenderer.on('agent:done',  ()       => cb()); },
 
   // ── Memory Replay ─────────────────────────────────────────────────────────
   listActiveMonths:   ()                          => ipcRenderer.invoke('replay:active-months'),

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -63,6 +63,11 @@ contextBridge.exposeInMainWorld('neurologue', {
   // ── Graph ─────────────────────────────────────────────────────────────────
   getGraphData: () => ipcRenderer.invoke('graph:data'),
 
+  // ── Agents ────────────────────────────────────────────────────────────────
+  listAgents:    ()        => ipcRenderer.invoke('agents:list'),
+  runAgent:      (agentId) => ipcRenderer.invoke('agents:run', { agentId }),
+  onAgentToken:  (cb)      => { ipcRenderer.on('agent:token', (_e, d) => cb(d)); },
+
   // ── Memory Replay ─────────────────────────────────────────────────────────
   listActiveMonths:   ()                          => ipcRenderer.invoke('replay:active-months'),
   getMonthSnapshot:   (year, month)               => ipcRenderer.invoke('replay:month-snapshot',  { year, month }),

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 const { getGraphData } = require('./backend/db/graph');
 const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
+const { listAgents, runAgent } = require('./backend/agents/runner');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -351,6 +352,19 @@ handle('replay:active-months',  async () => listActiveMonths());
 handle('replay:month-snapshot', async (_e, { year, month }) => getMonthSnapshot(year, month));
 handle('replay:compare-periods', async (_e, { from1, to1, from2, to2 }) => comparePeriods(from1, to1, from2, to2));
 handle('replay:abandoned-ideas', async () => getAbandonedIdeas());
+
+// ── Agents IPC ───────────────────────────────────────────────────────────────
+
+handle('agents:list', async () => listAgents());
+
+handle('agents:run', async (event, { agentId }) => {
+  await runAgent(agentId, (token) => {
+    if (!event.sender.isDestroyed()) {
+      event.sender.send('agent:token', { token });
+    }
+  });
+  return { ok: true };
+});
 
 // ── Priorities IPC ───────────────────────────────────────────────────────────
 

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 const { getGraphData } = require('./backend/db/graph');
 const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
-const { listAgents, runAgent } = require('./backend/agents/runner');
+const { listAgents, runAgent, abortAgent } = require('./backend/agents/runner');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
@@ -363,6 +363,14 @@ handle('agents:run', async (event, { agentId }) => {
       event.sender.send('agent:token', { token });
     }
   });
+  if (!event.sender.isDestroyed()) {
+    event.sender.send('agent:done');
+  }
+  return { ok: true };
+});
+
+handle('agents:abort', async () => {
+  abortAgent();
   return { ok: true };
 });
 

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -448,4 +448,75 @@ function clamp(val, min, max) {
   return Math.min(max, Math.max(min, val));
 }
 
-module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry, suggestTags, setAvailableModels, detectContradiction, computeEntrySignals };
+/**
+ * Stream a text generation response from Ollama, calling `onToken` for each
+ * token as it arrives.  Uses the configured LLM model.
+ *
+ * @param {string}   prompt
+ * @param {function} onToken       Called with each text fragment (string)
+ * @param {number}   [timeoutMs=180000]  Hard cap; large models can be slow to load
+ * @returns {Promise<void>}
+ */
+function generateStream(prompt, onToken, timeoutMs = 180_000) {
+  return new Promise((resolve, reject) => {
+    const settings = getSettings();
+    const model    = settings.llmModel || 'phi3:mini';
+    const payload  = JSON.stringify({ model, prompt, stream: true });
+    const url      = new URL(config.ollama.baseUrl);
+
+    const options = {
+      hostname: url.hostname,
+      port:     url.port || 11434,
+      path:     '/api/generate',
+      method:   'POST',
+      headers: {
+        'Content-Type':   'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+
+    const req = http.request(options, (res) => {
+      if (res.statusCode >= 400) {
+        res.resume();
+        return reject(new Error(`Ollama generateStream HTTP ${res.statusCode}`));
+      }
+
+      let buf = '';
+      res.on('data', (chunk) => {
+        buf += chunk.toString('utf8');
+        // NDJSON — split on newlines, keep any trailing incomplete fragment
+        const lines = buf.split('\n');
+        buf = lines.pop();
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const obj = JSON.parse(line);
+            if (obj.response) onToken(obj.response);
+            if (obj.done) resolve();
+          } catch { /* ignore malformed line */ }
+        }
+      });
+
+      res.on('end', () => {
+        if (buf.trim()) {
+          try {
+            const obj = JSON.parse(buf);
+            if (obj.response) onToken(obj.response);
+          } catch { /* ignore */ }
+        }
+        resolve();
+      });
+
+      res.on('error', reject);
+    });
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`generateStream timed out after ${timeoutMs / 1000}s`));
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry, suggestTags, setAvailableModels, detectContradiction, computeEntrySignals, generateStream };

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -452,13 +452,16 @@ function clamp(val, min, max) {
  * Stream a text generation response from Ollama, calling `onToken` for each
  * token as it arrives.  Uses the configured LLM model.
  *
- * @param {string}   prompt
- * @param {function} onToken       Called with each text fragment (string)
- * @param {number}   [timeoutMs=180000]  Hard cap; large models can be slow to load
+ * @param {string}      prompt
+ * @param {function}    onToken       Called with each text fragment (string)
+ * @param {number}      [timeoutMs=180000]  Hard cap; large models can be slow to load
+ * @param {AbortSignal} [signal]      When aborted, destroys the HTTP request immediately
  * @returns {Promise<void>}
  */
-function generateStream(prompt, onToken, timeoutMs = 180_000) {
+function generateStream(prompt, onToken, timeoutMs = 180_000, signal = null) {
   return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) return resolve();
+
     const settings = getSettings();
     const model    = settings.llmModel || 'phi3:mini';
     const payload  = JSON.stringify({ model, prompt, stream: true });
@@ -475,10 +478,19 @@ function generateStream(prompt, onToken, timeoutMs = 180_000) {
       },
     };
 
+    let settled = false;
+    function finish() { if (!settled) { settled = true; resolve(); } }
+    function fail(err) { if (!settled) { settled = true; reject(err); } }
+
+    // Wire up abort signal before making the request
+    if (signal) {
+      signal.addEventListener('abort', () => { req.destroy(); finish(); }, { once: true });
+    }
+
     const req = http.request(options, (res) => {
       if (res.statusCode >= 400) {
         res.resume();
-        return reject(new Error(`Ollama generateStream HTTP ${res.statusCode}`));
+        return fail(new Error(`Ollama generateStream HTTP ${res.statusCode}`));
       }
 
       let buf = '';
@@ -492,7 +504,7 @@ function generateStream(prompt, onToken, timeoutMs = 180_000) {
           try {
             const obj = JSON.parse(line);
             if (obj.response) onToken(obj.response);
-            if (obj.done) resolve();
+            if (obj.done) finish();
           } catch { /* ignore malformed line */ }
         }
       });
@@ -504,16 +516,16 @@ function generateStream(prompt, onToken, timeoutMs = 180_000) {
             if (obj.response) onToken(obj.response);
           } catch { /* ignore */ }
         }
-        resolve();
+        finish();
       });
 
-      res.on('error', reject);
+      res.on('error', (err) => { if (!settled) fail(err); });
     });
 
     req.setTimeout(timeoutMs, () => {
       req.destroy(new Error(`generateStream timed out after ${timeoutMs / 1000}s`));
     });
-    req.on('error', reject);
+    req.on('error', (err) => { if (!settled) fail(err); });
     req.write(payload);
     req.end();
   });

--- a/tests/unit/db/agents.test.js
+++ b/tests/unit/db/agents.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+const { randomUUID } = require('crypto');
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-agents-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+// ── Seed helpers ─────────────────────────────────────────────────────────────
+
+async function seedEntry(content, createdAt, category = null) {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  const id = randomUUID();
+  db.prepare(
+    'INSERT INTO entries (id, content, source, type, metadata, created_at, category) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(id, content, 'manual', 'note', '{}', createdAt, category);
+  return id;
+}
+
+async function seedTheme(name = 'Test Theme') {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  const id = randomUUID();
+  db.prepare('INSERT INTO themes (id, name) VALUES (?, ?)').run(id, name);
+  return id;
+}
+
+async function linkEntryToTheme(entryId, themeId) {
+  const { openDb } = require('../../../src/backend/db/connection');
+  const db = await openDb();
+  db.prepare('INSERT INTO theme_entries (theme_id, entry_id, score) VALUES (?, ?, ?)').run(themeId, entryId, 0.9);
+}
+
+// ── getWeekSummaryData ────────────────────────────────────────────────────────
+
+describe('getWeekSummaryData', () => {
+  test('returns empty entries when DB is empty', async () => {
+    const { getWeekSummaryData } = require('../../../src/backend/db/agents');
+    const { entries } = await getWeekSummaryData();
+    expect(entries).toEqual([]);
+  });
+
+  test('returns entries from last 7 days', async () => {
+    const { getWeekSummaryData } = require('../../../src/backend/db/agents');
+    await seedEntry('Recent note', new Date(Date.now() - 2 * 86400_000).toISOString().slice(0, 10));
+    const { entries } = await getWeekSummaryData();
+    expect(entries.length).toBe(1);
+    expect(entries[0].content).toBe('Recent note');
+  });
+
+  test('does not return entries older than 7 days', async () => {
+    const { getWeekSummaryData } = require('../../../src/backend/db/agents');
+    await seedEntry('Old note', '2020-01-01 10:00:00');
+    const { entries } = await getWeekSummaryData();
+    expect(entries).toEqual([]);
+  });
+});
+
+// ── getOpenTasksData ──────────────────────────────────────────────────────────
+
+describe('getOpenTasksData', () => {
+  test('returns empty array when no tasks exist', async () => {
+    const { getOpenTasksData } = require('../../../src/backend/db/agents');
+    const { tasks } = await getOpenTasksData();
+    expect(tasks).toEqual([]);
+  });
+
+  test('returns only Task-category entries', async () => {
+    const { getOpenTasksData } = require('../../../src/backend/db/agents');
+    await seedEntry('Buy milk', '2026-05-10 10:00:00', 'Task');
+    await seedEntry('Just a thought', '2026-05-10 10:00:00', 'Thought');
+    const { tasks } = await getOpenTasksData();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].content).toBe('Buy milk');
+  });
+
+  test('returns tasks ordered newest first', async () => {
+    const { getOpenTasksData } = require('../../../src/backend/db/agents');
+    await seedEntry('Old task', '2026-01-01 10:00:00', 'Task');
+    await seedEntry('New task', '2026-05-10 10:00:00', 'Task');
+    const { tasks } = await getOpenTasksData();
+    expect(tasks[0].content).toBe('New task');
+    expect(tasks[1].content).toBe('Old task');
+  });
+});
+
+// ── getEmergingPrioritiesData ────────────────────────────────────────────────
+
+describe('getEmergingPrioritiesData', () => {
+  test('returns empty themes when DB has no entries', async () => {
+    const { getEmergingPrioritiesData } = require('../../../src/backend/db/agents');
+    const { themes } = await getEmergingPrioritiesData();
+    expect(themes).toEqual([]);
+  });
+
+  test('returns theme with recent entry count', async () => {
+    const { getEmergingPrioritiesData } = require('../../../src/backend/db/agents');
+    const e = await seedEntry('This week', new Date(Date.now() - 2 * 86400_000).toISOString().slice(0, 10));
+    const t = await seedTheme('Active Theme');
+    await linkEntryToTheme(e, t);
+    const { themes } = await getEmergingPrioritiesData();
+    expect(themes).toHaveLength(1);
+    expect(themes[0].recent_count).toBe(1);
+    expect(themes[0].prev_count).toBe(0);
+  });
+
+  test('theme with only old entries has zero recent_count', async () => {
+    const { getEmergingPrioritiesData } = require('../../../src/backend/db/agents');
+    const e = await seedEntry('Old entry', '2020-01-01 10:00:00');
+    const t = await seedTheme('Old Theme');
+    await linkEntryToTheme(e, t);
+    const { themes } = await getEmergingPrioritiesData();
+    // Theme has entries but zero in recent windows — should still appear (total_count > 0)
+    // but with recent_count = 0 and prev_count = 0
+    const found = themes.find((th) => th.recent_count === 0 && th.prev_count === 0);
+    expect(found).toBeDefined();
+  });
+});
+
+// ── getTodayFocusData ────────────────────────────────────────────────────────
+
+describe('getTodayFocusData', () => {
+  test('returns empty arrays when DB is empty', async () => {
+    const { getTodayFocusData } = require('../../../src/backend/db/agents');
+    const result = await getTodayFocusData();
+    expect(result.recentEntries).toEqual([]);
+    expect(result.openTasks).toEqual([]);
+    expect(result.topThemes).toEqual([]);
+  });
+
+  test('includes recent entries and open tasks', async () => {
+    const { getTodayFocusData } = require('../../../src/backend/db/agents');
+    await seedEntry('Recent thought', new Date(Date.now() - 1 * 86400_000).toISOString().slice(0, 10), 'Thought');
+    await seedEntry('Pending task', new Date(Date.now() - 1 * 86400_000).toISOString().slice(0, 10), 'Task');
+    const result = await getTodayFocusData();
+    expect(result.recentEntries.length).toBeGreaterThanOrEqual(1);
+    expect(result.openTasks.length).toBe(1);
+    expect(result.openTasks[0].content).toBe('Pending task');
+  });
+
+  test('does not include entries older than 7 days in recentEntries', async () => {
+    const { getTodayFocusData } = require('../../../src/backend/db/agents');
+    await seedEntry('Old thought', '2020-01-01 10:00:00', 'Thought');
+    const result = await getTodayFocusData();
+    expect(result.recentEntries).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements the Agentic Extensions feature (issue #59).

## What's included

**Backend data layer** (\src/backend/db/agents.js\)
- \getWeekSummaryData()\ — entries from the last 7 days
- \getOpenTasksData()\ — all Task-category entries
- \getEmergingPrioritiesData()\ — per-theme entry counts for last two weeks (trend detection)
- \getTodayFocusData()\ — recent entries, open tasks, and active themes combined

**Agent runner** (\src/backend/agents/runner.js\)
Four agents, each building a tailored Ollama prompt from the corpus data:
- \week-summary\ — Summarise my week
- \open-tasks\ — Find open tasks
- \emerging-priorities\ — Identify emerging priorities
- \ocus-today\ — Suggest focus areas for today

**LLM streaming** (\src/worker/ollama.js\)
- Added \generateStream(prompt, onToken)\ — streams NDJSON token-by-token from \/api/generate\

**IPC / Preload**
- \gents:list\ and \gents:run\ handlers; \gent:token\ push event for streaming
- \listAgents\, \unAgent\, \onAgentToken\ exposed via contextBridge

**Frontend**
- New Agents nav item (✦)
- Agent card grid — click any card to run the agent
- Streaming output panel with live token display and clear button
- Running indicator with pulse animation

**Tests** — \	ests/unit/db/agents.test.js\, 12 tests (270 total, all passing)

Closes #59