### PR TITLE
feat: adapter registry + OneNote, NotebookLM, Copilot export adapters

### DIFF
--- a/src/backend/export/adapters/registry.js
+++ b/src/backend/export/adapters/registry.js
@@ -1,0 +1,47 @@
+'use strict';
+
+/**
+ * Adapter registry — single source of truth for all CCF export adapters.
+ *
+ * To add a new adapter:
+ *   1. Create src/backend/export/<name>/index.js satisfying the contract below.
+ *   2. Add one require() line here.
+ *
+ * Adapter contract:
+ * -----------------
+ *   module.exports = {
+ *     id:          string,   // stable, hyphen-case, used in settings & IPC
+ *     name:        string,   // human-readable label for the UI
+ *     description: string,   // one-line description shown in the export modal
+ *     export(ccfSnapshotDir, destDir) {
+ *       // Pure CCF-to-output transformation.  No DB access, no IPC.
+ *       // Both paths are absolute strings.  destDir is created by the adapter.
+ *       // Returns: { files: string[], entryCount: number, themeCount: number }
+ *     },
+ *   };
+ */
+
+const ADAPTERS = [
+  require('../onenote'),
+  require('../notebooklm'),
+  require('../copilot'),
+];
+
+/**
+ * Return all registered adapters.
+ * @returns {object[]}
+ */
+function listAdapters() {
+  return ADAPTERS;
+}
+
+/**
+ * Return a single adapter by id, or null if not found.
+ * @param {string} id
+ * @returns {object|null}
+ */
+function getAdapter(id) {
+  return ADAPTERS.find((a) => a.id === id) || null;
+}
+
+module.exports = { listAdapters, getAdapter };

