### PR TITLE
feat(export): CCF Scheduled Export scheduler (#55)

### DIFF
--- a/src/backend/export/scheduler/index.js
+++ b/src/backend/export/scheduler/index.js
@@ -1,0 +1,225 @@
+'use strict';
+
+/**
+ * CCF Scheduled Export Scheduler
+ *
+ * Runs periodic CCF snapshots in the background.
+ * Each run:
+ *   1. Calls exportCCF() to produce a full snapshot in a timestamped sub-folder.
+ *   2. Optionally computes a diff against the previous snapshot and writes diff.json.
+ *   3. Appends a record to the export history log.
+ *
+ * The scheduler is driven by setInterval and respects the configured frequency
+ * (daily / weekly).  It never blocks the UI.
+ *
+ * Public API
+ * ----------
+ *   startScheduler()        — start ticking (idempotent)
+ *   stopScheduler()         — stop ticking
+ *   runScheduledExport()    — trigger one export run immediately
+ *   getExportHistory()      — return the last N history records
+ *   getSchedulerStatus()    — { enabled, frequency, destDir, includeDiff, lastRun, nextRun }
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+const { exportCCF }  = require('../ccf');
+const { diffCCF }    = require('../../ccf/diff');
+const { getSettings, saveSettings } = require('../../settings');
+const config = require('../../../config');
+
+// ── constants ─────────────────────────────────────────────────────────────────
+
+const HISTORY_FILE    = path.join(path.dirname(config.settings.path), 'scheduled-export-history.json');
+const MAX_HISTORY     = 100;
+const TICK_MS         = 60 * 1000; // check once per minute
+
+// ── module state ──────────────────────────────────────────────────────────────
+
+let _timer = null;
+
+// ── history helpers ───────────────────────────────────────────────────────────
+
+function _readHistory() {
+  try {
+    return JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function _appendHistory(record) {
+  const history = _readHistory();
+  history.push(record);
+  // Keep only the most recent MAX_HISTORY entries
+  const trimmed = history.slice(-MAX_HISTORY);
+  fs.mkdirSync(path.dirname(HISTORY_FILE), { recursive: true });
+  fs.writeFileSync(HISTORY_FILE, JSON.stringify(trimmed, null, 2), 'utf8');
+}
+
+// ── scheduling helpers ────────────────────────────────────────────────────────
+
+/**
+ * Returns the number of milliseconds between scheduled runs for the given frequency.
+ */
+function _frequencyMs(frequency) {
+  if (frequency === 'weekly') return 7 * 24 * 60 * 60 * 1000;
+  return 24 * 60 * 60 * 1000; // default: daily
+}
+
+/**
+ * Returns true if a run is due given the last run timestamp and frequency.
+ */
+function _isDue(lastRunIso, frequency) {
+  if (!lastRunIso) return true;
+  const elapsed = Date.now() - new Date(lastRunIso).getTime();
+  return elapsed >= _frequencyMs(frequency);
+}
+
+/**
+ * Build a timestamped snapshot folder name, e.g. "2026-01-15T14-30-00-123Z"
+ */
+function _snapshotFolderName(now = new Date()) {
+  return now.toISOString().replace(/:/g, '-').replace('.', '-').replace('Z', 'Z');
+}
+
+// ── core export run ───────────────────────────────────────────────────────────
+
+/**
+ * Perform one scheduled export run.
+ * @param {object} [opts]
+ * @param {string}  opts.destDir     Destination root folder.
+ * @param {boolean} opts.includeDiff Whether to write diff.json.
+ * @returns {Promise<{ ok: boolean, snapshotDir: string, diffWritten: boolean, error?: string }>}
+ */
+async function runScheduledExport({ destDir, includeDiff } = {}) {
+  const settings = getSettings();
+  const resolvedDestDir   = destDir     ?? settings.scheduledExport?.destDir;
+  const resolvedDiff      = includeDiff ?? settings.scheduledExport?.includeDiff ?? false;
+
+  if (!resolvedDestDir) {
+    return { ok: false, snapshotDir: null, diffWritten: false, error: 'No destination folder configured' };
+  }
+
+  const snapshotName = _snapshotFolderName();
+  const snapshotDir  = path.join(resolvedDestDir, snapshotName);
+
+  try {
+    // ── 1. Full CCF export ────────────────────────────────────────────────
+    await exportCCF(snapshotDir);
+
+    // ── 2. Optional diff against previous snapshot ────────────────────────
+    let diffWritten = false;
+    if (resolvedDiff) {
+      const prevDir = _findPreviousSnapshot(resolvedDestDir, snapshotName);
+      if (prevDir) {
+        const diff = diffCCF(prevDir, snapshotDir);
+        fs.writeFileSync(
+          path.join(snapshotDir, 'diff.json'),
+          JSON.stringify(diff, null, 2),
+          'utf8',
+        );
+        diffWritten = true;
+      }
+    }
+
+    // ── 3. Record history ─────────────────────────────────────────────────
+    const record = {
+      runAt:       new Date().toISOString(),
+      snapshotDir,
+      diffWritten,
+      ok: true,
+    };
+    _appendHistory(record);
+
+    // ── 4. Persist lastRun in settings ────────────────────────────────────
+    saveSettings({
+      scheduledExport: {
+        ...(settings.scheduledExport || {}),
+        lastRun: record.runAt,
+      },
+    });
+
+    return { ok: true, snapshotDir, diffWritten };
+  } catch (err) {
+    const error = err && err.message ? err.message : String(err);
+    _appendHistory({ runAt: new Date().toISOString(), snapshotDir, diffWritten: false, ok: false, error });
+    return { ok: false, snapshotDir, diffWritten: false, error };
+  }
+}
+
+/**
+ * Find the most recent previous snapshot folder in destDir (excluding the
+ * just-created one identified by currentName).
+ * Returns the full path, or null if none found.
+ */
+function _findPreviousSnapshot(destDir, currentName) {
+  if (!fs.existsSync(destDir)) return null;
+  const siblings = fs.readdirSync(destDir)
+    .filter((name) => name !== currentName && fs.statSync(path.join(destDir, name)).isDirectory())
+    .sort(); // ISO timestamp names sort lexicographically = chronologically
+  if (siblings.length === 0) return null;
+  return path.join(destDir, siblings[siblings.length - 1]);
+}
+
+// ── scheduler tick ────────────────────────────────────────────────────────────
+
+async function _tick() {
+  const settings = getSettings();
+  const cfg = settings.scheduledExport;
+  if (!cfg || !cfg.enabled || !cfg.destDir) return;
+  if (!_isDue(cfg.lastRun, cfg.frequency)) return;
+  await runScheduledExport({ destDir: cfg.destDir, includeDiff: cfg.includeDiff });
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+function startScheduler() {
+  if (_timer) return; // idempotent
+  _timer = setInterval(_tick, TICK_MS);
+  // Unref so the timer doesn't prevent the Node process from exiting in tests
+  if (_timer.unref) _timer.unref();
+}
+
+function stopScheduler() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+function getExportHistory(limit = MAX_HISTORY) {
+  const history = _readHistory();
+  return history.slice(-limit);
+}
+
+function getSchedulerStatus() {
+  const settings = getSettings();
+  const cfg = settings.scheduledExport || {};
+  const lastRun = cfg.lastRun || null;
+  let nextRun = null;
+  if (cfg.enabled && cfg.destDir && lastRun) {
+    nextRun = new Date(new Date(lastRun).getTime() + _frequencyMs(cfg.frequency || 'daily')).toISOString();
+  }
+  return {
+    enabled:     cfg.enabled     ?? false,
+    frequency:   cfg.frequency   ?? 'daily',
+    destDir:     cfg.destDir     ?? null,
+    includeDiff: cfg.includeDiff ?? false,
+    lastRun,
+    nextRun,
+  };
+}
+
+module.exports = {
+  startScheduler,
+  stopScheduler,
+  runScheduledExport,
+  getExportHistory,
+  getSchedulerStatus,
+  // exported for testing
+  _isDue,
+  _snapshotFolderName,
+  _findPreviousSnapshot,
+};

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -30,6 +30,13 @@ const DEFAULTS = {
   },
   signalsEnabled: true,   // enable LLM entry signal classification (Pass 3)
   theme: 'dark',          // 'dark' | 'light'
+  scheduledExport: {
+    enabled:     false,
+    frequency:   'daily',   // 'daily' | 'weekly'
+    destDir:     null,      // absolute path chosen by user
+    includeDiff: false,
+    lastRun:     null,
+  },
 };
 
 /**

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -42,6 +42,12 @@ contextBridge.exposeInMainWorld('neurologue', {
   exportCCF:  ()    => ipcRenderer.invoke('export:ccf'),
   importCCF:  ()    => ipcRenderer.invoke('import:ccf'),
 
+  // ── Scheduled Export ──────────────────────────────────────────────────────
+  schedulerStatus:     ()       => ipcRenderer.invoke('scheduler:status'),
+  schedulerHistory:    (limit)  => ipcRenderer.invoke('scheduler:history', { limit }),
+  schedulerRunNow:     ()       => ipcRenderer.invoke('scheduler:run-now'),
+  schedulerSaveConfig: (config) => ipcRenderer.invoke('scheduler:save-config', config),
+
   // ── Help ─────────────────────────────────────────────────────────────────
   openHelp: () => ipcRenderer.invoke('help:open'),
 

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { exportCCF }  = require('./backend/export/ccf');
 const { importCCF }  = require('./backend/import/ccf-import');
+const { startScheduler, stopScheduler, runScheduledExport, getExportHistory, getSchedulerStatus } = require('./backend/export/scheduler/index');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
 const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
@@ -452,12 +453,33 @@ handle('import:ccf', async () => {
   return { canceled: false, ...result };
 });
 
+// ── Scheduled Export IPC ─────────────────────────────────────────────────────
+
+handle('scheduler:status', async () => getSchedulerStatus());
+
+handle('scheduler:history', async (_event, { limit = 20 } = {}) => getExportHistory(limit));
+
+handle('scheduler:run-now', async () => {
+  const result = await runScheduledExport();
+  return result;
+});
+
+handle('scheduler:save-config', async (_event, updates) => {
+  const { saveSettings } = require('./backend/settings');
+  saveSettings({ scheduledExport: updates });
+  // Restart scheduler so new settings take effect immediately
+  stopScheduler();
+  startScheduler();
+  return getSchedulerStatus();
+});
+
 app.whenReady().then(async () => {
   await initialise();
   createMainWindow();
   const { captureHotkey } = getSettings();
   registerCaptureHotkey(captureHotkey);
   startWorker();
+  startScheduler();
   // Wire the worker to push IPC events to the library window once it is ready
   _mainWindow.webContents.on('did-finish-load', () => {
     setMainWindow(_mainWindow.webContents);

--- a/tests/unit/export/scheduler.test.js
+++ b/tests/unit/export/scheduler.test.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neurologue-scheduler-'));
+  process.env.NEUROLOGUE_DATA_PATH = tmpDir;
+  jest.resetModules();
+  const { runMigrations } = require('../../../src/db/migrate');
+  await runMigrations();
+});
+
+afterEach(() => {
+  try {
+    const { stopScheduler } = require('../../../src/backend/export/scheduler/index');
+    stopScheduler();
+  } catch { /* not loaded */ }
+  try {
+    const { closeDb } = require('../../../src/backend/db/connection');
+    closeDb();
+  } catch { /* not loaded */ }
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.NEUROLOGUE_DATA_PATH;
+});
+
+// ── _isDue ────────────────────────────────────────────────────────────────────
+
+describe('_isDue', () => {
+  test('returns true when lastRun is null', () => {
+    const { _isDue } = require('../../../src/backend/export/scheduler/index');
+    expect(_isDue(null, 'daily')).toBe(true);
+  });
+
+  test('returns false when last run was less than 24h ago (daily)', () => {
+    const { _isDue } = require('../../../src/backend/export/scheduler/index');
+    const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+    expect(_isDue(recent, 'daily')).toBe(false);
+  });
+
+  test('returns true when last run was more than 24h ago (daily)', () => {
+    const { _isDue } = require('../../../src/backend/export/scheduler/index');
+    const old = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25h ago
+    expect(_isDue(old, 'daily')).toBe(true);
+  });
+
+  test('returns false when last run was less than 7 days ago (weekly)', () => {
+    const { _isDue } = require('../../../src/backend/export/scheduler/index');
+    const recent = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString(); // 6d ago
+    expect(_isDue(recent, 'weekly')).toBe(false);
+  });
+
+  test('returns true when last run was more than 7 days ago (weekly)', () => {
+    const { _isDue } = require('../../../src/backend/export/scheduler/index');
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(); // 8d ago
+    expect(_isDue(old, 'weekly')).toBe(true);
+  });
+});
+
+// ── _snapshotFolderName ───────────────────────────────────────────────────────
+
+describe('_snapshotFolderName', () => {
+  test('returns a string without colons', () => {
+    const { _snapshotFolderName } = require('../../../src/backend/export/scheduler/index');
+    const name = _snapshotFolderName(new Date('2026-01-15T14:30:00.000Z'));
+    expect(name).not.toContain(':');
+  });
+
+  test('produces a valid directory name', () => {
+    const { _snapshotFolderName } = require('../../../src/backend/export/scheduler/index');
+    const name = _snapshotFolderName(new Date('2026-01-15T14:30:00.123Z'));
+    expect(name).toBe('2026-01-15T14-30-00-123Z');
+  });
+
+  test('is deterministic for same input', () => {
+    const { _snapshotFolderName } = require('../../../src/backend/export/scheduler/index');
+    const d = new Date('2026-06-01T09:00:00.000Z');
+    expect(_snapshotFolderName(d)).toBe(_snapshotFolderName(d));
+  });
+});
+
+// ── _findPreviousSnapshot ─────────────────────────────────────────────────────
+
+describe('_findPreviousSnapshot', () => {
+  test('returns null when destDir is empty', () => {
+    const { _findPreviousSnapshot } = require('../../../src/backend/export/scheduler/index');
+    const dir = path.join(tmpDir, 'snapshots');
+    fs.mkdirSync(dir);
+    expect(_findPreviousSnapshot(dir, '2026-01-15T14-30-00Z')).toBeNull();
+  });
+
+  test('returns null when destDir does not exist', () => {
+    const { _findPreviousSnapshot } = require('../../../src/backend/export/scheduler/index');
+    expect(_findPreviousSnapshot(path.join(tmpDir, 'nonexistent'), 'current')).toBeNull();
+  });
+
+  test('returns the most recent sibling snapshot folder', () => {
+    const { _findPreviousSnapshot } = require('../../../src/backend/export/scheduler/index');
+    const dir = path.join(tmpDir, 'snapshots');
+    fs.mkdirSync(path.join(dir, '2026-01-10T12-00-00Z'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '2026-01-12T08-00-00Z'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '2026-01-14T16-00-00Z'), { recursive: true });
+    const prev = _findPreviousSnapshot(dir, '2026-01-15T10-00-00Z');
+    expect(prev).toBe(path.join(dir, '2026-01-14T16-00-00Z'));
+  });
+
+  test('excludes the current snapshot from consideration', () => {
+    const { _findPreviousSnapshot } = require('../../../src/backend/export/scheduler/index');
+    const dir = path.join(tmpDir, 'snapshots');
+    const current = '2026-01-15T10-00-00Z';
+    fs.mkdirSync(path.join(dir, current), { recursive: true });
+    const prev = _findPreviousSnapshot(dir, current);
+    expect(prev).toBeNull();
+  });
+});
+
+// ── getSchedulerStatus ────────────────────────────────────────────────────────
+
+describe('getSchedulerStatus', () => {
+  test('returns defaults when no settings have been saved', () => {
+    const { getSchedulerStatus } = require('../../../src/backend/export/scheduler/index');
+    const status = getSchedulerStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.frequency).toBe('daily');
+    expect(status.destDir).toBeNull();
+    expect(status.includeDiff).toBe(false);
+    expect(status.lastRun).toBeNull();
+    expect(status.nextRun).toBeNull();
+  });
+
+  test('computes nextRun when enabled with a lastRun', () => {
+    const { getSchedulerStatus } = require('../../../src/backend/export/scheduler/index');
+    const { saveSettings }       = require('../../../src/backend/settings');
+    const lastRun = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2h ago
+    saveSettings({ scheduledExport: { enabled: true, frequency: 'daily', destDir: tmpDir, includeDiff: false, lastRun } });
+    jest.resetModules();
+    const { getSchedulerStatus: getStatus2 } = require('../../../src/backend/export/scheduler/index');
+    const status = getStatus2();
+    expect(status.nextRun).not.toBeNull();
+    expect(new Date(status.nextRun).getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+// ── runScheduledExport ────────────────────────────────────────────────────────
+
+describe('runScheduledExport', () => {
+  test('returns ok:false when no destDir configured', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const result = await runScheduledExport();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/destination/i);
+  });
+
+  test('creates a timestamped snapshot folder', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    const result = await runScheduledExport({ destDir, includeDiff: false });
+    expect(result.ok).toBe(true);
+    expect(fs.existsSync(result.snapshotDir)).toBe(true);
+    // Snapshot folder must be inside destDir
+    expect(result.snapshotDir.startsWith(destDir)).toBe(true);
+  });
+
+  test('snapshot folder contains required CCF files', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    const { ok, snapshotDir } = await runScheduledExport({ destDir, includeDiff: false });
+    expect(ok).toBe(true);
+    expect(fs.existsSync(path.join(snapshotDir, 'entries.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(snapshotDir, 'themes.json'))).toBe(true);
+    expect(fs.existsSync(path.join(snapshotDir, 'metadata.json'))).toBe(true);
+  });
+
+  test('records run in history', async () => {
+    const { runScheduledExport, getExportHistory } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: false });
+    const history = getExportHistory();
+    expect(history.length).toBe(1);
+    expect(history[0].ok).toBe(true);
+  });
+
+  test('updates lastRun in settings', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const { getSettings }        = require('../../../src/backend/settings');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: false });
+    const settings = getSettings();
+    expect(settings.scheduledExport.lastRun).not.toBeNull();
+  });
+
+  test('writes diff.json when includeDiff is true and a previous snapshot exists', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+
+    // First run — no previous snapshot, so no diff
+    const first = await runScheduledExport({ destDir, includeDiff: true });
+    expect(first.ok).toBe(true);
+    expect(first.diffWritten).toBe(false); // nothing to diff against
+
+    // Second run — should diff against the first
+    const second = await runScheduledExport({ destDir, includeDiff: true });
+    expect(second.ok).toBe(true);
+    expect(second.diffWritten).toBe(true);
+    expect(fs.existsSync(path.join(second.snapshotDir, 'diff.json'))).toBe(true);
+  });
+
+  test('diff.json contains expected keys', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: true });
+    const second = await runScheduledExport({ destDir, includeDiff: true });
+    const diff = JSON.parse(fs.readFileSync(path.join(second.snapshotDir, 'diff.json'), 'utf8'));
+    expect(diff).toHaveProperty('addedEntries');
+    expect(diff).toHaveProperty('updatedEntries');
+    expect(diff).toHaveProperty('deletedEntries');
+    expect(diff).toHaveProperty('themeChanges');
+  });
+
+  test('does not write diff.json when includeDiff is false', async () => {
+    const { runScheduledExport } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: false }); // first
+    const second = await runScheduledExport({ destDir, includeDiff: false });
+    expect(second.diffWritten).toBe(false);
+    expect(fs.existsSync(path.join(second.snapshotDir, 'diff.json'))).toBe(false);
+  });
+});
+
+// ── getExportHistory ──────────────────────────────────────────────────────────
+
+describe('getExportHistory', () => {
+  test('returns empty array before any runs', () => {
+    const { getExportHistory } = require('../../../src/backend/export/scheduler/index');
+    expect(getExportHistory()).toEqual([]);
+  });
+
+  test('respects limit parameter', async () => {
+    const { runScheduledExport, getExportHistory } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: false });
+    await runScheduledExport({ destDir, includeDiff: false });
+    await runScheduledExport({ destDir, includeDiff: false });
+    expect(getExportHistory(2).length).toBe(2);
+  });
+
+  test('most recent records are last in the array', async () => {
+    const { runScheduledExport, getExportHistory } = require('../../../src/backend/export/scheduler/index');
+    const destDir = path.join(tmpDir, 'exports');
+    await runScheduledExport({ destDir, includeDiff: false });
+    await runScheduledExport({ destDir, includeDiff: false });
+    const history = getExportHistory();
+    expect(new Date(history[0].runAt).getTime())
+      .toBeLessThanOrEqual(new Date(history[1].runAt).getTime());
+  });
+});
+
+// ── startScheduler / stopScheduler ───────────────────────────────────────────
+
+describe('startScheduler / stopScheduler', () => {
+  test('startScheduler is idempotent', () => {
+    const { startScheduler, stopScheduler } = require('../../../src/backend/export/scheduler/index');
+    expect(() => {
+      startScheduler();
+      startScheduler(); // second call must not throw
+      stopScheduler();
+    }).not.toThrow();
+  });
+
+  test('stopScheduler is safe when scheduler was never started', () => {
+    const { stopScheduler } = require('../../../src/backend/export/scheduler/index');
+    expect(() => stopScheduler()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements CCF Scheduled Exports — automatic periodic corpus snapshots running in the background, with optional diffs. Depends on #118 (Export Engine) and #121 (Diff Engine), both merged.

## Changes

### `src/backend/export/scheduler/index.js` (new)
- `startScheduler()` / `stopScheduler()` — idempotent interval-driven scheduler (60s tick, `unref()`'d so it doesn't block process exit)
- `runScheduledExport({ destDir, includeDiff })` — one export run:
  1. Calls `exportCCF()` into a ms-precision timestamped sub-folder (e.g. `2026-01-15T14-30-00-123Z`)
  2. Optionally computes `diffCCF(prevSnapshot, newSnapshot)` and writes `diff.json`
  3. Appends to `scheduled-export-history.json` (capped at 100 entries)
  4. Updates `settings.scheduledExport.lastRun`
- `getExportHistory(limit)` — returns last N history records
- `getSchedulerStatus()` — `{ enabled, frequency, destDir, includeDiff, lastRun, nextRun }`
- `_isDue`, `_snapshotFolderName`, `_findPreviousSnapshot` exported for testing

### `src/backend/settings.js`
- Added `scheduledExport` defaults: `{ enabled: false, frequency: 'daily', destDir: null, includeDiff: false, lastRun: null }`

### `src/main.js`
- Added `require('./backend/export/scheduler/index')`
- `startScheduler()` called in `app.whenReady`
- Four IPC handlers: `scheduler:status`, `scheduler:history`, `scheduler:run-now`, `scheduler:save-config`

### `src/frontend/preload.js`
- Exposed `schedulerStatus`, `schedulerHistory`, `schedulerRunNow`, `schedulerSaveConfig`

### `tests/unit/export/scheduler.test.js` (new, 27 tests)
- `_isDue`: null lastRun, daily/weekly threshold logic
- `_snapshotFolderName`: no-colon format, determinism
- `_findPreviousSnapshot`: empty dir, missing dir, most-recent selection, excludes current
- `getSchedulerStatus`: defaults, nextRun computation
- `runScheduledExport`: no destDir, snapshot folder created, required CCF files present, history recorded, lastRun updated, diff.json written on second run, diff keys, no diff when disabled
- `getExportHistory`: empty initial, limit respected, ordering
- `startScheduler`/`stopScheduler`: idempotent start, safe stop

## Test results

```
Tests: 384 passed, 384 total (+27 new)
```

Closes #55
