### PR TITLE
feat(ui): Scheduled Export settings tab + fix tab bar clipping (#129)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -668,6 +668,7 @@
         <button class="settings-tab" data-tab="worker"     role="tab" aria-selected="false">Worker</button>
         <button class="settings-tab" data-tab="appearance" role="tab" aria-selected="false">Appearance</button>
         <button class="settings-tab" data-tab="data"       role="tab" aria-selected="false">Data</button>
+        <button class="settings-tab" data-tab="scheduled-export" role="tab" aria-selected="false">Scheduled Export</button>
       </div>
 
       <!-- Models panel -->
@@ -761,6 +762,50 @@
           <label>Reindex all entries</label>
           <button id="btn-reindex-all" class="btn-secondary">Reindex all entries…</button>
           <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
+        </div>
+      </div>
+
+      <!-- Scheduled Export panel -->
+      <div class="settings-panel hidden" id="settings-tab-scheduled-export">
+        <div class="settings-field">
+          <label>Enable scheduled exports</label>
+          <label class="toggle-label">
+            <input type="checkbox" id="sched-enabled" />
+            <span class="settings-hint">Automatically snapshot your corpus on a regular schedule.</span>
+          </label>
+        </div>
+        <div class="settings-field">
+          <label for="sched-frequency">Frequency</label>
+          <select id="sched-frequency">
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+          </select>
+        </div>
+        <div class="settings-field">
+          <label>Destination folder</label>
+          <div class="sched-folder-row">
+            <span id="sched-dest-display" class="sched-dest-display">Not set</span>
+            <button id="btn-sched-choose-folder" class="btn-secondary btn-sm">Choose folder…</button>
+          </div>
+          <span class="settings-hint">Each run creates a timestamped sub-folder here.</span>
+        </div>
+        <div class="settings-field">
+          <label class="toggle-label">
+            <input type="checkbox" id="sched-include-diff" />
+            Include diff.json (changes since last snapshot)
+          </label>
+        </div>
+        <div class="settings-field">
+          <label>Status</label>
+          <div id="sched-status-line" class="sched-status-line">—</div>
+        </div>
+        <div class="settings-field">
+          <label>Run now <button id="btn-sched-run-now" class="btn-secondary btn-sm" style="margin-left:8px">Export now</button></label>
+          <span id="sched-run-feedback" class="settings-hint"></span>
+        </div>
+        <div class="settings-field">
+          <label>Export history <button id="btn-sched-refresh-history" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
+          <div id="sched-history-panel" class="sched-history-panel"><span class="worker-log-empty">No exports recorded yet.</span></div>
         </div>
       </div>
 

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1763,6 +1763,7 @@ html, body {
 /* Tab bar */
 .settings-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 2px;
   border-bottom: 1px solid var(--border);
   margin: 12px 0 20px;
@@ -1828,6 +1829,61 @@ html, body {
 }
 .settings-saved          { font-size: 12px; color: var(--cortex-teal); }
 .settings-saved.hidden   { display: none; }
+
+/* ── Scheduled Export settings panel ──────────────────────────────────── */
+.sched-folder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sched-dest-display {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 8px;
+}
+.sched-status-line {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.sched-history-panel {
+  max-height: 180px;
+  overflow-y: auto;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+}
+.sched-history-row {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  gap: 6px;
+  align-items: center;
+  font-size: 11px;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.sched-history-row:last-child { border-bottom: none; }
+.sched-ok   { color: var(--cortex-teal); }
+.sched-fail { color: #e05c5c; }
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: normal;
+}
 
 /* ── Settings section headings ──────────────────────────────────────────── */
 .settings-section-heading {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1667,6 +1667,124 @@ document.querySelectorAll('.settings-tab').forEach((tab) => {
   }
 });
 
+// ── Scheduled Export settings ────────────────────────────────────────────────
+
+let _schedConfig = {};
+
+function _fmtSchedDate(iso) {
+  if (!iso) return 'Never';
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+async function loadSchedSettings() {
+  const status = await window.neurologue.schedulerStatus();
+  _schedConfig = { ...status };
+
+  document.getElementById('sched-enabled').checked       = status.enabled;
+  document.getElementById('sched-frequency').value       = status.frequency || 'daily';
+  document.getElementById('sched-include-diff').checked  = status.includeDiff;
+  document.getElementById('sched-dest-display').textContent = status.destDir || 'Not set';
+
+  const lastRun = _fmtSchedDate(status.lastRun);
+  const nextRun = status.enabled && status.nextRun ? _fmtSchedDate(status.nextRun) : 'Not scheduled';
+  document.getElementById('sched-status-line').textContent =
+    `Last run: ${lastRun}  ·  Next run: ${nextRun}`;
+
+  await renderSchedHistory();
+}
+
+async function renderSchedHistory() {
+  const panel = document.getElementById('sched-history-panel');
+  const records = await window.neurologue.schedulerHistory(20);
+  panel.innerHTML = '';
+  if (!records || records.length === 0) {
+    const empty = document.createElement('span');
+    empty.className = 'worker-log-empty';
+    empty.textContent = 'No exports recorded yet.';
+    panel.appendChild(empty);
+    return;
+  }
+  [...records].reverse().forEach((r) => {
+    const row = document.createElement('div');
+    row.className = 'sched-history-row';
+
+    const icon = document.createElement('span');
+    icon.className = r.ok ? 'sched-ok' : 'sched-fail';
+    icon.textContent = r.ok ? '✓' : '✗';
+    row.appendChild(icon);
+
+    const ts = document.createElement('span');
+    ts.textContent = _fmtSchedDate(r.runAt);
+    row.appendChild(ts);
+
+    const dir = document.createElement('span');
+    const name = r.snapshotDir ? r.snapshotDir.split(/[\\/]/).pop() : '—';
+    dir.textContent = name;
+    dir.title = r.snapshotDir || '';
+    row.appendChild(dir);
+
+    panel.appendChild(row);
+  });
+}
+
+async function _saveSchedConfig() {
+  const cfg = {
+    enabled:     document.getElementById('sched-enabled').checked,
+    frequency:   document.getElementById('sched-frequency').value,
+    destDir:     _schedConfig.destDir || null,
+    includeDiff: document.getElementById('sched-include-diff').checked,
+    lastRun:     _schedConfig.lastRun || null,
+  };
+  _schedConfig = { ..._schedConfig, ...cfg };
+  await window.neurologue.schedulerSaveConfig(cfg);
+}
+
+document.getElementById('sched-enabled').addEventListener('change', _saveSchedConfig);
+document.getElementById('sched-frequency').addEventListener('change', _saveSchedConfig);
+document.getElementById('sched-include-diff').addEventListener('change', _saveSchedConfig);
+
+document.getElementById('btn-sched-choose-folder').addEventListener('click', async () => {
+  const result = await window.neurologue.schedulerChooseFolder();
+  if (result.canceled) return;
+  _schedConfig.destDir = result.path;
+  document.getElementById('sched-dest-display').textContent = result.path;
+  await _saveSchedConfig();
+});
+
+document.getElementById('btn-sched-run-now').addEventListener('click', async () => {
+  const btn = document.getElementById('btn-sched-run-now');
+  const feedback = document.getElementById('sched-run-feedback');
+  btn.disabled = true;
+  btn.textContent = 'Running…';
+  feedback.textContent = '';
+  try {
+    const result = await window.neurologue.schedulerRunNow();
+    if (result.ok) {
+      feedback.textContent = `✓ Snapshot saved to ${result.snapshotDir.split(/[\\/]/).pop()}`;
+    } else {
+      feedback.textContent = `✗ ${result.error || 'Export failed'}`;
+    }
+    await loadSchedSettings();
+  } catch (err) {
+    feedback.textContent = `✗ ${err.message || 'Unexpected error'}`;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Export now';
+  }
+});
+
+document.getElementById('btn-sched-refresh-history').addEventListener('click', renderSchedHistory);
+
+// Load scheduled export settings when that tab is activated
+document.querySelectorAll('.settings-tab').forEach((tab) => {
+  if (tab.dataset.tab === 'scheduled-export') {
+    tab.addEventListener('click', loadSchedSettings);
+  }
+});
+
 // ── Tag Management modal ─────────────────────────────────────────────────────
 
 const tagMgmtModal    = document.getElementById('tag-management-modal');

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -46,7 +46,8 @@ contextBridge.exposeInMainWorld('neurologue', {
   schedulerStatus:     ()       => ipcRenderer.invoke('scheduler:status'),
   schedulerHistory:    (limit)  => ipcRenderer.invoke('scheduler:history', { limit }),
   schedulerRunNow:     ()       => ipcRenderer.invoke('scheduler:run-now'),
-  schedulerSaveConfig: (config) => ipcRenderer.invoke('scheduler:save-config', config),
+  schedulerSaveConfig:   (config) => ipcRenderer.invoke('scheduler:save-config', config),
+  schedulerChooseFolder: ()       => ipcRenderer.invoke('scheduler:choose-folder'),
 
   // ── Help ─────────────────────────────────────────────────────────────────
   openHelp: () => ipcRenderer.invoke('help:open'),

--- a/src/main.js
+++ b/src/main.js
@@ -473,6 +473,17 @@ handle('scheduler:save-config', async (_event, updates) => {
   return getSchedulerStatus();
 });
 
+handle('scheduler:choose-folder', async () => {
+  const { dialog } = require('electron');
+  const win = BrowserWindow.getFocusedWindow();
+  const { canceled, filePaths } = await dialog.showOpenDialog(win || undefined, {
+    title: 'Choose scheduled export destination folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (canceled || !filePaths || filePaths.length === 0) return { canceled: true };
+  return { canceled: false, path: filePaths[0] };
+});
+
 app.whenReady().then(async () => {
   await initialise();
   createMainWindow();


### PR DESCRIPTION
## Summary

Adds the Scheduled Export settings tab to the Settings modal, making the scheduler feature (#55) visible and configurable. Also fixes the tab bar clipping bug where the "Data" tab was being partially hidden.

## Changes

### `src/frontend/library.css`
- **Bug fix**: Added `flex-wrap: wrap` to `.settings-tabs` — tab bar now wraps onto a second row instead of clipping tabs at the right edge
- Added styles for the Scheduled Export panel: `.sched-folder-row`, `.sched-dest-display`, `.sched-status-line`, `.sched-history-panel`, `.sched-history-row`, `.sched-ok`, `.sched-fail`, `.toggle-label`

### `src/frontend/index.html`
- Added **"Scheduled Export"** tab button to the Settings modal tab bar
- Added Scheduled Export panel (`#settings-tab-scheduled-export`) containing:
  - Enable/disable toggle
  - Frequency selector (Daily / Weekly)
  - Destination folder row with "Choose folder…" button
  - Include diff checkbox
  - Status line (Last run / Next run)
  - Run Now button with feedback
  - Export history panel with Refresh button

### `src/frontend/library.js`
- `loadSchedSettings()` — populates all fields from `schedulerStatus()` IPC
- `renderSchedHistory()` — renders last 20 history records (newest first) with ✓/✗ icons
- `_saveSchedConfig()` — saves config via `schedulerSaveConfig()` on any field change
- Event listeners: enabled toggle, frequency, diff checkbox, Choose folder, Run Now, Refresh history
- Tab click listener on `scheduled-export` tab to load settings on open

### `src/main.js`
- Added `scheduler:choose-folder` IPC handler (shows native folder picker, returns path)

### `src/frontend/preload.js`
- Exposed `schedulerChooseFolder: () => ipcRenderer.invoke('scheduler:choose-folder')`

## Test results

```
Tests: 384 passed, 384 total (no change — UI-only additions)
```

Closes #129