--- a/src/backend/export/copilot/index.js
+++ b/src/backend/export/copilot/index.js
@@ -1,0 +1,224 @@
+'use strict';
+
+/**
+ * Copilot-ready export adapter — CCF → grounding-optimised Markdown bundle
+ *
+ * Satisfies the adapter registry contract (id, name, description, export()).
+ *
+ * Optimised for Microsoft Copilot (and similar RAG systems) as grounding
+ * documents:
+ *   - Entries longer than CHUNK_WORDS words are split into numbered chunk files
+ *     so no single file is too large for a context window.
+ *   - Clear heading hierarchy (H1 = theme, H2 = entry) for predictable chunking.
+ *   - Each file begins with the theme summary for context.
+ *   - An index.md lists all generated files with entry/chunk counts.
+ *
+ * Output structure:
+ *   <destDir>/
+ *     index.md               ← manifest of all files
+ *     <theme-slug>.md        ← theme entries (short themes, ≤ CHUNK_WORDS words total)
+ *     <theme-slug>-1.md      ← chunk 1 of a long theme
+ *     <theme-slug>-2.md      ← chunk 2 …
+ *     uncategorized.md       ← unthemed entries (split the same way)
+ *     metadata.json
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// ── constants ─────────────────────────────────────────────────────────────────
+
+/** Maximum words in a single output file before a new chunk is started. */
+const CHUNK_WORDS = 500;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, 'utf8')
+    .split('\n').map((l) => l.trim()).filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function readJson(filePath, def = null) {
+  if (!fs.existsSync(filePath)) return def;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function slugify(name) {
+  return (name || 'unnamed')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60) || 'unnamed';
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toISOString().slice(0, 10);
+  } catch {
+    return iso;
+  }
+}
+
+function countWords(text) {
+  return (text || '').split(/\s+/).filter(Boolean).length;
+}
+
+// ── chunk builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Split an array of entries into chunks, each containing at most CHUNK_WORDS
+ * words (measured across all entry text in the chunk).
+ * @param {object[]} entries
+ * @returns {object[][]}  Array of entry-arrays (chunks)
+ */
+function chunkEntries(entries) {
+  const chunks  = [];
+  let current   = [];
+  let wordCount = 0;
+
+  for (const entry of entries) {
+    const words = countWords(entry.text);
+    // Start a new chunk when adding this entry would exceed the limit,
+    // but always include at least one entry per chunk.
+    if (current.length > 0 && wordCount + words > CHUNK_WORDS) {
+      chunks.push(current);
+      current   = [];
+      wordCount = 0;
+    }
+    current.push(entry);
+    wordCount += words;
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks.length > 0 ? chunks : [[]];
+}
+
+// ── content builders ──────────────────────────────────────────────────────────
+
+function buildChunkFile(theme, entries, chunkIndex, totalChunks) {
+  const themeName = theme ? theme.name || 'Unnamed Theme' : 'Uncategorized';
+  const summary   = theme ? (theme.summary || theme.description || '') : '';
+  const chunkLabel = totalChunks > 1 ? ` (part ${chunkIndex + 1} of ${totalChunks})` : '';
+
+  const lines = [];
+  lines.push(`# ${themeName}${chunkLabel}`);
+  lines.push('');
+
+  if (summary) {
+    lines.push(`> ${summary}`);
+    lines.push('');
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    lines.push(`## Entry ${i + 1} — ${fmtDate(entry.created_at)}`);
+    lines.push('');
+
+    const tags = (entry.tags || []).join(', ');
+    if (tags)         lines.push(`**Tags:** ${tags}  `);
+    if (entry.domain) lines.push(`**Domain:** ${entry.domain}  `);
+    if (tags || entry.domain) lines.push('');
+
+    lines.push(entry.text || '');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ── adapter ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+  id:          'copilot',
+  name:        'Copilot-ready',
+  description: 'Grounding-optimised Markdown bundle — chunked for Copilot and RAG systems',
+
+  /**
+   * @param {string} ccfSnapshotDir  Absolute path to a CCF snapshot folder.
+   * @param {string} destDir         Absolute path for output (created if needed).
+   * @returns {{ files: string[], entryCount: number, themeCount: number }}
+   */
+  export(ccfSnapshotDir, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+
+    const entries = readJsonl(path.join(ccfSnapshotDir, 'entries.jsonl'));
+    const themes  = readJson(path.join(ccfSnapshotDir, 'themes.json'), []);
+    const files   = [];
+    const indexRows = [];
+
+    const entryMap  = new Map(entries.map((e) => [e.id, e]));
+    const themedIds = new Set(themes.flatMap((t) => t.entry_ids || []));
+
+    // ── themed sections ───────────────────────────────────────────────────
+    for (const theme of themes) {
+      const memberEntries = (theme.entry_ids || [])
+        .map((id) => entryMap.get(id))
+        .filter(Boolean)
+        .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+
+      const slug   = slugify(theme.name);
+      const chunks = chunkEntries(memberEntries);
+
+      for (let ci = 0; ci < chunks.length; ci++) {
+        const fileName = chunks.length === 1 ? `${slug}.md` : `${slug}-${ci + 1}.md`;
+        const filePath = path.join(destDir, fileName);
+        fs.writeFileSync(filePath, buildChunkFile(theme, chunks[ci], ci, chunks.length), 'utf8');
+        files.push(filePath);
+        indexRows.push({ file: fileName, theme: theme.name, entries: chunks[ci].length, chunk: chunks.length > 1 ? `${ci + 1}/${chunks.length}` : null });
+      }
+    }
+
+    // ── uncategorized ─────────────────────────────────────────────────────
+    const unthemed = entries
+      .filter((e) => !themedIds.has(e.id))
+      .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+
+    if (unthemed.length > 0) {
+      const chunks = chunkEntries(unthemed);
+      for (let ci = 0; ci < chunks.length; ci++) {
+        const fileName = chunks.length === 1 ? 'uncategorized.md' : `uncategorized-${ci + 1}.md`;
+        const filePath = path.join(destDir, fileName);
+        fs.writeFileSync(filePath, buildChunkFile(null, chunks[ci], ci, chunks.length), 'utf8');
+        files.push(filePath);
+        indexRows.push({ file: fileName, theme: 'Uncategorized', entries: chunks[ci].length, chunk: chunks.length > 1 ? `${ci + 1}/${chunks.length}` : null });
+      }
+    }
+
+    // ── index.md ──────────────────────────────────────────────────────────
+    const indexLines = [
+      '# Copilot Grounding Index',
+      '',
+      `_Exported from Neurologue on ${new Date().toISOString().slice(0, 10)}_`,
+      '',
+      `${entries.length} entries across ${themes.length} themes in ${files.length} files.`,
+      '',
+      '## Files',
+      '',
+    ];
+    for (const row of indexRows) {
+      const chunkNote = row.chunk ? ` (chunk ${row.chunk})` : '';
+      indexLines.push(`- **${row.file}** — ${row.theme}${chunkNote}, ${row.entries} ${row.entries === 1 ? 'entry' : 'entries'}`);
+    }
+    const indexPath = path.join(destDir, 'index.md');
+    fs.writeFileSync(indexPath, indexLines.join('\n'), 'utf8');
+    files.push(indexPath);
+
+    // ── metadata.json ─────────────────────────────────────────────────────
+    const meta = {
+      exportedAt:  new Date().toISOString(),
+      adapter:     'copilot',
+      chunkWords:  CHUNK_WORDS,
+      entryCount:  entries.length,
+      themeCount:  themes.length,
+      fileCount:   files.length,
+    };
+    const metaPath = path.join(destDir, 'metadata.json');
+    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf8');
+    files.push(metaPath);
+
+    return { files, entryCount: entries.length, themeCount: themes.length };
+  },
+};

--- a/src/backend/export/notebooklm/index.js
+++ b/src/backend/export/notebooklm/index.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * NotebookLM export adapter — CCF → Markdown folder
+ *
+ * Satisfies the adapter registry contract (id, name, description, export()).
+ *
+ * Output structure:
+ *   <destDir>/
+ *     <theme-slug>.md        ← one file per theme; theme summary + all member entries
+ *     uncategorized.md       ← entries not belonging to any theme (omitted if empty)
+ *     metadata.json          ← export timestamp, counts
+ *
+ * File naming is deterministic: slugified theme name, truncated to 60 chars.
+ * NotebookLM ingests folders of Markdown files as "sources".
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, 'utf8')
+    .split('\n').map((l) => l.trim()).filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function readJson(filePath, def = null) {
+  if (!fs.existsSync(filePath)) return def;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function slugify(name) {
+  return (name || 'unnamed')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60) || 'unnamed';
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toISOString().slice(0, 10);
+  } catch {
+    return iso;
+  }
+}
+
+// ── content builders ──────────────────────────────────────────────────────────
+
+function buildThemeFile(theme, entries) {
+  const lines = [];
+  lines.push(`# ${theme.name || 'Unnamed Theme'}`);
+  lines.push('');
+
+  if (theme.summary || theme.description) {
+    lines.push(theme.summary || theme.description);
+    lines.push('');
+  }
+
+  lines.push(`_${entries.length} ${entries.length === 1 ? 'entry' : 'entries'}_`);
+  lines.push('');
+  lines.push('---');
+
+  for (const entry of entries) {
+    lines.push('');
+    lines.push(`## Entry — ${fmtDate(entry.created_at)}`);
+    lines.push('');
+
+    const tags = (entry.tags || []).join(', ');
+    if (tags)         lines.push(`**Tags:** ${tags}`);
+    if (entry.domain) lines.push(`**Domain:** ${entry.domain}`);
+    lines.push('');
+
+    lines.push(entry.text || '');
+    lines.push('');
+    lines.push('---');
+  }
+
+  return lines.join('\n');
+}
+
+function buildUncategorizedFile(entries) {
+  const lines = [];
+  lines.push('# Uncategorized Entries');
+  lines.push('');
+  lines.push(`_${entries.length} ${entries.length === 1 ? 'entry' : 'entries'} not assigned to a theme_`);
+  lines.push('');
+  lines.push('---');
+
+  for (const entry of entries) {
+    lines.push('');
+    lines.push(`## Entry — ${fmtDate(entry.created_at)}`);
+    lines.push('');
+
+    const tags = (entry.tags || []).join(', ');
+    if (tags)         lines.push(`**Tags:** ${tags}`);
+    if (entry.domain) lines.push(`**Domain:** ${entry.domain}`);
+    lines.push('');
+
+    lines.push(entry.text || '');
+    lines.push('');
+    lines.push('---');
+  }
+
+  return lines.join('\n');
+}
+
+// ── adapter ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+  id:          'notebooklm',
+  name:        'NotebookLM',
+  description: 'Markdown folder — one file per theme, ready to upload as NotebookLM sources',
+
+  /**
+   * @param {string} ccfSnapshotDir  Absolute path to a CCF snapshot folder.
+   * @param {string} destDir         Absolute path for output (created if needed).
+   * @returns {{ files: string[], entryCount: number, themeCount: number }}
+   */
+  export(ccfSnapshotDir, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+
+    const entries = readJsonl(path.join(ccfSnapshotDir, 'entries.jsonl'));
+    const themes  = readJson(path.join(ccfSnapshotDir, 'themes.json'), []);
+    const files   = [];
+
+    const entryMap  = new Map(entries.map((e) => [e.id, e]));
+    const themedIds = new Set(themes.flatMap((t) => t.entry_ids || []));
+
+    // ── one file per theme ────────────────────────────────────────────────
+    for (const theme of themes) {
+      const memberEntries = (theme.entry_ids || [])
+        .map((id) => entryMap.get(id))
+        .filter(Boolean)
+        .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+
+      const slug     = slugify(theme.name);
+      const filePath = path.join(destDir, `${slug}.md`);
+      fs.writeFileSync(filePath, buildThemeFile(theme, memberEntries), 'utf8');
+      files.push(filePath);
+    }
+
+    // ── uncategorized ─────────────────────────────────────────────────────
+    const unthemed = entries
+      .filter((e) => !themedIds.has(e.id))
+      .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+
+    if (unthemed.length > 0) {
+      const filePath = path.join(destDir, 'uncategorized.md');
+      fs.writeFileSync(filePath, buildUncategorizedFile(unthemed), 'utf8');
+      files.push(filePath);
+    }
+
+    // ── metadata ──────────────────────────────────────────────────────────
+    const meta = {
+      exportedAt:  new Date().toISOString(),
+      adapter:     'notebooklm',
+      entryCount:  entries.length,
+      themeCount:  themes.length,
+      fileCount:   files.length,
+    };
+    const metaPath = path.join(destDir, 'metadata.json');
+    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf8');
+    files.push(metaPath);
+
+    return { files, entryCount: entries.length, themeCount: themes.length };
+  },
+};

