### PR TITLE
feat: Settings as main nav view + heatmap label fixes (#137, #134)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
@@ -23,7 +23,6 @@
       <button id="btn-export" class="mode-btn">Export…</button>
       <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
       <button id="btn-maintenance" class="mode-btn toolbar-library-only" title="Tag management">Maintenance</button>
-      <button id="btn-settings" class="mode-btn" title="Settings">⚙</button>
       <button id="btn-help" class="mode-btn">Help</button>
     </div>
 
@@ -63,6 +62,10 @@
         <button class="nav-item" data-view="agents" title="Agents">
           <span class="nav-icon">&#10022;</span>
           <span class="nav-label">Agents</span>
+        </button>
+        <button class="nav-item nav-item--settings" data-view="settings" title="Settings">
+          <span class="nav-icon">&#9881;</span>
+          <span class="nav-label">Settings</span>
         </button>
       </nav>
 
@@ -593,6 +596,201 @@
           </div>
         </div><!-- /#view-agents -->
 
+        <!-- ── View: Settings ──────────────────────────────────────── -->
+        <div id="view-settings" class="view">
+          <nav id="settings-subnav">
+            <button class="settings-subnav-item active" data-section="models">Models</button>
+            <button class="settings-subnav-item" data-section="tags">Tags</button>
+            <button class="settings-subnav-item" data-section="hotkey">Hotkey</button>
+            <button class="settings-subnav-item" data-section="worker">Worker</button>
+            <button class="settings-subnav-item" data-section="appearance">Appearance</button>
+            <button class="settings-subnav-item" data-section="data">Data</button>
+            <button class="settings-subnav-item" data-section="scheduled-export">Scheduled Export</button>
+          </nav>
+          <div id="settings-content">
+
+            <!-- Models panel -->
+            <div class="settings-panel" id="settings-tab-models">
+              <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
+              <div class="settings-field">
+                <label for="select-embed-model">Embedding model</label>
+                <select id="select-embed-model"></select>
+                <span class="settings-hint">Used for semantic search. Changing this will re-embed your entries over time.</span>
+              </div>
+              <div class="settings-field">
+                <label for="select-llm-model">LLM model (theme summaries)</label>
+                <select id="select-llm-model"></select>
+                <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
+              </div>
+            </div>
+
+            <!-- Tags panel -->
+            <div class="settings-panel hidden" id="settings-tab-tags">
+              <div class="settings-field">
+                <label for="select-tag-format">Multi-word tag format</label>
+                <select id="select-tag-format">
+                  <option value="hyphenated">Hyphenated (two-words)</option>
+                  <option value="concatenated">Concatenated (twowords)</option>
+                </select>
+                <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
+              </div>
+              <div class="settings-field">
+                <label for="select-similarity-threshold">Duplicate detection sensitivity</label>
+                <select id="select-similarity-threshold">
+                  <option value="0.93">Strict — near-identical meanings only</option>
+                  <option value="0.88">Balanced — recommended</option>
+                  <option value="0.82">Broad — more suggestions, more noise</option>
+                </select>
+                <span class="settings-hint">How closely two tags must be related (semantically) to appear as possible duplicates. Requires Ollama.</span>
+              </div>
+            </div>
+
+            <!-- Hotkey panel -->
+            <div class="settings-panel hidden" id="settings-tab-hotkey">
+              <div class="settings-field">
+                <label>Global shortcut</label>
+                <div class="hotkey-row">
+                  <span id="hotkey-display" class="hotkey-display"></span>
+                  <button id="btn-record-hotkey" class="btn-record-hotkey">Change</button>
+                </div>
+                <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
+                <span class="hotkey-conflict hidden" id="hotkey-conflict">&#9888; That shortcut is already claimed by another application.</span>
+              </div>
+            </div>
+
+            <!-- Worker panel -->
+            <div class="settings-panel hidden" id="settings-tab-worker">
+              <p class="settings-panel-desc">Tune how often background tasks run. Changes take effect immediately.</p>
+              <div class="settings-field">
+                <label for="input-interval-embedding">Embedding scan interval (seconds)</label>
+                <input type="number" id="input-interval-embedding" class="settings-number-input" min="10" max="3600" step="10" value="60" />
+                <span class="settings-hint">How often to check for new entries that need embedding. Default: 60 s.</span>
+              </div>
+              <div class="settings-field">
+                <label for="input-interval-clustering">Clustering interval (seconds)</label>
+                <input type="number" id="input-interval-clustering" class="settings-number-input" min="60" max="86400" step="60" value="300" />
+                <span class="settings-hint">How often to re-cluster entries into themes. Default: 300 s (5 min).</span>
+              </div>
+              <div class="settings-field">
+                <label for="input-interval-contradiction">Contradiction scan interval (seconds)</label>
+                <input type="number" id="input-interval-contradiction" class="settings-number-input" min="60" max="86400" step="60" value="900" />
+                <span class="settings-hint">How often to check for contradicting entries across themes. Default: 900 s (15 min).</span>
+              </div>
+              <div class="settings-field">
+                <label for="input-contradiction-scheduled-cap">Scheduled scan pair limit</label>
+                <input type="number" id="input-contradiction-scheduled-cap" class="settings-number-input" min="5" max="500" step="5" value="15" />
+                <span class="settings-hint">Max pairs the <em>scheduled</em> scan checks per run. Manual &#x201C;Scan now&#x201D; is always uncapped. Default: 15.</span>
+              </div>
+              <div class="settings-field">
+                <label>Contradiction scan scope</label>
+                <div class="theme-toggle-group" id="contradiction-scope-group">
+                  <button class="theme-toggle-btn active" data-scope-value="themes">Theme only</button>
+                  <button class="theme-toggle-btn" data-scope-value="tags">Tags also</button>
+                  <button class="theme-toggle-btn" data-scope-value="global">Global &#9888;</button>
+                </div>
+                <span class="settings-hint">Theme only: pairs within the same theme. Tags also: also compare entries sharing a tag. Global: all-pairs scan — expensive on large corpora.</span>
+              </div>
+              <div class="settings-field">
+                <label>Activity log <button id="btn-refresh-worker-log" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
+                <div id="worker-log-panel" class="worker-log-panel"><span class="worker-log-empty">No tasks recorded yet.</span></div>
+              </div>
+            </div>
+
+            <!-- Appearance panel -->
+            <div class="settings-panel hidden" id="settings-tab-appearance">
+              <p class="settings-panel-desc">Choose your preferred colour scheme.</p>
+              <div class="settings-field">
+                <label>Colour scheme</label>
+                <div class="theme-toggle-group" id="theme-toggle-group">
+                  <button class="theme-toggle-btn active" data-theme-value="dark">Dark</button>
+                  <button class="theme-toggle-btn" data-theme-value="light">Light</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Data panel -->
+            <div class="settings-panel hidden" id="settings-tab-data">
+              <div class="settings-field">
+                <label>Load demo content</label>
+                <button id="btn-load-demo" class="btn-secondary">Load Demo Content&#x2026;</button>
+                <span class="settings-hint">Imports 21 sample entries across 4 themes so you can explore Neurologue before adding your own notes. Existing entries are never overwritten.</span>
+              </div>
+              <div class="settings-field">
+                <label>Import from CCF snapshot</label>
+                <button id="btn-import-ccf" class="btn-secondary">Import CCF&#x2026;</button>
+                <span class="settings-hint">Load entries and themes from a previously exported CCF folder. Entries with matching IDs are skipped.</span>
+              </div>
+              <div class="settings-field">
+                <label>Start fresh</label>
+                <button id="btn-start-fresh" class="btn-danger">Start Fresh&#x2026;</button>
+                <span class="settings-hint">Permanently delete all entries, themes, and embeddings. You will be offered a CCF backup before anything is deleted.</span>
+              </div>
+              <div class="settings-field">
+                <label>Reindex all entries</label>
+                <button id="btn-reindex-all" class="btn-secondary">Reindex all entries&#x2026;</button>
+                <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
+              </div>
+            </div>
+
+            <!-- Scheduled Export panel -->
+            <div class="settings-panel hidden" id="settings-tab-scheduled-export">
+              <div class="settings-field">
+                <label>Enable scheduled exports</label>
+                <label class="toggle-label">
+                  <input type="checkbox" id="sched-enabled" />
+                  <span class="settings-hint">Automatically snapshot your corpus on a regular schedule.</span>
+                </label>
+              </div>
+              <div class="settings-field">
+                <label for="sched-frequency">Frequency</label>
+                <select id="sched-frequency">
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                </select>
+              </div>
+              <div class="settings-field">
+                <label>Destination folder</label>
+                <div class="sched-folder-row">
+                  <span id="sched-dest-display" class="sched-dest-display">Not set</span>
+                  <button id="btn-sched-choose-folder" class="btn-secondary btn-sm">Choose folder&#x2026;</button>
+                </div>
+                <span class="settings-hint">Each run creates a timestamped sub-folder here.</span>
+              </div>
+              <div class="settings-field">
+                <label class="toggle-label">
+                  <input type="checkbox" id="sched-include-diff" />
+                  Include diff.json (changes since last snapshot)
+                </label>
+              </div>
+              <div class="settings-field">
+                <label>Also transform to&#x2026;</label>
+                <div id="sched-adapter-checks" class="sched-adapter-checks">
+                  <!-- populated dynamically by library.js -->
+                </div>
+                <span class="settings-hint">Selected adapters run automatically after each scheduled snapshot.</span>
+              </div>
+              <div class="settings-field">
+                <label>Status</label>
+                <div id="sched-status-line" class="sched-status-line">&#x2014;</div>
+              </div>
+              <div class="settings-field">
+                <label>Run now <button id="btn-sched-run-now" class="btn-secondary btn-sm" style="margin-left:8px">Export now</button></label>
+                <span id="sched-run-feedback" class="settings-hint"></span>
+              </div>
+              <div class="settings-field">
+                <label>Export history <button id="btn-sched-refresh-history" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
+                <div id="sched-history-panel" class="sched-history-panel"><span class="worker-log-empty">No exports recorded yet.</span></div>
+              </div>
+            </div>
+
+            <div class="settings-actions">
+              <button class="btn-setup-primary" id="btn-save-settings">Save settings</button>
+              <span class="settings-saved hidden" id="settings-saved-msg">&#x2713; Saved</span>
+            </div>
+
+          </div><!-- /#settings-content -->
+        </div><!-- /#view-settings -->
+
       </div><!-- /#view-container -->
     </div><!-- /#shell -->
 
@@ -660,204 +858,9 @@
       </div>
     </div>
   </div>
-  <!-- ── Settings modal ────────────────────────────────────────────────────── -->
-  <div id="settings-modal" class="modal-overlay hidden">
-    <div class="modal-box modal-box--settings">
-      <button class="modal-close" id="settings-close" title="Close">✕</button>
-      <h2>Settings</h2>
+  <!-- settings moved to #view-settings inside #view-container (issue #137) -->
 
-      <div class="settings-tabs" role="tablist">
-        <button class="settings-tab active" data-tab="models" role="tab" aria-selected="true">Models</button>
-        <button class="settings-tab" data-tab="tags"    role="tab" aria-selected="false">Tags</button>
-        <button class="settings-tab" data-tab="hotkey"  role="tab" aria-selected="false">Hotkey</button>
-        <button class="settings-tab" data-tab="worker"     role="tab" aria-selected="false">Worker</button>
-        <button class="settings-tab" data-tab="appearance" role="tab" aria-selected="false">Appearance</button>
-        <button class="settings-tab" data-tab="data"       role="tab" aria-selected="false">Data</button>
-        <button class="settings-tab" data-tab="scheduled-export" role="tab" aria-selected="false">Scheduled Export</button>
-      </div>
-
-      <!-- Models panel -->
-      <div class="settings-panel" id="settings-tab-models">
-        <p>Choose which Ollama models Neurologue uses. Only models available in your local Ollama install are shown.</p>
-        <div class="settings-field">
-          <label for="select-embed-model">Embedding model</label>
-          <select id="select-embed-model"></select>
-          <span class="settings-hint">Used for semantic search. Changing this will re-embed your entries over time.</span>
-        </div>
-        <div class="settings-field">
-          <label for="select-llm-model">LLM model (theme summaries)</label>
-          <select id="select-llm-model"></select>
-          <span class="settings-hint">Used to generate human-readable theme descriptions.</span>
-        </div>
-      </div>
-
-      <!-- Tags panel -->
-      <div class="settings-panel hidden" id="settings-tab-tags">
-        <div class="settings-field">
-          <label for="select-tag-format">Multi-word tag format</label>
-          <select id="select-tag-format">
-            <option value="hyphenated">Hyphenated (two-words)</option>
-            <option value="concatenated">Concatenated (twowords)</option>
-          </select>
-          <span class="settings-hint">How suggested tags with multiple words are formatted when applied.</span>
-        </div>
-        <div class="settings-field">
-          <label for="select-similarity-threshold">Duplicate detection sensitivity</label>
-          <select id="select-similarity-threshold">
-            <option value="0.93">Strict — near-identical meanings only</option>
-            <option value="0.88">Balanced — recommended</option>
-            <option value="0.82">Broad — more suggestions, more noise</option>
-          </select>
-          <span class="settings-hint">How closely two tags must be related (semantically) to appear as possible duplicates. Requires Ollama.</span>
-        </div>
-      </div>
-
-      <!-- Hotkey panel -->
-      <div class="settings-panel hidden" id="settings-tab-hotkey">
-        <div class="settings-field">
-          <label>Global shortcut</label>
-          <div class="hotkey-row">
-            <span id="hotkey-display" class="hotkey-display"></span>
-            <button id="btn-record-hotkey" class="btn-record-hotkey">Change</button>
-          </div>
-          <span class="settings-hint">Global shortcut to open the capture popup. Must include at least one modifier key (Ctrl, Alt, Shift).</span>
-          <span class="hotkey-conflict hidden" id="hotkey-conflict">⚠ That shortcut is already claimed by another application.</span>
-        </div>
-      </div>
-
-      <!-- Worker panel -->
-      <div class="settings-panel hidden" id="settings-tab-worker">
-        <p class="settings-panel-desc">Tune how often background tasks run. Changes take effect immediately.</p>
-        <div class="settings-field">
-          <label for="input-interval-embedding">Embedding scan interval (seconds)</label>
-          <input type="number" id="input-interval-embedding" class="settings-number-input" min="10" max="3600" step="10" value="60" />
-          <span class="settings-hint">How often to check for new entries that need embedding. Default: 60 s.</span>
-        </div>
-        <div class="settings-field">
-          <label for="input-interval-clustering">Clustering interval (seconds)</label>
-          <input type="number" id="input-interval-clustering" class="settings-number-input" min="60" max="86400" step="60" value="300" />
-          <span class="settings-hint">How often to re-cluster entries into themes. Default: 300 s (5 min).</span>
-        </div>
-        <div class="settings-field">
-          <label for="input-interval-contradiction">Contradiction scan interval (seconds)</label>
-          <input type="number" id="input-interval-contradiction" class="settings-number-input" min="60" max="86400" step="60" value="900" />
-          <span class="settings-hint">How often to check for contradicting entries across themes. Default: 900 s (15 min).</span>
-        </div>
-        <div class="settings-field">
-          <label for="input-contradiction-scheduled-cap">Scheduled scan pair limit</label>
-          <input type="number" id="input-contradiction-scheduled-cap" class="settings-number-input" min="5" max="500" step="5" value="15" />
-          <span class="settings-hint">Max pairs the <em>scheduled</em> scan checks per run. Manual “Scan now” is always uncapped. Default: 15.</span>
-        </div>
-        <div class="settings-field">
-          <label>Contradiction scan scope</label>
-          <div class="theme-toggle-group" id="contradiction-scope-group">
-            <button class="theme-toggle-btn active" data-scope-value="themes">Theme only</button>
-            <button class="theme-toggle-btn" data-scope-value="tags">Tags also</button>
-            <button class="theme-toggle-btn" data-scope-value="global">Global ⚠</button>
-          </div>
-          <span class="settings-hint">Theme only: pairs within the same theme. Tags also: also compare entries sharing a tag. Global: all-pairs scan — expensive on large corpora.</span>
-        </div>
-        <div class="settings-field">
-          <label>Activity log <button id="btn-refresh-worker-log" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
-          <div id="worker-log-panel" class="worker-log-panel"><span class="worker-log-empty">No tasks recorded yet.</span></div>
-        </div>
-      </div>
-
-      <!-- Appearance panel -->
-      <div class="settings-panel hidden" id="settings-tab-appearance">
-        <p class="settings-panel-desc">Choose your preferred colour scheme.</p>
-        <div class="settings-field">
-          <label>Colour scheme</label>
-          <div class="theme-toggle-group" id="theme-toggle-group">
-            <button class="theme-toggle-btn active" data-theme-value="dark">Dark</button>
-            <button class="theme-toggle-btn" data-theme-value="light">Light</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Data panel -->
-      <div class="settings-panel hidden" id="settings-tab-data">
-        <div class="settings-field">
-          <label>Load demo content</label>
-          <button id="btn-load-demo" class="btn-secondary">Load Demo Content…</button>
-          <span class="settings-hint">Imports 21 sample entries across 4 themes so you can explore Neurologue before adding your own notes. Existing entries are never overwritten.</span>
-        </div>
-        <div class="settings-field">
-          <label>Import from CCF snapshot</label>
-          <button id="btn-import-ccf" class="btn-secondary">Import CCF…</button>
-          <span class="settings-hint">Load entries and themes from a previously exported CCF folder. Entries with matching IDs are skipped.</span>
-        </div>
-        <div class="settings-field">
-          <label>Start fresh</label>
-          <button id="btn-start-fresh" class="btn-danger">Start Fresh…</button>
-          <span class="settings-hint">Permanently delete all entries, themes, and embeddings. You will be offered a CCF backup before anything is deleted.</span>
-        </div>
-        <div class="settings-field">
-          <label>Reindex all entries</label>
-          <button id="btn-reindex-all" class="btn-secondary">Reindex all entries…</button>
-          <span class="settings-hint">Clears all stored embeddings and re-processes every entry. Use this after changing the embedding model, or if semantic search feels off. Requires Ollama.</span>
-        </div>
-      </div>
-
-      <!-- Scheduled Export panel -->
-      <div class="settings-panel hidden" id="settings-tab-scheduled-export">
-        <div class="settings-field">
-          <label>Enable scheduled exports</label>
-          <label class="toggle-label">
-            <input type="checkbox" id="sched-enabled" />
-            <span class="settings-hint">Automatically snapshot your corpus on a regular schedule.</span>
-          </label>
-        </div>
-        <div class="settings-field">
-          <label for="sched-frequency">Frequency</label>
-          <select id="sched-frequency">
-            <option value="daily">Daily</option>
-            <option value="weekly">Weekly</option>
-          </select>
-        </div>
-        <div class="settings-field">
-          <label>Destination folder</label>
-          <div class="sched-folder-row">
-            <span id="sched-dest-display" class="sched-dest-display">Not set</span>
-            <button id="btn-sched-choose-folder" class="btn-secondary btn-sm">Choose folder…</button>
-          </div>
-          <span class="settings-hint">Each run creates a timestamped sub-folder here.</span>
-        </div>
-        <div class="settings-field">
-          <label class="toggle-label">
-            <input type="checkbox" id="sched-include-diff" />
-            Include diff.json (changes since last snapshot)
-          </label>
-        </div>
-        <div class="settings-field">
-          <label>Also transform to…</label>
-          <div id="sched-adapter-checks" class="sched-adapter-checks">
-            <!-- populated dynamically by library.js -->
-          </div>
-          <span class="settings-hint">Selected adapters run automatically after each scheduled snapshot.</span>
-        </div>
-        <div class="settings-field">
-          <label>Status</label>
-          <div id="sched-status-line" class="sched-status-line">—</div>
-        </div>
-        <div class="settings-field">
-          <label>Run now <button id="btn-sched-run-now" class="btn-secondary btn-sm" style="margin-left:8px">Export now</button></label>
-          <span id="sched-run-feedback" class="settings-hint"></span>
-        </div>
-        <div class="settings-field">
-          <label>Export history <button id="btn-sched-refresh-history" class="btn-secondary btn-sm" style="margin-left:8px">Refresh</button></label>
-          <div id="sched-history-panel" class="sched-history-panel"><span class="worker-log-empty">No exports recorded yet.</span></div>
-        </div>
-      </div>
-
-      <div class="settings-actions">
-        <button class="btn-setup-primary" id="btn-save-settings">Save settings</button>
-        <span class="settings-saved hidden" id="settings-saved-msg">✓ Saved</span>
-      </div>
-    </div>
-  </div>
-
-  <!-- ── Export modal ──────────────────────────────────────────────────────── -->
+    <!-- ── Export modal ──────────────────────────────────────────────────────── -->
   <div id="export-modal" class="modal-overlay hidden">
     <div class="modal-box modal-box--export">
       <button class="modal-close" id="export-modal-close" title="Cancel">✕</button>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -108,6 +108,7 @@
           <button id="btn-heatmap-toggle" class="tl-grp-btn" title="Toggle activity heatmap">Heatmap</button>
         </div>
         <div id="heatmap-panel" class="hidden">
+          <div id="heatmap-years"></div>
           <div id="heatmap-months"></div>
           <div id="heatmap-grid"></div>
         </div>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -162,6 +162,7 @@ html, body {
 }
 .nav-item:hover { background: var(--surface2); color: var(--text-muted); }
 .nav-item.active { background: var(--surface2); color: var(--cortex-teal); }
+.nav-item--settings { margin-top: auto; }
 
 .nav-icon {
   font-size: 16px;
@@ -1771,42 +1772,55 @@ html, body {
   width: 0%;
 }
 
-/* ── Settings modal fields ──────────────────────────────────────────────── */
-.modal-box--settings {
-  max-width: 500px;
+/* ── Settings view ─────────────────────────────────────────────────────── */
+#view-settings {
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
 }
 
-/* Tab bar */
-.settings-tabs {
+#settings-subnav {
+  width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 24px 0;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 2px;
-  border-bottom: 1px solid var(--border);
-  margin: 12px 0 20px;
+  overflow-y: auto;
 }
-.settings-tab {
+
+.settings-subnav-item {
   background: none;
   border: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  color: var(--text-dim);
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 6px 14px 8px;
+  border-left: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  padding: 8px 16px;
   cursor: pointer;
-  border-radius: var(--radius) var(--radius) 0 0;
-  transition: color 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
-.settings-tab:hover { color: var(--text-muted); }
-.settings-tab.active {
+.settings-subnav-item:hover {
+  color: var(--text);
+  background: var(--surface2);
+}
+.settings-subnav-item.active {
   color: var(--cortex-teal);
-  border-bottom-color: var(--cortex-teal);
+  background: var(--surface2);
+  border-left-color: var(--cortex-teal);
 }
 
-/* Tab panels */
-.settings-panel { min-height: 140px; }
+#settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 40px;
+  max-width: 640px;
+}
+
+/* Section panels */
+.settings-panel { display: block; }
 .settings-panel.hidden { display: none; }
 
 .settings-field {

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -509,6 +509,14 @@ html, body {
 }
 #heatmap-panel.hidden { display: none; }
 
+#heatmap-years {
+  height: 13px;
+  margin-bottom: 1px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
 #heatmap-months {
   height: 14px;
   margin-bottom: 4px;

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -1774,7 +1774,6 @@ html, body {
 
 /* ── Settings view ─────────────────────────────────────────────────────── */
 #view-settings {
-  display: flex;
   flex-direction: row;
   overflow: hidden;
 }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -254,6 +254,8 @@ function updateCount(total) {
 async function renderHeatmap() {
   heatmapGrid.innerHTML = '';
   heatmapMonths.innerHTML = '';
+  const heatmapYears = document.getElementById('heatmap-years');
+  heatmapYears.innerHTML = '';
 
   const data = await window.neurologue.getActivity();
   const countMap = {};
@@ -294,12 +296,9 @@ async function renderHeatmap() {
         cell.title = `${key}: ${count} entr${count === 1 ? 'y' : 'ies'}`;
 
         if (d === 0 && cellDate.getMonth() !== lastMonth) {
-          const isJan = cellDate.getMonth() === 0;
           monthLabels.push({
             col: w,
-            label: isJan
-              ? String(cellDate.getFullYear())
-              : cellDate.toLocaleDateString(undefined, { month: 'short' }),
+            label: cellDate.toLocaleDateString(undefined, { month: 'short' }),
           });
           lastMonth = cellDate.getMonth();
         }
@@ -309,6 +308,29 @@ async function renderHeatmap() {
     }
     heatmapGrid.appendChild(weekEl);
   }
+
+  // Render year labels: one per year, at the column of the first visible month of that year
+  const yearLabels = [];
+  let lastYear = -1;
+  monthLabels.forEach(({ col, label }) => {
+    // find the cellDate for this column's first day to get the year
+    const cellDate = new Date(startDate);
+    cellDate.setDate(startDate.getDate() + col * 7);
+    const yr = cellDate.getFullYear();
+    if (yr !== lastYear) {
+      yearLabels.push({ col, label: String(yr) });
+      lastYear = yr;
+    }
+  });
+
+  heatmapYears.style.position = 'relative';
+  yearLabels.forEach(({ col, label }) => {
+    const span = document.createElement('span');
+    span.textContent = label;
+    span.style.position = 'absolute';
+    span.style.left = `${col * WEEK_PX}px`;
+    heatmapYears.appendChild(span);
+  });
 
   // Render month labels using absolute positioning.
   // Skip a label if it would be within 28px of the previous one (prevents overlap

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -307,13 +307,19 @@ async function renderHeatmap() {
     heatmapGrid.appendChild(weekEl);
   }
 
-  // Render month labels using absolute positioning
+  // Render month labels using absolute positioning.
+  // Skip a label if it would be within 28px of the previous one (prevents overlap
+  // when a month boundary falls close to the start of the 52-week window).
   heatmapMonths.style.position = 'relative';
+  let lastLabelX = -Infinity;
   monthLabels.forEach(({ col, label }) => {
+    const x = col * WEEK_PX;
+    if (x - lastLabelX < 28) return;
+    lastLabelX = x;
     const span = document.createElement('span');
     span.textContent = label;
     span.style.position = 'absolute';
-    span.style.left = `${col * WEEK_PX}px`;
+    span.style.left = `${x}px`;
     heatmapMonths.appendChild(span);
   });
 }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1284,11 +1284,10 @@ window.neurologue.onWorkerTaskCompleted(({ task, status, message }) => {
   }
 });
 
-// Clicking the error badge opens Settings → Worker tab
-statusErrorBadge.addEventListener('click', () => {
-  settingsModal.classList.remove('hidden');
-  window.neurologue.pauseHotkey();
-  activateSettingsTab('worker');
+// Clicking the error badge opens Settings → Worker section
+statusErrorBadge.addEventListener('click', async () => {
+  activateView('settings');
+  await loadSettingsView('worker');
   renderWorkerLog();
 });
 
@@ -1347,8 +1346,6 @@ window.neurologue.onContradictionsUpdated(() => loadContradictionsView());
 // ── Setup + settings modals ────────────────────────────────────────
 
 const setupModal    = document.getElementById('setup-modal');
-const settingsModal = document.getElementById('settings-modal');
-const btnSettings   = document.getElementById('btn-settings');
 
 function showSetupStep(stepId) {
   document.querySelectorAll('.setup-step').forEach((el) => el.classList.add('hidden'));
@@ -1463,22 +1460,20 @@ document.getElementById('btn-recheck-running').addEventListener('click', async (
 
 document.getElementById('btn-pull-all').addEventListener('click', pullAllMissing);
 
-// ── Settings modal ─────────────────────────────────────────────────
+// ── Settings view ──────────────────────────────────────────────────
 
-// Tab switching
-function activateSettingsTab(name) {
-  document.querySelectorAll('.settings-tab').forEach((t) => {
-    const active = t.dataset.tab === name;
-    t.classList.toggle('active', active);
-    t.setAttribute('aria-selected', String(active));
+// Section switching
+function activateSettingsSection(name) {
+  document.querySelectorAll('.settings-subnav-item').forEach((t) => {
+    t.classList.toggle('active', t.dataset.section === name);
   });
   document.querySelectorAll('.settings-panel').forEach((p) => {
     p.classList.toggle('hidden', p.id !== `settings-tab-${name}`);
   });
 }
 
-document.querySelectorAll('.settings-tab').forEach((tab) => {
-  tab.addEventListener('click', () => activateSettingsTab(tab.dataset.tab));
+document.querySelectorAll('.settings-subnav-item').forEach((item) => {
+  item.addEventListener('click', () => activateSettingsSection(item.dataset.section));
 });
 
 // ── Hotkey recorder ─────────────────────────────────────────────────────────
@@ -1528,6 +1523,7 @@ function onHotkeyKeydown(e) {
 
 function startHotkeyRecording() {
   _recordingHotkey = true;
+  window.neurologue.pauseHotkey();
   hotkeyDisplay.textContent = 'Press keys…';
   hotkeyDisplay.classList.add('recording');
   btnRecord.textContent = 'Cancel';
@@ -1538,6 +1534,7 @@ function startHotkeyRecording() {
 
 function stopHotkeyRecording(restore) {
   _recordingHotkey = false;
+  window.neurologue.resumeHotkey();
   document.removeEventListener('keydown', onHotkeyKeydown, { capture: true });
   hotkeyDisplay.classList.remove('recording');
   btnRecord.textContent = 'Change';
@@ -1555,7 +1552,7 @@ btnRecord.addEventListener('click', () => {
 });
 // ────────────────────────────────────────────────────────────────────────────
 
-btnSettings.addEventListener('click', async () => {
+async function loadSettingsView(section = 'models') {
   _pendingHotkey = null;
   hotkeyConflict.classList.add('hidden');
   const [settings, status] = await Promise.all([
@@ -1615,16 +1612,8 @@ btnSettings.addEventListener('click', async () => {
     btn.classList.toggle('active', btn.dataset.scopeValue === scope);
   });
 
-  activateSettingsTab('models');
-  settingsModal.classList.remove('hidden');
-  window.neurologue.pauseHotkey();
-});
-
-document.getElementById('settings-close').addEventListener('click', () => {
-  if (_recordingHotkey) stopHotkeyRecording(true);
-  settingsModal.classList.add('hidden');
-  window.neurologue.resumeHotkey();
-});
+  activateSettingsSection(section);
+}
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
   const embedModel = document.getElementById('select-embed-model').value;
@@ -1675,9 +1664,6 @@ document.getElementById('btn-reindex-all').addEventListener('click', async () =>
   );
   if (!confirmed) return;
   const { queued } = await window.neurologue.reindexAll();
-  const settingsModal = document.getElementById('settings-modal');
-  settingsModal.classList.add('hidden');
-  window.neurologue.resumeHotkey();
   console.info(`[library] Reindex started — ${queued} entries queued`);
 });
 
@@ -2241,7 +2227,10 @@ function activateView(viewId) {
 }
 
 navItems.forEach(btn => {
-  btn.addEventListener('click', () => activateView(btn.dataset.view));
+  btn.addEventListener('click', async () => {
+    activateView(btn.dataset.view);
+    if (btn.dataset.view === 'settings') await loadSettingsView();
+  });
 });
 
 // ── Themes view controller ───────────────────────────────────────────────────

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1613,6 +1613,7 @@ async function loadSettingsView(section = 'models') {
   });
 
   activateSettingsSection(section);
+  if (section === 'scheduled-export') await loadSchedSettings();
 }
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
@@ -1945,10 +1946,10 @@ document.getElementById('btn-sched-run-now').addEventListener('click', async () 
 
 document.getElementById('btn-sched-refresh-history').addEventListener('click', renderSchedHistory);
 
-// Load scheduled export settings when that tab is activated
-document.querySelectorAll('.settings-tab').forEach((tab) => {
-  if (tab.dataset.tab === 'scheduled-export') {
-    tab.addEventListener('click', loadSchedSettings);
+// Load scheduled export settings when that section is activated
+document.querySelectorAll('.settings-subnav-item').forEach((item) => {
+  if (item.dataset.section === 'scheduled-export') {
+    item.addEventListener('click', loadSchedSettings);
   }
 });
 

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -294,9 +294,12 @@ async function renderHeatmap() {
         cell.title = `${key}: ${count} entr${count === 1 ? 'y' : 'ies'}`;
 
         if (d === 0 && cellDate.getMonth() !== lastMonth) {
+          const isJan = cellDate.getMonth() === 0;
           monthLabels.push({
             col: w,
-            label: cellDate.toLocaleDateString(undefined, { month: 'short' }),
+            label: isJan
+              ? String(cellDate.getFullYear())
+              : cellDate.toLocaleDateString(undefined, { month: 'short' }),
           });
           lastMonth = cellDate.getMonth();
         }


### PR DESCRIPTION
## Summary

Converts Settings from a modal dialog to a first-class navigation view, completing issue #137. Also bundles two heatmap fixes (#134).

## Changes

### #137 — Settings as main nav view
- **Nav rail**: Added ⚙ Settings item pinned to the bottom of the rail (margin-top: auto), following VS Code / Slack convention for config destinations
- **Removed** toolbar ⚙ button; settings is now reached via the nav rail
- **New #view-settings**: two-column layout — 160px left sub-nav + scrollable right content pane (max-width: 640px)
- Replaced horizontal tab bar with vertical settings-subnav-item list (active state uses left border indicator)
- ctivateSettingsTab → ctivateSettingsSection using data-section attributes
- Extracted loadSettingsView(section) async function; called on nav click and directly by the error badge with loadSettingsView('worker')
- pauseHotkey/esumeHotkey moved into startHotkeyRecording/stopHotkeyRecording — correct location (only needed during key capture)
- Removed modal overlay and close button
- Fixed stale .settings-tab listener for scheduled-export → now .settings-subnav-item; loadSettingsView calls loadSchedSettings() when navigating to that section directly

### #134 — Heatmap month label fixes
- Suppress labels that would land within 28px of the previous one (prevents collision at window boundary)
- Add #heatmap-years row above months: one year label per calendar year at its first visible column, giving clear year-boundary markers without sacrificing month abbreviations

## Tests
463/463 passing