### PR TITLE
feat(ccf): CCF Diff Engine (#121)

### DIFF
--- a/src/backend/ccf/diff.js
+++ b/src/backend/ccf/diff.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * CCF Diff Engine
+ *
+ * Compares two CCF snapshot folders and produces a structured diff.
+ * Operates purely on snapshot files — no DB access.
+ *
+ * @see docs/architecture/07-canonical-corpus-format.md
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Read a .jsonl file and return an array of parsed objects.
+ * Empty or missing files return [].
+ */
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const lines = fs.readFileSync(filePath, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.map((line) => JSON.parse(line));
+}
+
+/**
+ * Read a .json file and return the parsed value.
+ * Returns the supplied default if the file is missing.
+ */
+function readJson(filePath, defaultValue = null) {
+  if (!fs.existsSync(filePath)) return defaultValue;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * Build a Map<id, entry> from an entries.jsonl array.
+ */
+function indexById(arr) {
+  const map = new Map();
+  for (const item of arr) {
+    if (item && item.id) map.set(item.id, item);
+  }
+  return map;
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Compare two CCF snapshot folders and return a structured diff.
+ *
+ * @param {string} oldSnapshotDir  Path to the older CCF snapshot folder.
+ * @param {string} newSnapshotDir  Path to the newer CCF snapshot folder.
+ * @returns {{
+ *   addedEntries:   object[],
+ *   updatedEntries: { id: string, before: object, after: object }[],
+ *   deletedEntries: { id: string, entry: object }[],
+ *   themeChanges:   {
+ *     id: string,
+ *     name: string,
+ *     status: 'added'|'removed'|'modified',
+ *     addedEntryIds:   string[],
+ *     removedEntryIds: string[],
+ *   }[],
+ * }}
+ */
+function diffCCF(oldSnapshotDir, newSnapshotDir) {
+  // ── load entries ──────────────────────────────────────────────────────────
+  const oldEntries = indexById(readJsonl(path.join(oldSnapshotDir, 'entries.jsonl')));
+  const newEntries = indexById(readJsonl(path.join(newSnapshotDir, 'entries.jsonl')));
+
+  // Added: present in new, absent in old
+  const addedEntries = [];
+  for (const [id, entry] of newEntries) {
+    if (!oldEntries.has(id)) addedEntries.push(entry);
+  }
+  // Sort for determinism
+  addedEntries.sort((a, b) => a.id.localeCompare(b.id));
+
+  // Updated: present in both, but updated_at has changed
+  const updatedEntries = [];
+  for (const [id, newEntry] of newEntries) {
+    const oldEntry = oldEntries.get(id);
+    if (oldEntry && oldEntry.updated_at !== newEntry.updated_at) {
+      updatedEntries.push({ id, before: oldEntry, after: newEntry });
+    }
+  }
+  updatedEntries.sort((a, b) => a.id.localeCompare(b.id));
+
+  // Deleted: present in old, absent in new
+  const deletedEntries = [];
+  for (const [id, entry] of oldEntries) {
+    if (!newEntries.has(id)) deletedEntries.push({ id, entry });
+  }
+  deletedEntries.sort((a, b) => a.id.localeCompare(b.id));
+
+  // ── load themes ───────────────────────────────────────────────────────────
+  const oldThemes = readJson(path.join(oldSnapshotDir, 'themes.json'), []);
+  const newThemes = readJson(path.join(newSnapshotDir, 'themes.json'), []);
+
+  const oldThemeMap = indexById(oldThemes);
+  const newThemeMap = indexById(newThemes);
+
+  const themeChanges = [];
+
+  // Added themes
+  for (const [id, theme] of newThemeMap) {
+    if (!oldThemeMap.has(id)) {
+      themeChanges.push({
+        id,
+        name: theme.name,
+        status: 'added',
+        addedEntryIds:   (theme.entry_ids || []).slice().sort(),
+        removedEntryIds: [],
+      });
+    }
+  }
+
+  // Removed themes
+  for (const [id, theme] of oldThemeMap) {
+    if (!newThemeMap.has(id)) {
+      themeChanges.push({
+        id,
+        name: theme.name,
+        status: 'removed',
+        addedEntryIds:   [],
+        removedEntryIds: (theme.entry_ids || []).slice().sort(),
+      });
+    }
+  }
+
+  // Modified themes — same ID, check membership
+  for (const [id, newTheme] of newThemeMap) {
+    const oldTheme = oldThemeMap.get(id);
+    if (!oldTheme) continue;
+
+    const oldIds = new Set(oldTheme.entry_ids || []);
+    const newIds = new Set(newTheme.entry_ids || []);
+
+    const addedEntryIds   = [...newIds].filter((eid) => !oldIds.has(eid)).sort();
+    const removedEntryIds = [...oldIds].filter((eid) => !newIds.has(eid)).sort();
+
+    if (addedEntryIds.length > 0 || removedEntryIds.length > 0) {
+      themeChanges.push({
+        id,
+        name:   newTheme.name,
+        status: 'modified',
+        addedEntryIds,
+        removedEntryIds,
+      });
+    }
+  }
+
+  themeChanges.sort((a, b) => a.id.localeCompare(b.id));
+
+  return { addedEntries, updatedEntries, deletedEntries, themeChanges };
+}
+
+module.exports = { diffCCF };

--- a/tests/unit/ccf/diff.test.js
+++ b/tests/unit/ccf/diff.test.js
@@ -1,0 +1,246 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+const { diffCCF } = require('../../../src/backend/ccf/diff');
+
+// ── snapshot fixture builder ──────────────────────────────────────────────────
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-ccf-diff-'));
+});
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeSnapshot(name, { entries = [], themes = [] } = {}) {
+  const dir = path.join(tmpDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'entries.jsonl'),
+    entries.map((e) => JSON.stringify(e)).join('\n'), 'utf8');
+  fs.writeFileSync(path.join(dir, 'themes.json'),
+    JSON.stringify(themes, null, 2), 'utf8');
+  return dir;
+}
+
+function entry(id, updatedAt = '2026-01-01T00:00:00Z', extra = {}) {
+  return { id, created_at: '2026-01-01T00:00:00Z', updated_at: updatedAt, text: `Entry ${id}`, tags: [], theme_ids: [], media_refs: [], metadata: {}, ...extra };
+}
+
+function theme(id, entryIds = [], extra = {}) {
+  return { id, name: `Theme ${id}`, summary: '', entry_ids: entryIds, metrics: {}, metadata: {}, ...extra };
+}
+
+// ── identical snapshots ───────────────────────────────────────────────────────
+
+describe('identical snapshots', () => {
+  test('returns empty diff for two identical snapshots', () => {
+    const entries = [entry('e1'), entry('e2')];
+    const themes  = [theme('t1', ['e1', 'e2'])];
+    const old = makeSnapshot('old', { entries, themes });
+    const nw  = makeSnapshot('new', { entries, themes });
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries).toHaveLength(0);
+    expect(diff.updatedEntries).toHaveLength(0);
+    expect(diff.deletedEntries).toHaveLength(0);
+    expect(diff.themeChanges).toHaveLength(0);
+  });
+});
+
+// ── addedEntries ─────────────────────────────────────────────────────────────
+
+describe('addedEntries', () => {
+  test('detects entries present in new but absent in old', () => {
+    const old = makeSnapshot('old', { entries: [entry('e1')] });
+    const nw  = makeSnapshot('new', { entries: [entry('e1'), entry('e2'), entry('e3')] });
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries.map((e) => e.id).sort()).toEqual(['e2', 'e3']);
+  });
+
+  test('addedEntries are sorted by id for determinism', () => {
+    const old = makeSnapshot('old', { entries: [] });
+    const nw  = makeSnapshot('new', { entries: [entry('e3'), entry('e1'), entry('e2')] });
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries.map((e) => e.id)).toEqual(['e1', 'e2', 'e3']);
+  });
+
+  test('addedEntries contains the full entry object', () => {
+    const old = makeSnapshot('old', { entries: [] });
+    const nw  = makeSnapshot('new', { entries: [entry('e1', '2026-03-01T00:00:00Z', { text: 'hello' })] });
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries[0].text).toBe('hello');
+  });
+});
+
+// ── updatedEntries ────────────────────────────────────────────────────────────
+
+describe('updatedEntries', () => {
+  test('detects entries with changed updated_at', () => {
+    const old = makeSnapshot('old', { entries: [entry('e1', '2026-01-01T00:00:00Z')] });
+    const nw  = makeSnapshot('new', { entries: [entry('e1', '2026-06-01T00:00:00Z')] });
+    const diff = diffCCF(old, nw);
+    expect(diff.updatedEntries).toHaveLength(1);
+    expect(diff.updatedEntries[0].id).toBe('e1');
+  });
+
+  test('updatedEntries contains before and after', () => {
+    const oldEntry = entry('e1', '2026-01-01T00:00:00Z', { text: 'old text' });
+    const newEntry = entry('e1', '2026-06-01T00:00:00Z', { text: 'new text' });
+    const old = makeSnapshot('old', { entries: [oldEntry] });
+    const nw  = makeSnapshot('new', { entries: [newEntry] });
+    const diff = diffCCF(old, nw);
+    expect(diff.updatedEntries[0].before.text).toBe('old text');
+    expect(diff.updatedEntries[0].after.text).toBe('new text');
+  });
+
+  test('does not flag entries with identical updated_at as updated', () => {
+    const e = entry('e1', '2026-01-01T00:00:00Z');
+    const old = makeSnapshot('old', { entries: [e] });
+    const nw  = makeSnapshot('new', { entries: [e] });
+    const diff = diffCCF(old, nw);
+    expect(diff.updatedEntries).toHaveLength(0);
+  });
+
+  test('updatedEntries are sorted by id for determinism', () => {
+    const old = makeSnapshot('old', { entries: [entry('ec', '2026-01-01T00:00:00Z'), entry('ea', '2026-01-01T00:00:00Z')] });
+    const nw  = makeSnapshot('new', { entries: [entry('ec', '2026-06-01T00:00:00Z'), entry('ea', '2026-06-01T00:00:00Z')] });
+    const diff = diffCCF(old, nw);
+    expect(diff.updatedEntries.map((u) => u.id)).toEqual(['ea', 'ec']);
+  });
+});
+
+// ── deletedEntries ────────────────────────────────────────────────────────────
+
+describe('deletedEntries', () => {
+  test('detects entries present in old but absent in new', () => {
+    const old = makeSnapshot('old', { entries: [entry('e1'), entry('e2')] });
+    const nw  = makeSnapshot('new', { entries: [entry('e1')] });
+    const diff = diffCCF(old, nw);
+    expect(diff.deletedEntries).toHaveLength(1);
+    expect(diff.deletedEntries[0].id).toBe('e2');
+  });
+
+  test('deletedEntries contains the original entry object', () => {
+    const old = makeSnapshot('old', { entries: [entry('e1', '2026-01-01T00:00:00Z', { text: 'gone' })] });
+    const nw  = makeSnapshot('new', { entries: [] });
+    const diff = diffCCF(old, nw);
+    expect(diff.deletedEntries[0].entry.text).toBe('gone');
+  });
+
+  test('deletedEntries are sorted by id for determinism', () => {
+    const old = makeSnapshot('old', { entries: [entry('ez'), entry('ea'), entry('em')] });
+    const nw  = makeSnapshot('new', { entries: [] });
+    const diff = diffCCF(old, nw);
+    expect(diff.deletedEntries.map((d) => d.id)).toEqual(['ea', 'em', 'ez']);
+  });
+});
+
+// ── themeChanges — added ──────────────────────────────────────────────────────
+
+describe('themeChanges — added themes', () => {
+  test('detects themes present in new but absent in old', () => {
+    const old = makeSnapshot('old', { themes: [] });
+    const nw  = makeSnapshot('new', { themes: [theme('t1', ['e1'])] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges).toHaveLength(1);
+    expect(diff.themeChanges[0].status).toBe('added');
+    expect(diff.themeChanges[0].id).toBe('t1');
+  });
+
+  test('added theme includes all its entry IDs as addedEntryIds', () => {
+    const old = makeSnapshot('old', { themes: [] });
+    const nw  = makeSnapshot('new', { themes: [theme('t1', ['e2', 'e1', 'e3'])] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges[0].addedEntryIds).toEqual(['e1', 'e2', 'e3']); // sorted
+    expect(diff.themeChanges[0].removedEntryIds).toEqual([]);
+  });
+});
+
+// ── themeChanges — removed ────────────────────────────────────────────────────
+
+describe('themeChanges — removed themes', () => {
+  test('detects themes present in old but absent in new', () => {
+    const old = makeSnapshot('old', { themes: [theme('t1', ['e1'])] });
+    const nw  = makeSnapshot('new', { themes: [] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges).toHaveLength(1);
+    expect(diff.themeChanges[0].status).toBe('removed');
+    expect(diff.themeChanges[0].id).toBe('t1');
+  });
+
+  test('removed theme includes all its entry IDs as removedEntryIds', () => {
+    const old = makeSnapshot('old', { themes: [theme('t1', ['e2', 'e1'])] });
+    const nw  = makeSnapshot('new', { themes: [] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges[0].removedEntryIds).toEqual(['e1', 'e2']);
+    expect(diff.themeChanges[0].addedEntryIds).toEqual([]);
+  });
+});
+
+// ── themeChanges — modified ───────────────────────────────────────────────────
+
+describe('themeChanges — modified themes', () => {
+  test('detects membership changes in an existing theme', () => {
+    const old = makeSnapshot('old', { themes: [theme('t1', ['e1', 'e2'])] });
+    const nw  = makeSnapshot('new', { themes: [theme('t1', ['e1', 'e3'])] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges).toHaveLength(1);
+    expect(diff.themeChanges[0].status).toBe('modified');
+    expect(diff.themeChanges[0].addedEntryIds).toEqual(['e3']);
+    expect(diff.themeChanges[0].removedEntryIds).toEqual(['e2']);
+  });
+
+  test('does not flag theme as modified when membership is identical', () => {
+    const t = theme('t1', ['e1', 'e2']);
+    const old = makeSnapshot('old', { themes: [t] });
+    const nw  = makeSnapshot('new', { themes: [t] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges).toHaveLength(0);
+  });
+
+  test('themeChanges are sorted by id for determinism', () => {
+    const old = makeSnapshot('old', { themes: [theme('tc', ['e1']), theme('ta', ['e1'])] });
+    const nw  = makeSnapshot('new', { themes: [theme('tc', ['e1', 'e2']), theme('ta', ['e1', 'e2'])] });
+    const diff = diffCCF(old, nw);
+    expect(diff.themeChanges.map((c) => c.id)).toEqual(['ta', 'tc']);
+  });
+});
+
+// ── edge cases ────────────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  test('handles empty old and new snapshots', () => {
+    const old = makeSnapshot('old');
+    const nw  = makeSnapshot('new');
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries).toHaveLength(0);
+    expect(diff.updatedEntries).toHaveLength(0);
+    expect(diff.deletedEntries).toHaveLength(0);
+    expect(diff.themeChanges).toHaveLength(0);
+  });
+
+  test('handles missing themes.json gracefully', () => {
+    const old = makeSnapshot('old', { entries: [entry('e1')] });
+    const nw  = makeSnapshot('new', { entries: [entry('e1'), entry('e2')] });
+    // Remove themes.json from both
+    fs.unlinkSync(path.join(old, 'themes.json'));
+    fs.unlinkSync(path.join(nw, 'themes.json'));
+    expect(() => diffCCF(old, nw)).not.toThrow();
+  });
+
+  test('correctly handles large symmetric diff', () => {
+    const oldEntries = Array.from({ length: 50 }, (_, i) => entry(`e${String(i).padStart(3, '0')}`));
+    const newEntries = Array.from({ length: 50 }, (_, i) => entry(`e${String(i + 50).padStart(3, '0')}`));
+    const old = makeSnapshot('old', { entries: oldEntries });
+    const nw  = makeSnapshot('new', { entries: newEntries });
+    const diff = diffCCF(old, nw);
+    expect(diff.addedEntries).toHaveLength(50);
+    expect(diff.deletedEntries).toHaveLength(50);
+    expect(diff.updatedEntries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the CCF Diff Engine, enabling structured comparison of two CCF snapshots. Required by #55 (scheduled exports) and future sync functionality.

## Changes

### `src/backend/ccf/diff.js` (new)
- `diffCCF(oldSnapshotDir, newSnapshotDir)` — pure function, no DB access
- **addedEntries**: entries in new but absent in old (full entry objects)
- **updatedEntries**: entries in both snapshots but with changed `updated_at` (`{ id, before, after }`)
- **deletedEntries**: entries in old but absent in new (`{ id, entry }`)
- **themeChanges**: per-theme status (`added` / `removed` / `modified`) with `addedEntryIds` and `removedEntryIds`
- All arrays sorted by ID for deterministic output
- Missing `themes.json` handled gracefully (defaults to empty array)

### `tests/unit/ccf/diff.test.js` (new, 21 tests)
- Identical snapshots → empty diff
- addedEntries: detection, ordering, full object preservation
- updatedEntries: changed `updated_at`, before/after contents, no false positives, ordering
- deletedEntries: detection, entry object preserved, ordering
- themeChanges — added: detection, `addedEntryIds` populated
- themeChanges — removed: detection, `removedEntryIds` populated
- themeChanges — modified: membership delta, no false positives, ordering
- Edge cases: empty snapshots, missing themes.json, large symmetric diff (50 added / 50 deleted)

## Test results

```
Tests: 357 passed, 357 total (+21 new)
```

Closes #121