--- a/src/backend/export/onenote/index.js
+++ b/src/backend/export/onenote/index.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * OneNote export adapter — CCF → OneNote-compatible HTML
+ *
+ * Satisfies the adapter registry contract (id, name, description, export()).
+ *
+ * Output structure:
+ *   <destDir>/
+ *     <theme-slug>/          ← one sub-folder per theme (OneNote section)
+ *       _summary.htm         ← section overview page
+ *       <entry-id>.htm       ← one page per entry, chronological
+ *     _unthemed/             ← entries not belonging to any theme
+ *       <entry-id>.htm
+ *
+ * Files use the OneNote HTML schema so they can be dragged into OneNote
+ * or imported via File → Open.
+ *
+ * @see https://learn.microsoft.com/en-us/graph/integrate-with-onenote
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, 'utf8')
+    .split('\n').map((l) => l.trim()).filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function readJson(filePath, def = null) {
+  if (!fs.existsSync(filePath)) return def;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function slugify(name) {
+  return (name || 'unnamed')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64) || 'unnamed';
+}
+
+function escapeHtml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString('en-GB', {
+      day: '2-digit', month: 'short', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ── HTML page builders ────────────────────────────────────────────────────────
+
+function buildEntryPage(entry) {
+  const title   = `Entry — ${fmtDate(entry.created_at)}`;
+  const tags    = (entry.tags || []).join(', ') || '—';
+  const domain  = entry.domain || '—';
+  const updated = entry.updated_at ? fmtDate(entry.updated_at) : '—';
+  const body    = escapeHtml(entry.text || '').replace(/\n/g, '<br />');
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="Microsoft.Office.Document.Type" content="Microsoft OneNote Page" />
+  <title>${escapeHtml(title)}</title>
+</head>
+<body data-absolute-enabled="true">
+  <h1>${escapeHtml(title)}</h1>
+  <table style="font-size:11pt;color:#555;width:100%;margin-bottom:16px">
+    <tr><td><strong>Created</strong></td><td>${escapeHtml(fmtDate(entry.created_at))}</td></tr>
+    <tr><td><strong>Updated</strong></td><td>${escapeHtml(updated)}</td></tr>
+    <tr><td><strong>Domain</strong></td><td>${escapeHtml(domain)}</td></tr>
+    <tr><td><strong>Tags</strong></td><td>${escapeHtml(tags)}</td></tr>
+  </table>
+  <div style="font-size:13pt;line-height:1.6">${body}</div>
+</body>
+</html>`;
+}
+
+function buildSummaryPage(theme) {
+  const name    = escapeHtml(theme.name || 'Unnamed Theme');
+  const summary = escapeHtml(theme.summary || theme.description || '').replace(/\n/g, '<br />');
+  const count   = (theme.entry_ids || []).length;
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="Microsoft.Office.Document.Type" content="Microsoft OneNote Page" />
+  <title>${name}</title>
+</head>
+<body data-absolute-enabled="true">
+  <h1>${name}</h1>
+  <p style="font-size:11pt;color:#555">${count} entries</p>
+  <div style="font-size:13pt;line-height:1.6">${summary || '<em>No summary available.</em>'}</div>
+</body>
+</html>`;
+}
+
+// ── adapter ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+  id:          'onenote',
+  name:        'OneNote',
+  description: 'OneNote-compatible HTML files — one section per theme, one page per entry',
+
+  /**
+   * @param {string} ccfSnapshotDir  Absolute path to a CCF snapshot folder.
+   * @param {string} destDir         Absolute path for output (created if needed).
+   * @returns {{ files: string[], entryCount: number, themeCount: number }}
+   */
+  export(ccfSnapshotDir, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+
+    const entries = readJsonl(path.join(ccfSnapshotDir, 'entries.jsonl'));
+    const themes  = readJson(path.join(ccfSnapshotDir, 'themes.json'), []);
+    const files   = [];
+
+    const entryMap  = new Map(entries.map((e) => [e.id, e]));
+    const themedIds = new Set(themes.flatMap((t) => t.entry_ids || []));
+
+    // ── themed sections ─────────────────────────────────────────────────────
+    for (const theme of themes) {
+      const sectionDir = path.join(destDir, slugify(theme.name));
+      fs.mkdirSync(sectionDir, { recursive: true });
+
+      const summaryPath = path.join(sectionDir, '_summary.htm');
+      fs.writeFileSync(summaryPath, buildSummaryPage(theme), 'utf8');
+      files.push(summaryPath);
+
+      const memberIds = (theme.entry_ids || []).slice()
+        .sort((a, b) => (entryMap.get(a)?.created_at || '').localeCompare(entryMap.get(b)?.created_at || ''));
+
+      for (const eid of memberIds) {
+        const entry = entryMap.get(eid);
+        if (!entry) continue;
+        const pagePath = path.join(sectionDir, `${eid}.htm`);
+        fs.writeFileSync(pagePath, buildEntryPage(entry), 'utf8');
+        files.push(pagePath);
+      }
+    }
+
+    // ── unthemed entries ─────────────────────────────────────────────────────
+    const unthemed = entries
+      .filter((e) => !themedIds.has(e.id))
+      .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+
+    if (unthemed.length > 0) {
+      const unthemedDir = path.join(destDir, '_unthemed');
+      fs.mkdirSync(unthemedDir, { recursive: true });
+      for (const entry of unthemed) {
+        const pagePath = path.join(unthemedDir, `${entry.id}.htm`);
+        fs.writeFileSync(pagePath, buildEntryPage(entry), 'utf8');
+        files.push(pagePath);
+      }
+    }
+
+    return { files, entryCount: entries.length, themeCount: themes.length };
+  },
+};

--- a/src/backend/export/scheduler/index.js
+++ b/src/backend/export/scheduler/index.js
@@ -27,6 +27,7 @@ const path = require('path');
 const { exportCCF }  = require('../ccf');
 const { diffCCF }    = require('../../ccf/diff');
 const { getSettings, saveSettings } = require('../../settings');
+const { getAdapter } = require('../adapters/registry');
 const config = require('../../../config');
 
 // ── constants ─────────────────────────────────────────────────────────────────
@@ -93,10 +94,11 @@ function _snapshotFolderName(now = new Date()) {
  * @param {boolean} opts.includeDiff Whether to write diff.json.
  * @returns {Promise<{ ok: boolean, snapshotDir: string, diffWritten: boolean, error?: string }>}
  */
-async function runScheduledExport({ destDir, includeDiff } = {}) {
+async function runScheduledExport({ destDir, includeDiff, adapterIds } = {}) {
   const settings = getSettings();
   const resolvedDestDir   = destDir     ?? settings.scheduledExport?.destDir;
   const resolvedDiff      = includeDiff ?? settings.scheduledExport?.includeDiff ?? false;
+  const resolvedAdapterIds = adapterIds ?? settings.scheduledExport?.adapterIds ?? [];
 
   if (!resolvedDestDir) {
     return { ok: false, snapshotDir: null, diffWritten: false, error: 'No destination folder configured' };
@@ -124,16 +126,31 @@ async function runScheduledExport({ destDir, includeDiff } = {}) {
       }
     }
 
-    // ── 3. Record history ─────────────────────────────────────────────────
+    // ── 3. Run adapter transforms (if any configured) ─────────────────────────
+    const adapterResults = {};
+    for (const adapterId of resolvedAdapterIds) {
+      const adapter = getAdapter(adapterId);
+      if (!adapter) continue;
+      try {
+        const adapterDest = path.join(snapshotDir, adapterId);
+        const result = adapter.export(snapshotDir, adapterDest);
+        adapterResults[adapterId] = { ok: true, fileCount: result.files.length };
+      } catch (adapterErr) {
+        adapterResults[adapterId] = { ok: false, error: adapterErr.message || String(adapterErr) };
+      }
+    }
+
+    // ── 4. Record history ─────────────────────────────────────────────────────
     const record = {
-      runAt:       new Date().toISOString(),
+      runAt:          new Date().toISOString(),
       snapshotDir,
       diffWritten,
+      adapterResults,
       ok: true,
     };
     _appendHistory(record);
 
-    // ── 4. Persist lastRun in settings ────────────────────────────────────
+    // ── 5. Persist lastRun in settings ───────────────────────────────────────────
     saveSettings({
       scheduledExport: {
         ...(settings.scheduledExport || {}),
@@ -141,11 +158,11 @@ async function runScheduledExport({ destDir, includeDiff } = {}) {
       },
     });
 
-    return { ok: true, snapshotDir, diffWritten };
+    return { ok: true, snapshotDir, diffWritten, adapterResults };
   } catch (err) {
     const error = err && err.message ? err.message : String(err);
-    _appendHistory({ runAt: new Date().toISOString(), snapshotDir, diffWritten: false, ok: false, error });
-    return { ok: false, snapshotDir, diffWritten: false, error };
+    _appendHistory({ runAt: new Date().toISOString(), snapshotDir, diffWritten: false, adapterResults: {}, ok: false, error });
+    return { ok: false, snapshotDir, diffWritten: false, adapterResults: {}, error };
   }
 }
 
@@ -207,6 +224,7 @@ function getSchedulerStatus() {
     frequency:   cfg.frequency   ?? 'daily',
     destDir:     cfg.destDir     ?? null,
     includeDiff: cfg.includeDiff ?? false,
+    adapterIds:  cfg.adapterIds  ?? [],
     lastRun,
     nextRun,
   };

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -35,6 +35,7 @@ const DEFAULTS = {
     frequency:   'daily',   // 'daily' | 'weekly'
     destDir:     null,      // absolute path chosen by user
     includeDiff: false,
+    adapterIds:  [],        // adapter ids to run after each CCF snapshot
     lastRun:     null,
   },
 };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -796,6 +796,13 @@
           </label>
         </div>
         <div class="settings-field">
+          <label>Also transform to…</label>
+          <div id="sched-adapter-checks" class="sched-adapter-checks">
+            <!-- populated dynamically by library.js -->
+          </div>
+          <span class="settings-hint">Selected adapters run automatically after each scheduled snapshot.</span>
+        </div>
+        <div class="settings-field">
           <label>Status</label>
           <div id="sched-status-line" class="sched-status-line">—</div>
         </div>
@@ -859,6 +866,14 @@
       <div class="export-modal-actions">
         <button id="btn-export-cancel" class="btn-secondary">Cancel</button>
         <button id="btn-export-confirm" class="btn-primary">Choose folder…</button>
+      </div>
+
+      <hr style="margin:20px 0;border-color:var(--border)" />
+
+      <h3 class="modal-section-title">Export to third-party format</h3>
+      <p class="export-modal-desc">Select a format and choose an output folder. Neurologue will snapshot your corpus and transform it automatically.</p>
+      <div id="adapter-list" class="export-format-list">
+        <!-- populated dynamically by library.js -->
       </div>
     </div>
   </div>

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1150,6 +1150,59 @@ exportConfirmBtn.addEventListener('click', async () => {
   }
 });
 
+// ── Adapter exports ─────────────────────────────────────────────────────────
+
+async function loadAdapterList() {
+  const container = document.getElementById('adapter-list');
+  if (!container) return;
+  try {
+    const adapters = await window.neurologue.listAdapters();
+    if (!adapters || adapters.length === 0) {
+      container.innerHTML = '<p style="color:var(--text-muted);font-size:13px">No adapters registered.</p>';
+      return;
+    }
+    container.innerHTML = adapters.map((a) => `
+      <div class="export-format-row export-adapter-row" data-adapter-id="${a.id}">
+        <div>
+          <span class="export-fmt-label">${a.name}</span>
+          <span class="export-fmt-desc">${a.description}</span>
+        </div>
+        <button class="btn-secondary btn-adapter-export" data-adapter-id="${a.id}" style="margin-left:auto;white-space:nowrap">
+          Export…
+        </button>
+      </div>
+    `).join('');
+
+    container.querySelectorAll('.btn-adapter-export').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const id = btn.dataset.adapterId;
+        btn.disabled = true;
+        btn.textContent = 'Exporting…';
+        try {
+          const result = await window.neurologue.exportAdapter(id);
+          if (result.canceled) {
+            // user dismissed the folder picker — no toast needed
+          } else if (result.ok) {
+            showToast(`${id} export complete — ${result.entryCount} entries → ${result.destDir}`, 'success');
+          } else {
+            showToast(`${id} export failed: ${result.error}`, 'error');
+          }
+        } catch (err) {
+          showToast(`${id} export failed: ${err.message}`, 'error');
+        } finally {
+          btn.disabled = false;
+          btn.textContent = 'Export…';
+        }
+      });
+    });
+  } catch (err) {
+    container.innerHTML = `<p style="color:var(--error)">Could not load adapters: ${err.message}</p>`;
+  }
+}
+
+// Load adapter list when the export modal opens
+exportBtn.addEventListener('click', loadAdapterList);
+
 helpBtn.addEventListener('click', () => {
   window.neurologue.openHelp();
 });
