### PR TITLE
feat(export): CCF Export Engine (#118)

### DIFF
--- a/src/backend/export/ccf.js
+++ b/src/backend/export/ccf.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * Canonical Corpus Format (CCF) Export Engine.
+ *
+ * Produces a versioned, portable snapshot of the entire corpus:
+ *
+ *   <destDir>/
+ *     entries.jsonl          — one CCF entry object per line
+ *     themes.json            — array of CCF theme objects
+ *     embeddings/
+ *       entries.jsonl        — one CCF embedding object per line
+ *     metadata.json          — format version, app version, export timestamp
+ *
+ * See docs/architecture/07-canonical-corpus-format.md for the full spec.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const { openDb }            = require('../db/connection');
+const { getEntryWithTags }  = require('../db/search');
+const { listThemes, getEntriesForTheme } = require('../db/themes');
+
+const FORMAT_VERSION = '1.0.0';
+
+// ── Schema mappers ─────────────────────────────────────────────────────────────
+
+/**
+ * Map an internal enriched entry + theme-id lookup to the CCF entry schema.
+ *
+ * @param {object}            entry            — enriched entry row (with .tags[])
+ * @param {Map<string, string[]>} themeIdsByEntry — entry_id → [theme_id, …]
+ * @returns {object}
+ */
+function toCCFEntry(entry, themeIdsByEntry) {
+  return {
+    id:         entry.id,
+    created_at: entry.created_at,
+    updated_at: entry.edited_at || entry.created_at,
+    text:       entry.content,
+    source: {
+      type:        'user',
+      app:         'neurologue',
+      external_id: null,
+    },
+    domain:     'personal',
+    tags:       (entry.tags || []).map((t) => t.name),
+    theme_ids:  (themeIdsByEntry && themeIdsByEntry.get(entry.id)) || [],
+    media_refs: [],
+    metadata: {
+      pinned:   false,
+      archived: false,
+      custom:   {},
+    },
+  };
+}
+
+/**
+ * Map an enriched internal theme (with .entries[]) to the CCF theme schema.
+ *
+ * @param {object} theme — theme row enriched with .entries[] (from getEntriesForTheme)
+ * @returns {object}
+ */
+function toCCFTheme(theme) {
+  const entries   = theme.entries || [];
+  const entryIds  = entries.map((e) => e.entry_id || e.id);
+  const createdAts = entries
+    .map((e) => e.created_at)
+    .filter(Boolean)
+    .sort();
+
+  return {
+    id:         theme.id,
+    name:       theme.display_name || theme.name,
+    created_at: theme.created_at  || null,
+    updated_at: theme.updated_at  || null,
+    summary:    theme.description || '',
+    entry_ids:  entryIds,
+    metrics: {
+      entry_count:    entryIds.length,
+      first_entry_at: createdAts[0]                         || null,
+      last_entry_at:  createdAts[createdAts.length - 1]     || null,
+    },
+    metadata: {
+      color:  null,
+      custom: {},
+    },
+  };
+}
+
+// ── Engine ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Export the full corpus as a Canonical Corpus Format (CCF) snapshot.
+ *
+ * @param {string} destDir  Absolute path to the output directory (created if absent).
+ * @returns {Promise<{
+ *   dir:             string,
+ *   entryCount:      number,
+ *   themeCount:      number,
+ *   embeddingCount:  number,
+ *   embeddingModel:  string|null,
+ *   dimension:       number|null,
+ * }>}
+ */
+async function exportCCF(destDir) {
+  fs.mkdirSync(path.join(destDir, 'embeddings'), { recursive: true });
+
+  const db = await openDb();
+
+  // ── Entries ──────────────────────────────────────────────────────────────
+  const rawEntries = db
+    .prepare('SELECT * FROM entries ORDER BY created_at DESC')
+    .all();
+  const entries = (
+    await Promise.all(rawEntries.map((e) => getEntryWithTags(e.id)))
+  ).filter(Boolean);
+
+  // ── Themes ───────────────────────────────────────────────────────────────
+  const themeRows = await listThemes();
+  const themes = await Promise.all(
+    themeRows.map(async (t) => {
+      const members = await getEntriesForTheme(t.id);
+      return { ...t, entries: members };
+    }),
+  );
+
+  // Build entry_id → [theme_id, …] for the entries.jsonl theme_ids field
+  const themeIdsByEntry = new Map();
+  for (const t of themes) {
+    for (const e of t.entries) {
+      const eid = e.entry_id || e.id;
+      if (!themeIdsByEntry.has(eid)) themeIdsByEntry.set(eid, []);
+      themeIdsByEntry.get(eid).push(t.id);
+    }
+  }
+
+  // ── Write entries.jsonl ──────────────────────────────────────────────────
+  const entriesJsonl = entries
+    .map((e) => JSON.stringify(toCCFEntry(e, themeIdsByEntry)))
+    .join('\n');
+  fs.writeFileSync(path.join(destDir, 'entries.jsonl'), entriesJsonl, 'utf8');
+
+  // ── Write themes.json ────────────────────────────────────────────────────
+  fs.writeFileSync(
+    path.join(destDir, 'themes.json'),
+    JSON.stringify(themes.map(toCCFTheme), null, 2),
+    'utf8',
+  );
+
+  // ── Embeddings ────────────────────────────────────────────────────────────
+  const embRows = db
+    .prepare('SELECT entry_id, vector, model_name FROM embeddings')
+    .all();
+
+  let embeddingModel = null;
+  let dimension      = null;
+
+  const embeddingsJsonl = embRows
+    .map((r) => {
+      const vec = Array.from(new Float32Array(new Uint8Array(r.vector).buffer));
+      if (!embeddingModel) { embeddingModel = r.model_name; dimension = vec.length; }
+      return JSON.stringify({
+        entry_id: r.entry_id,
+        model:    r.model_name,
+        vector:   vec,
+      });
+    })
+    .join('\n');
+
+  fs.writeFileSync(
+    path.join(destDir, 'embeddings', 'entries.jsonl'),
+    embeddingsJsonl,
+    'utf8',
+  );
+
+  // ── Write metadata.json ──────────────────────────────────────────────────
+  // eslint-disable-next-line import/no-dynamic-require
+  const { version } = require(path.resolve(__dirname, '../../../package.json'));
+
+  const metadata = {
+    format_version: FORMAT_VERSION,
+    exported_at:    new Date().toISOString(),
+    app: {
+      name:    'Neurologue',
+      version,
+    },
+    embedding: {
+      model:     embeddingModel,
+      dimension,
+    },
+    notes: {
+      entry_count: entries.length,
+      theme_count: themes.length,
+    },
+    custom: {},
+  };
+
+  fs.writeFileSync(
+    path.join(destDir, 'metadata.json'),
+    JSON.stringify(metadata, null, 2),
+    'utf8',
+  );
+
+  return {
+    dir:            destDir,
+    entryCount:     entries.length,
+    themeCount:     themes.length,
+    embeddingCount: embRows.length,
+    embeddingModel,
+    dimension,
+  };
+}
+
+module.exports = { exportCCF, toCCFEntry, toCCFTheme };

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -39,6 +39,7 @@ contextBridge.exposeInMainWorld('neurologue', {
   bulkDeleteEntries: (ids) => ipcRenderer.invoke('library:bulk-delete-entries', { ids }),
   // ── Export ───────────────────────────────────────────────────────────────
   exportAll: (opts) => ipcRenderer.invoke('export:run', opts),
+  exportCCF:  ()    => ipcRenderer.invoke('export:ccf'),
 
   // ── Help ─────────────────────────────────────────────────────────────────
   openHelp: () => ipcRenderer.invoke('help:open'),

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ const { listThemes, getThemeById, renameTheme, deleteTheme, getThemeWeeklyActivi
 const { listContradictions, resolveContradiction, dismissContradiction } = require('./backend/db/contradictions');
 const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
+const { exportCCF }  = require('./backend/export/ccf');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
 const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
@@ -422,6 +423,19 @@ ipcMain.handle('export:run', async (_event, { formats } = {}) => {
   }
   const result = await runExport(filePaths[0], { formats });
   return { canceled: false, destDir: filePaths[0], ...result };
+});
+
+// Show native folder picker and run a CCF snapshot export
+handle('export:ccf', async () => {
+  const { dialog } = require('electron');
+  const win = BrowserWindow.getFocusedWindow();
+  const { canceled, filePaths } = await dialog.showOpenDialog(win || undefined, {
+    title: 'Choose CCF export folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (canceled || !filePaths || filePaths.length === 0) return { canceled: true };
+  const result = await exportCCF(filePaths[0]);
+  return { canceled: false, ...result };
 });
 
 app.whenReady().then(async () => {

--- a/tests/unit/export/ccf.test.js
+++ b/tests/unit/export/ccf.test.js
@@ -1,0 +1,366 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+let tmpDir;
+let exportDir;
+
+beforeEach(async () => {
+  tmpDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-ccf-'));
+  exportDir = path.join(tmpDir, 'ccf-out');
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+async function seedData() {
+  const { createEntry }       = require('../../../src/backend/db/entries');
+  const { setTagsForEntry }   = require('../../../src/backend/db/tags');
+  const { upsertEmbedding }   = require('../../../src/backend/db/embeddings');
+  const { upsertTheme, setThemeEntries } = require('../../../src/backend/db/themes');
+
+  const e1 = await createEntry({ content: 'First entry about ideas' });
+  const e2 = await createEntry({ content: 'Second entry about memory' });
+  await setTagsForEntry(e1.id, ['ideas', 'project:alpha']);
+  await upsertEmbedding(e1.id, new Float32Array([0.1, 0.2, 0.3]), 'test-model');
+  await upsertEmbedding(e2.id, new Float32Array([0.4, 0.5, 0.6]), 'test-model');
+
+  const theme = await upsertTheme({ name: 'Test Theme', description: 'A test summary' });
+  await setThemeEntries(theme.id, [
+    { entryId: e1.id, score: 0.9 },
+    { entryId: e2.id, score: 0.7 },
+  ]);
+
+  return { e1, e2, theme };
+}
+
+// ── exportCCF — folder structure ────────────────────────────────────────────
+
+describe('exportCCF — folder structure', () => {
+  test('creates output directory if it does not exist', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await exportCCF(exportDir);
+    expect(fs.existsSync(exportDir)).toBe(true);
+  });
+
+  test('creates embeddings/ subdirectory', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await exportCCF(exportDir);
+    expect(fs.existsSync(path.join(exportDir, 'embeddings'))).toBe(true);
+  });
+
+  test('writes all four required CCF files', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    expect(fs.existsSync(path.join(exportDir, 'entries.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(exportDir, 'themes.json'))).toBe(true);
+    expect(fs.existsSync(path.join(exportDir, 'embeddings', 'entries.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(exportDir, 'metadata.json'))).toBe(true);
+  });
+
+  test('returns correct counts', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    const { e1, e2, theme } = await seedData();
+    const result = await exportCCF(exportDir);
+    expect(result.entryCount).toBe(2);
+    expect(result.themeCount).toBe(1);
+    expect(result.embeddingCount).toBe(2);
+    expect(result.dir).toBe(exportDir);
+  });
+
+  test('returns embedding model and dimension', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    const result = await exportCCF(exportDir);
+    expect(result.embeddingModel).toBe('test-model');
+    expect(result.dimension).toBe(3);
+  });
+});
+
+// ── exportCCF — entries.jsonl ───────────────────────────────────────────────
+
+describe('exportCCF — entries.jsonl', () => {
+  test('each line is valid JSON', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const lines = fs
+      .readFileSync(path.join(exportDir, 'entries.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean);
+    expect(lines.length).toBe(2);
+    lines.forEach((line) => expect(() => JSON.parse(line)).not.toThrow());
+  });
+
+  test('each entry has required CCF fields', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const entries = fs
+      .readFileSync(path.join(exportDir, 'entries.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+    for (const e of entries) {
+      expect(e).toHaveProperty('id');
+      expect(e).toHaveProperty('created_at');
+      expect(e).toHaveProperty('updated_at');
+      expect(e).toHaveProperty('text');
+      expect(e).toHaveProperty('source');
+      expect(e.source).toMatchObject({ type: 'user', app: 'neurologue' });
+      expect(e).toHaveProperty('domain', 'personal');
+      expect(Array.isArray(e.tags)).toBe(true);
+      expect(Array.isArray(e.theme_ids)).toBe(true);
+      expect(Array.isArray(e.media_refs)).toBe(true);
+      expect(e).toHaveProperty('metadata');
+    }
+  });
+
+  test('tags are populated correctly', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    const { e1 } = await seedData();
+    await exportCCF(exportDir);
+    const entries = fs
+      .readFileSync(path.join(exportDir, 'entries.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+    const exported = entries.find((e) => e.id === e1.id);
+    expect(exported.tags).toEqual(expect.arrayContaining(['ideas', 'project:alpha']));
+  });
+
+  test('theme_ids are populated for entries belonging to a theme', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    const { e1, theme } = await seedData();
+    await exportCCF(exportDir);
+    const entries = fs
+      .readFileSync(path.join(exportDir, 'entries.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+    const exported = entries.find((e) => e.id === e1.id);
+    expect(exported.theme_ids).toContain(theme.id);
+  });
+});
+
+// ── exportCCF — themes.json ─────────────────────────────────────────────────
+
+describe('exportCCF — themes.json', () => {
+  test('parses as a JSON array', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const themes = JSON.parse(
+      fs.readFileSync(path.join(exportDir, 'themes.json'), 'utf8'),
+    );
+    expect(Array.isArray(themes)).toBe(true);
+    expect(themes.length).toBe(1);
+  });
+
+  test('each theme has required CCF fields', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const themes = JSON.parse(
+      fs.readFileSync(path.join(exportDir, 'themes.json'), 'utf8'),
+    );
+    for (const t of themes) {
+      expect(t).toHaveProperty('id');
+      expect(t).toHaveProperty('name');
+      expect(t).toHaveProperty('summary');
+      expect(Array.isArray(t.entry_ids)).toBe(true);
+      expect(t).toHaveProperty('metrics');
+      expect(t.metrics).toHaveProperty('entry_count');
+    }
+  });
+
+  test('entry_ids are populated', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    const { e1, e2 } = await seedData();
+    await exportCCF(exportDir);
+    const themes = JSON.parse(
+      fs.readFileSync(path.join(exportDir, 'themes.json'), 'utf8'),
+    );
+    expect(themes[0].entry_ids).toEqual(expect.arrayContaining([e1.id, e2.id]));
+    expect(themes[0].metrics.entry_count).toBe(2);
+  });
+});
+
+// ── exportCCF — embeddings/entries.jsonl ───────────────────────────────────
+
+describe('exportCCF — embeddings/entries.jsonl', () => {
+  test('each line is valid JSON with required fields', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const lines = fs
+      .readFileSync(path.join(exportDir, 'embeddings', 'entries.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean);
+    expect(lines.length).toBe(2);
+    for (const line of lines) {
+      const emb = JSON.parse(line);
+      expect(emb).toHaveProperty('entry_id');
+      expect(emb).toHaveProperty('model');
+      expect(Array.isArray(emb.vector)).toBe(true);
+      expect(emb.vector.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── exportCCF — metadata.json ───────────────────────────────────────────────
+
+describe('exportCCF — metadata.json', () => {
+  test('has required top-level fields', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await seedData();
+    await exportCCF(exportDir);
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(exportDir, 'metadata.json'), 'utf8'),
+    );
+    expect(meta).toHaveProperty('format_version', '1.0.0');
+    expect(meta).toHaveProperty('exported_at');
+    expect(meta).toHaveProperty('app');
+    expect(meta.app).toMatchObject({ name: 'Neurologue' });
+    expect(typeof meta.app.version).toBe('string');
+    expect(meta).toHaveProperty('embedding');
+    expect(meta).toHaveProperty('notes');
+    expect(meta.notes.entry_count).toBe(2);
+    expect(meta.notes.theme_count).toBe(1);
+  });
+
+  test('exported_at is a valid ISO 8601 date', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    await exportCCF(exportDir);
+    const meta = JSON.parse(
+      fs.readFileSync(path.join(exportDir, 'metadata.json'), 'utf8'),
+    );
+    expect(new Date(meta.exported_at).toISOString()).toBe(meta.exported_at);
+  });
+});
+
+// ── exportCCF — empty corpus ────────────────────────────────────────────────
+
+describe('exportCCF — empty corpus', () => {
+  test('produces all four files with empty/null data', async () => {
+    const { exportCCF } = require('../../../src/backend/export/ccf');
+    const result = await exportCCF(exportDir);
+    expect(result.entryCount).toBe(0);
+    expect(result.themeCount).toBe(0);
+    expect(result.embeddingCount).toBe(0);
+    expect(result.embeddingModel).toBeNull();
+    // entries.jsonl should be empty string
+    const entriesContent = fs.readFileSync(path.join(exportDir, 'entries.jsonl'), 'utf8');
+    expect(entriesContent).toBe('');
+    // themes.json should be empty array
+    const themes = JSON.parse(fs.readFileSync(path.join(exportDir, 'themes.json'), 'utf8'));
+    expect(themes).toEqual([]);
+  });
+});
+
+// ── toCCFEntry — pure transform ─────────────────────────────────────────────
+
+describe('toCCFEntry', () => {
+  const { toCCFEntry } = require('../../../src/backend/export/ccf');
+
+  const ENTRY = {
+    id:         'abc123',
+    content:    'A thought',
+    created_at: '2026-01-01T10:00:00.000Z',
+    edited_at:  '2026-01-02T12:00:00.000Z',
+    tags:       [{ id: 't1', name: 'ideas' }],
+  };
+
+  test('maps required fields correctly', () => {
+    const ccf = toCCFEntry(ENTRY, new Map());
+    expect(ccf.id).toBe('abc123');
+    expect(ccf.text).toBe('A thought');
+    expect(ccf.created_at).toBe('2026-01-01T10:00:00.000Z');
+    expect(ccf.updated_at).toBe('2026-01-02T12:00:00.000Z');
+    expect(ccf.source).toMatchObject({ type: 'user', app: 'neurologue', external_id: null });
+    expect(ccf.domain).toBe('personal');
+    expect(ccf.tags).toEqual(['ideas']);
+    expect(ccf.media_refs).toEqual([]);
+  });
+
+  test('uses created_at as updated_at when edited_at is absent', () => {
+    const { toCCFEntry: fn } = require('../../../src/backend/export/ccf');
+    const ccf = fn({ ...ENTRY, edited_at: null }, new Map());
+    expect(ccf.updated_at).toBe(ENTRY.created_at);
+  });
+
+  test('populates theme_ids from the lookup map', () => {
+    const map = new Map([['abc123', ['theme1', 'theme2']]]);
+    const ccf = toCCFEntry(ENTRY, map);
+    expect(ccf.theme_ids).toEqual(['theme1', 'theme2']);
+  });
+
+  test('theme_ids is empty when entry not in any theme', () => {
+    const ccf = toCCFEntry(ENTRY, new Map());
+    expect(ccf.theme_ids).toEqual([]);
+  });
+});
+
+// ── toCCFTheme — pure transform ─────────────────────────────────────────────
+
+describe('toCCFTheme', () => {
+  const { toCCFTheme } = require('../../../src/backend/export/ccf');
+
+  const THEME = {
+    id:          'theme1',
+    name:        'Ideas',
+    display_name: 'Ideas (user)',
+    description: 'All about ideas',
+    created_at:  '2026-01-01T00:00:00.000Z',
+    entries: [
+      { entry_id: 'e1', score: 0.9, created_at: '2026-01-05T00:00:00.000Z' },
+      { entry_id: 'e2', score: 0.8, created_at: '2026-01-10T00:00:00.000Z' },
+    ],
+  };
+
+  test('maps required fields', () => {
+    const ccf = toCCFTheme(THEME);
+    expect(ccf.id).toBe('theme1');
+    expect(ccf.name).toBe('Ideas (user)');
+    expect(ccf.summary).toBe('All about ideas');
+    expect(ccf.entry_ids).toEqual(['e1', 'e2']);
+  });
+
+  test('computes metrics correctly', () => {
+    const ccf = toCCFTheme(THEME);
+    expect(ccf.metrics.entry_count).toBe(2);
+    expect(ccf.metrics.first_entry_at).toBe('2026-01-05T00:00:00.000Z');
+    expect(ccf.metrics.last_entry_at).toBe('2026-01-10T00:00:00.000Z');
+  });
+
+  test('handles theme with no entries', () => {
+    const ccf = toCCFTheme({ ...THEME, entries: [] });
+    expect(ccf.entry_ids).toEqual([]);
+    expect(ccf.metrics.entry_count).toBe(0);
+    expect(ccf.metrics.first_entry_at).toBeNull();
+    expect(ccf.metrics.last_entry_at).toBeNull();
+  });
+
+  test('falls back to name when display_name is absent', () => {
+    const ccf = toCCFTheme({ ...THEME, display_name: undefined });
+    expect(ccf.name).toBe('Ideas');
+  });
+});


### PR DESCRIPTION
Implements the Canonical Corpus Format (CCF) Export Engine as defined in docs/architecture/07-canonical-corpus-format.md.

## Changes

- **New** \src/backend/export/ccf.js\ — \exportCCF(destDir)\ produces a versioned CCF snapshot:
  - \entries.jsonl\ — one CCF entry object per line (id, text, source, domain, tags, theme_ids, media_refs, metadata)
  - \	hemes.json\ — array of CCF theme objects (id, name, summary, entry_ids, metrics, metadata)
  - \embeddings/entries.jsonl\ — one embedding object per line (entry_id, model, vector)
  - \metadata.json\ — format_version, exported_at, app version, embedding model/dimension, entry/theme counts
- Pure schema mappers \	oCCFEntry\ and \	oCCFTheme\ exported for use by downstream adapters
- **Modified** \src/main.js\ — new \export:ccf\ IPC handler (folder picker → exportCCF)
- **Modified** \src/frontend/preload.js\ — exposes \exportCCF()\ to renderer
- **New** \	ests/unit/export/ccf.test.js\ — 24 tests covering folder structure, all four files, CCF schema shape, empty corpus, and pure transform functions

## Test results

294 tests passing (24 new)

Closes #118