@@ -1693,6 +1746,24 @@ async function loadSchedSettings() {
   document.getElementById('sched-status-line').textContent =
     `Last run: ${lastRun}  ·  Next run: ${nextRun}`;
 
+  // Populate adapter checkboxes
+  const checksContainer = document.getElementById('sched-adapter-checks');
+  if (checksContainer) {
+    try {
+      const adapters = await window.neurologue.listAdapters();
+      const activeIds = status.adapterIds || [];
+      checksContainer.innerHTML = adapters.map((a) => `
+        <label class="toggle-label" style="margin-right:16px">
+          <input type="checkbox" class="sched-adapter-check" value="${a.id}" ${activeIds.includes(a.id) ? 'checked' : ''} />
+          ${a.name}
+        </label>
+      `).join('');
+      checksContainer.querySelectorAll('.sched-adapter-check').forEach((cb) => {
+        cb.addEventListener('change', _saveSchedConfig);
+      });
+    } catch { /* adapters not critical */ }
+  }
+
   await renderSchedHistory();
 }
 
@@ -1731,11 +1802,14 @@ async function renderSchedHistory() {
 }
 
 async function _saveSchedConfig() {
+  const adapterIds = [...document.querySelectorAll('.sched-adapter-check')]
+    .filter((cb) => cb.checked).map((cb) => cb.value);
   const cfg = {
     enabled:     document.getElementById('sched-enabled').checked,
     frequency:   document.getElementById('sched-frequency').value,
     destDir:     _schedConfig.destDir || null,
     includeDiff: document.getElementById('sched-include-diff').checked,
+    adapterIds,
     lastRun:     _schedConfig.lastRun || null,
   };
   _schedConfig = { ..._schedConfig, ...cfg };

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -42,6 +42,10 @@ contextBridge.exposeInMainWorld('neurologue', {
   exportCCF:  ()    => ipcRenderer.invoke('export:ccf'),
   importCCF:  ()    => ipcRenderer.invoke('import:ccf'),
 
+  // ── Adapter exports ───────────────────────────────────────────────────────
+  listAdapters:  ()   => ipcRenderer.invoke('adapter:list'),
+  exportAdapter: (id) => ipcRenderer.invoke('export:adapter', { id }),
+
   // ── Scheduled Export ──────────────────────────────────────────────────────
   schedulerStatus:     ()       => ipcRenderer.invoke('scheduler:status'),
   schedulerHistory:    (limit)  => ipcRenderer.invoke('scheduler:history', { limit }),

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const { runClustering } = require('./backend/clustering/themes');
 const { runExport } = require('./backend/export/runner');
 const { exportCCF }  = require('./backend/export/ccf');
 const { importCCF }  = require('./backend/import/ccf-import');
+const { listAdapters, getAdapter } = require('./backend/export/adapters/registry');
 const { startScheduler, stopScheduler, runScheduledExport, getExportHistory, getSchedulerStatus } = require('./backend/export/scheduler/index');
 const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, recomputeMetrics } = require('./worker/index');
@@ -482,6 +483,41 @@ handle('scheduler:choose-folder', async () => {
   });
   if (canceled || !filePaths || filePaths.length === 0) return { canceled: true };
   return { canceled: false, path: filePaths[0] };
+});
+
+// ── Adapter IPC ─────────────────────────────────────────────────────────────────
+
+// Return id/name/description for all registered adapters
+handle('adapter:list', async () =>
+  listAdapters().map(({ id, name, description }) => ({ id, name, description }))
+);
+
+// Run a single adapter: snapshot CCF to a temp sub-folder, transform, return result
+handle('export:adapter', async (_event, { id } = {}) => {
+  const { dialog } = require('electron');
+  const os   = require('os');
+  const win  = BrowserWindow.getFocusedWindow();
+
+  const adapter = getAdapter(id);
+  if (!adapter) return { canceled: false, ok: false, error: `Unknown adapter: ${id}` };
+
+  const { canceled, filePaths } = await dialog.showOpenDialog(win || undefined, {
+    title: `Choose output folder for ${adapter.name} export`,
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (canceled || !filePaths || filePaths.length === 0) return { canceled: true };
+
+  const destDir     = filePaths[0];
+  const tmpSnapshot = require('path').join(os.tmpdir(), `neurologue-ccf-${Date.now()}`);
+
+  try {
+    await exportCCF(tmpSnapshot);
+    const result = adapter.export(tmpSnapshot, destDir);
+    return { canceled: false, ok: true, destDir, ...result };
+  } finally {
+    // Clean up the temporary CCF snapshot
+    try { require('fs').rmSync(tmpSnapshot, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
 });
 
 app.whenReady().then(async () => {

--- a/tests/unit/export/copilot.test.js
+++ b/tests/unit/export/copilot.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function makeEntry(id, text, tags = []) {
+  return { id, created_at: `2026-01-0${id.slice(-1)}T10:00:00.000Z`, text, domain: 'work', tags };
+}
+
+/** Generate a long entry whose text exceeds CHUNK_WORDS (500) alone. */
+function longText(words = 600) {
+  return Array.from({ length: words }, (_, i) => `word${i}`).join(' ');
+}
+
+const ENTRIES_SHORT = [
+  makeEntry('e1', 'Short entry one',   ['tag-a']),
+  makeEntry('e2', 'Short entry two',   []),
+  makeEntry('e3', 'Unthemed entry',    []),
+];
+
+const THEMES = [
+  { id: 't1', name: 'Quick Ideas', summary: 'Brief theme summary', entry_ids: ['e1', 'e2'] },
+];
+
+function writeCcfSnapshot(dir, { entries = ENTRIES_SHORT, themes = THEMES } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'entries.jsonl'),
+    entries.map((e) => JSON.stringify(e)).join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(dir, 'themes.json'),
+    JSON.stringify(themes),
+    'utf8',
+  );
+}
+
+// ── setup / teardown ──────────────────────────────────────────────────────────
+
+let tmpDir, snapshotDir, outDir;
+
+beforeEach(() => {
+  tmpDir      = fs.mkdtempSync(path.join(os.tmpdir(), 'nrlg-copilot-'));
+  snapshotDir = path.join(tmpDir, 'snapshot');
+  outDir      = path.join(tmpDir, 'out');
+  writeCcfSnapshot(snapshotDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+const adapter = require('../../../src/backend/export/copilot');
+
+describe('Copilot adapter — registry contract', () => {
+  test('exposes id, name, description, export', () => {
+    expect(typeof adapter.id).toBe('string');
+    expect(typeof adapter.name).toBe('string');
+    expect(typeof adapter.description).toBe('string');
+    expect(typeof adapter.export).toBe('function');
+    expect(adapter.id).toBe('copilot');
+  });
+});
+
+describe('Copilot adapter — export()', () => {
+  test('creates output directory', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(outDir)).toBe(true);
+  });
+
+  test('returns expected counts', () => {
+    const result = adapter.export(snapshotDir, outDir);
+    expect(result.entryCount).toBe(3);
+    expect(result.themeCount).toBe(1);
+  });
+
+  test('writes a theme file with deterministic slug', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'quick-ideas.md'))).toBe(true);
+  });
+
+  test('theme file contains H1 heading and summary', () => {
+    adapter.export(snapshotDir, outDir);
+    const md = fs.readFileSync(path.join(outDir, 'quick-ideas.md'), 'utf8');
+    expect(md).toContain('# Quick Ideas');
+    expect(md).toContain('Brief theme summary');
+  });
+
+  test('theme file contains H2 per entry', () => {
+    adapter.export(snapshotDir, outDir);
+    const md = fs.readFileSync(path.join(outDir, 'quick-ideas.md'), 'utf8');
+    expect(md).toContain('## Entry 1');
+    expect(md).toContain('## Entry 2');
+  });
+
+  test('writes uncategorized.md for unthemed entries', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'uncategorized.md'))).toBe(true);
+    const md = fs.readFileSync(path.join(outDir, 'uncategorized.md'), 'utf8');
+    expect(md).toContain('Unthemed entry');
+  });
+
+  test('writes index.md listing all files', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'index.md'))).toBe(true);
+    const md = fs.readFileSync(path.join(outDir, 'index.md'), 'utf8');
+    expect(md).toContain('quick-ideas.md');
+    expect(md).toContain('uncategorized.md');
+  });
+
+  test('writes metadata.json with correct fields', () => {
+    adapter.export(snapshotDir, outDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf8'));
+    expect(meta.adapter).toBe('copilot');
+    expect(meta.entryCount).toBe(3);
+    expect(meta.themeCount).toBe(1);
+    expect(typeof meta.chunkWords).toBe('number');
+    expect(typeof meta.exportedAt).toBe('string');
+  });
+
+  test('long entries are split into numbered chunk files', () => {
+    const entries = [
+      { id: 'e1', created_at: '2026-01-01T00:00:00.000Z', text: longText(600), tags: [] },
+      { id: 'e2', created_at: '2026-01-02T00:00:00.000Z', text: longText(600), tags: [] },
+    ];
+    const themes = [{ id: 't1', name: 'Big Topic', entry_ids: ['e1', 'e2'] }];
+    writeCcfSnapshot(snapshotDir, { entries, themes });
+    adapter.export(snapshotDir, outDir);
+    // Two 600-word entries exceed the 500-word chunk limit, so should split into 2 chunks
+    expect(fs.existsSync(path.join(outDir, 'big-topic-1.md'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'big-topic-2.md'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'big-topic.md'))).toBe(false);
+  });
+
+  test('chunk files are mentioned in index.md', () => {
+    const entries = [
+      { id: 'e1', created_at: '2026-01-01T00:00:00.000Z', text: longText(600), tags: [] },
+      { id: 'e2', created_at: '2026-01-02T00:00:00.000Z', text: longText(600), tags: [] },
+    ];
+    const themes = [{ id: 't1', name: 'Big Topic', entry_ids: ['e1', 'e2'] }];
+    writeCcfSnapshot(snapshotDir, { entries, themes });
+    adapter.export(snapshotDir, outDir);
+    const index = fs.readFileSync(path.join(outDir, 'index.md'), 'utf8');
+    expect(index).toContain('big-topic-1.md');
+    expect(index).toContain('big-topic-2.md');
+  });
+
+  test('handles empty corpus gracefully', () => {
+    writeCcfSnapshot(snapshotDir, { entries: [], themes: [] });
+    const result = adapter.export(snapshotDir, outDir);
+    expect(result.entryCount).toBe(0);
+    expect(result.themeCount).toBe(0);
+    expect(fs.existsSync(path.join(outDir, 'index.md'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'metadata.json'))).toBe(true);
+  });
+
+  test('files array lists all written files', () => {
+    const result = adapter.export(snapshotDir, outDir);
+    for (const f of result.files) {
+      expect(fs.existsSync(f)).toBe(true);
+    }
+  });
+});
+
+describe('Copilot adapter — registry', () => {
+  test('getAdapter("copilot") returns the copilot adapter', () => {
+    const { getAdapter, listAdapters } = require('../../../src/backend/export/adapters/registry');
+    const found = getAdapter('copilot');
+    expect(found).toBeTruthy();
+    expect(found.id).toBe('copilot');
+
+    const all = listAdapters();
+    expect(all.length).toBeGreaterThanOrEqual(3);
+    expect(all.map((a) => a.id)).toContain('onenote');
+    expect(all.map((a) => a.id)).toContain('notebooklm');
+    expect(all.map((a) => a.id)).toContain('copilot');
+  });
+
+  test('getAdapter returns null for unknown id', () => {
+    const { getAdapter } = require('../../../src/backend/export/adapters/registry');
+    expect(getAdapter('nonexistent')).toBeNull();
+  });
+});

--- a/tests/unit/export/notebooklm.test.js
+++ b/tests/unit/export/notebooklm.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const ENTRIES = [
+  { id: 'e1', created_at: '2026-01-01T10:00:00.000Z', text: 'First entry',  domain: 'work',     tags: ['alpha'] },
+  { id: 'e2', created_at: '2026-01-03T10:00:00.000Z', text: 'Second entry', domain: 'personal', tags: [] },
+  { id: 'e3', created_at: '2026-01-05T10:00:00.000Z', text: 'Unthemed',     domain: null,       tags: [] },
+];
+
+const THEMES = [
+  { id: 't1', name: 'Research Notes', summary: 'A summary', entry_ids: ['e1', 'e2'] },
+];
+
+function writeCcfSnapshot(dir, { entries = ENTRIES, themes = THEMES } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'entries.jsonl'),
+    entries.map((e) => JSON.stringify(e)).join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(dir, 'themes.json'),
+    JSON.stringify(themes),
+    'utf8',
+  );
+}
+
+// ── setup / teardown ──────────────────────────────────────────────────────────
+
+let tmpDir, snapshotDir, outDir;
+
+beforeEach(() => {
+  tmpDir      = fs.mkdtempSync(path.join(os.tmpdir(), 'nrlg-notebooklm-'));
+  snapshotDir = path.join(tmpDir, 'snapshot');
+  outDir      = path.join(tmpDir, 'out');
+  writeCcfSnapshot(snapshotDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+const adapter = require('../../../src/backend/export/notebooklm');
+
+describe('NotebookLM adapter — registry contract', () => {
+  test('exposes id, name, description, export', () => {
+    expect(typeof adapter.id).toBe('string');
+    expect(typeof adapter.name).toBe('string');
+    expect(typeof adapter.description).toBe('string');
+    expect(typeof adapter.export).toBe('function');
+    expect(adapter.id).toBe('notebooklm');
+  });
+});
+
+describe('NotebookLM adapter — export()', () => {
+  test('creates output directory', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(outDir)).toBe(true);
+  });
+
+  test('returns expected counts', () => {
+    const result = adapter.export(snapshotDir, outDir);
+    expect(result.entryCount).toBe(3);
+    expect(result.themeCount).toBe(1);
+  });
+
+  test('creates one markdown file per theme with deterministic slug', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'research-notes.md'))).toBe(true);
+  });
+
+  test('theme file contains theme name and summary', () => {
+    adapter.export(snapshotDir, outDir);
+    const md = fs.readFileSync(path.join(outDir, 'research-notes.md'), 'utf8');
+    expect(md).toContain('# Research Notes');
+    expect(md).toContain('A summary');
+  });
+
+  test('theme file contains member entry content', () => {
+    adapter.export(snapshotDir, outDir);
+    const md = fs.readFileSync(path.join(outDir, 'research-notes.md'), 'utf8');
+    expect(md).toContain('First entry');
+    expect(md).toContain('Second entry');
+  });
+
+  test('theme file lists tags and domain', () => {
+    adapter.export(snapshotDir, outDir);
+    const md = fs.readFileSync(path.join(outDir, 'research-notes.md'), 'utf8');
+    expect(md).toContain('alpha');
+    expect(md).toContain('work');
+  });
+
+  test('creates uncategorized.md for unthemed entries', () => {
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'uncategorized.md'))).toBe(true);
+    const md = fs.readFileSync(path.join(outDir, 'uncategorized.md'), 'utf8');
+    expect(md).toContain('Unthemed');
+  });
+
+  test('does not create uncategorized.md when all entries are themed', () => {
+    const entries = [{ id: 'e1', created_at: '2026-01-01T00:00:00.000Z', text: 'A', tags: [] }];
+    const themes  = [{ id: 't1', name: 'T', entry_ids: ['e1'] }];
+    writeCcfSnapshot(snapshotDir, { entries, themes });
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'uncategorized.md'))).toBe(false);
+  });
+
+  test('writes metadata.json with correct fields', () => {
+    adapter.export(snapshotDir, outDir);
+    const meta = JSON.parse(fs.readFileSync(path.join(outDir, 'metadata.json'), 'utf8'));
+    expect(meta.adapter).toBe('notebooklm');
+    expect(meta.entryCount).toBe(3);
+    expect(meta.themeCount).toBe(1);
+    expect(typeof meta.exportedAt).toBe('string');
+  });
+
+  test('handles empty corpus gracefully', () => {
+    writeCcfSnapshot(snapshotDir, { entries: [], themes: [] });
+    const result = adapter.export(snapshotDir, outDir);
+    expect(result.entryCount).toBe(0);
+    expect(result.themeCount).toBe(0);
+    expect(fs.existsSync(path.join(outDir, 'metadata.json'))).toBe(true);
+  });
+
+  test('slugifies theme names with special characters', () => {
+    const themes = [{ id: 't1', name: 'My Research & Notes!', entry_ids: [] }];
+    writeCcfSnapshot(snapshotDir, { entries: [], themes });
+    adapter.export(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'my-research-notes.md'))).toBe(true);
+  });
+
+  test('files array lists all written files', () => {
+    const result = adapter.export(snapshotDir, outDir);
+    for (const f of result.files) {
+      expect(fs.existsSync(f)).toBe(true);
+    }
+  });
+});

--- a/tests/unit/export/onenote.test.js
+++ b/tests/unit/export/onenote.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const os   = require('os');
+const path = require('path');
+const fs   = require('fs');
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const ENTRIES = [
+  { id: 'e1', created_at: '2026-01-01T10:00:00.000Z', updated_at: '2026-01-02T10:00:00.000Z', text: 'First entry content', domain: 'work', tags: ['tag-a', 'tag-b'] },
+  { id: 'e2', created_at: '2026-01-03T10:00:00.000Z', updated_at: null,                        text: 'Second entry content', domain: 'personal', tags: [] },
+  { id: 'e3', created_at: '2026-01-05T10:00:00.000Z', updated_at: null,                        text: 'Unthemed entry',       domain: null,       tags: [] },
+];
+
+const THEMES = [
+  { id: 't1', name: 'Alpha Theme', summary: 'A summary of alpha', entry_ids: ['e1', 'e2'] },
+];
+
+function writeCcfSnapshot(dir, { entries = ENTRIES, themes = THEMES } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'entries.jsonl'),
+    entries.map((e) => JSON.stringify(e)).join('\n'),
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(dir, 'themes.json'),
+    JSON.stringify(themes),
+    'utf8',
+  );
+}
+
+// ── setup / teardown ──────────────────────────────────────────────────────────
+
+let tmpDir, snapshotDir, outDir;
+
+beforeEach(() => {
+  tmpDir      = fs.mkdtempSync(path.join(os.tmpdir(), 'nrlg-onenote-'));
+  snapshotDir = path.join(tmpDir, 'snapshot');
+  outDir      = path.join(tmpDir, 'out');
+  writeCcfSnapshot(snapshotDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+const { export: exportOneNote } = require('../../../src/backend/export/onenote');
+
+describe('OneNote adapter — registry contract', () => {
+  test('exposes id, name, description, export', () => {
+    const adapter = require('../../../src/backend/export/onenote');
+    expect(typeof adapter.id).toBe('string');
+    expect(typeof adapter.name).toBe('string');
+    expect(typeof adapter.description).toBe('string');
+    expect(typeof adapter.export).toBe('function');
+    expect(adapter.id).toBe('onenote');
+  });
+});
+
+describe('OneNote adapter — export()', () => {
+  test('creates output directory', () => {
+    exportOneNote(snapshotDir, outDir);
+    expect(fs.existsSync(outDir)).toBe(true);
+  });
+
+  test('returns expected counts', () => {
+    const result = exportOneNote(snapshotDir, outDir);
+    expect(result.entryCount).toBe(3);
+    expect(result.themeCount).toBe(1);
+  });
+
+  test('creates a sub-folder for the theme', () => {
+    exportOneNote(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'alpha-theme'))).toBe(true);
+  });
+
+  test('writes a _summary.htm for each theme', () => {
+    exportOneNote(snapshotDir, outDir);
+    const summary = path.join(outDir, 'alpha-theme', '_summary.htm');
+    expect(fs.existsSync(summary)).toBe(true);
+    const html = fs.readFileSync(summary, 'utf8');
+    expect(html).toContain('Alpha Theme');
+    expect(html).toContain('Microsoft OneNote Page');
+  });
+
+  test('writes one .htm per themed entry', () => {
+    exportOneNote(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, 'alpha-theme', 'e1.htm'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'alpha-theme', 'e2.htm'))).toBe(true);
+  });
+
+  test('entry page contains entry text and metadata', () => {
+    exportOneNote(snapshotDir, outDir);
+    const html = fs.readFileSync(path.join(outDir, 'alpha-theme', 'e1.htm'), 'utf8');
+    expect(html).toContain('First entry content');
+    expect(html).toContain('tag-a');
+    expect(html).toContain('work');
+  });
+
+  test('writes _unthemed sub-folder for unthemed entries', () => {
+    exportOneNote(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, '_unthemed', 'e3.htm'))).toBe(true);
+  });
+
+  test('does NOT write _unthemed when all entries are themed', () => {
+    const entries = [
+      { id: 'e1', created_at: '2026-01-01T10:00:00.000Z', text: 'A', tags: [] },
+    ];
+    const themes  = [{ id: 't1', name: 'T', entry_ids: ['e1'] }];
+    writeCcfSnapshot(snapshotDir, { entries, themes });
+    exportOneNote(snapshotDir, outDir);
+    expect(fs.existsSync(path.join(outDir, '_unthemed'))).toBe(false);
+  });
+
+  test('handles empty corpus gracefully', () => {
+    writeCcfSnapshot(snapshotDir, { entries: [], themes: [] });
+    const result = exportOneNote(snapshotDir, outDir);
+    expect(result.entryCount).toBe(0);
+    expect(result.themeCount).toBe(0);
+    expect(result.files).toEqual([]);
+  });
+
+  test('handles theme whose entries are not in entries.jsonl', () => {
+    const themes = [{ id: 't1', name: 'Ghost Theme', entry_ids: ['missing-id'] }];
+    writeCcfSnapshot(snapshotDir, { entries: ENTRIES, themes });
+    // Should not throw; ghost entries are skipped
+    expect(() => exportOneNote(snapshotDir, outDir)).not.toThrow();
+    const summary = path.join(outDir, 'ghost-theme', '_summary.htm');
+    expect(fs.existsSync(summary)).toBe(true);
+  });
+
+  test('escapes HTML special characters in entry text', () => {
+    const entries = [{ id: 'e1', created_at: '2026-01-01T00:00:00.000Z', text: '<script>alert("xss")</script>', tags: [] }];
+    writeCcfSnapshot(snapshotDir, { entries, themes: [] });
+    exportOneNote(snapshotDir, outDir);
+    const html = fs.readFileSync(path.join(outDir, '_unthemed', 'e1.htm'), 'utf8');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('files array lists all written files', () => {
+    const result = exportOneNote(snapshotDir, outDir);
+    for (const f of result.files) {
+      expect(fs.existsSync(f)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the adapter registry architecture (#131) and all three CCF export adapters (#52, #53, #54) in one PR.

## Architecture

The key insight: instead of wiring each adapter individually into IPC, preload, UI, and the scheduler, a single registry contract means any new adapter needs **one require() line** added to \egistry.js\ and nothing else.

**Adapter contract:**
\\\js
module.exports = {
  id:          'onenote',
  name:        'OneNote',
  description: '...',
  export(ccfSnapshotDir, destDir) {
    // pure CCF → output, no DB access
    return { files, entryCount, themeCount };
  },
};
\\\

## Changes

### New files
| File | Purpose |
|---|---|
| \src/backend/export/adapters/registry.js\ | \listAdapters()\ / \getAdapter(id)\ |
| \src/backend/export/onenote/index.js\ | OneNote HTML (section/theme, page/entry) |
| \src/backend/export/notebooklm/index.js\ | Markdown folder, one file per theme |
| \src/backend/export/copilot/index.js\ | Chunked Markdown bundle (500-word chunks, index.md) |

### Modified files
- **scheduler/index.js** — runs \dapterIds\ after each CCF snapshot, writes results to history
- **settings.js** — \scheduledExport.adapterIds: []\ default
- **main.js** — \dapter:list\ + \export:adapter\ IPC (snapshots CCF to tmp, transforms, cleans up)
- **preload.js** — \listAdapters()\, \exportAdapter(id)\
- **index.html** — dynamic adapter section in export modal + adapter checkboxes in scheduled export panel
- **library.js** — \loadAdapterList()\ renders registry; \_saveSchedConfig\ includes adapterIds

## Tests
41 new tests across 3 suites — pure filesystem tests, no DB required.  
**425 total, all passing.**

## Closes
Closes #131, closes #52, closes #53, closes #54