### PR TITLE
feat: worker log as status-bar popup panel (#138)

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -795,10 +795,19 @@
       </div><!-- /#view-container -->
     </div><!-- /#shell -->
 
-    <!-- ── Status bar ───────────────────────────────────────────────── -->
+    <!-- ── Worker log popup ──────────────────────────────────────── -->
+    <div id="worker-log-popup" class="hidden">
+      <div id="worker-log-popup-header">
+        <span>Activity log</span>
+        <button id="worker-log-popup-close" title="Close">&#x2715;</button>
+      </div>
+      <div id="worker-log-popup-body"></div>
+    </div>
+
+    <!-- ── Status bar ────────────────────────────────────────── -->
     <div id="status-bar">
       <span id="status-ollama"></span>
-      <span id="status-worker"></span>
+      <button id="status-worker" title="Click to view activity log"></button>
       <span id="status-task" class="status-task hidden"></span>
       <span id="status-error-badge" class="status-error-badge hidden" title="Worker error — click to view log">⚠ error</span>
     </div>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -2221,6 +2221,67 @@ html, body {
 @keyframes spin { to { transform: rotate(360deg); } }
 @keyframes status-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
 
+/* ── Status bar worker button ─────────────────────────────────────────── */
+#status-worker {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  border-radius: var(--radius);
+}
+#status-worker:hover { color: var(--text); }
+
+/* ── Worker log popup ─────────────────────────────────────────────────── */
+#worker-log-popup {
+  position: fixed;
+  bottom: 32px; /* just above status bar */
+  left: 64px;   /* clear of the nav rail */
+  width: 480px;
+  max-height: 320px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  z-index: 300;
+}
+#worker-log-popup.hidden { display: none; }
+
+#worker-log-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex-shrink: 0;
+}
+#worker-log-popup-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 5px;
+  border-radius: var(--radius);
+  line-height: 1;
+}
+#worker-log-popup-close:hover { color: var(--text); background: var(--surface2); }
+
+#worker-log-popup-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px 0;
+  font-size: 12px;
+}
+
 .status-error-badge {
   font-size: 10px;
   font-weight: 700;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1315,11 +1315,10 @@ window.neurologue.onWorkerTaskCompleted(({ task, status, message }) => {
   }
 });
 
-// Clicking the error badge opens Settings → Worker section
-statusErrorBadge.addEventListener('click', async () => {
-  activateView('settings');
-  await loadSettingsView('worker');
-  renderWorkerLog();
+// Clicking the error badge opens the worker log popup
+statusErrorBadge.addEventListener('click', async (e) => {
+  e.stopPropagation();
+  await openWorkerLogPopup();
 });
 
 window.neurologue.onWorkerStatus(updateStatus);
@@ -1645,6 +1644,7 @@ async function loadSettingsView(section = 'models') {
 
   activateSettingsSection(section);
   if (section === 'scheduled-export') await loadSchedSettings();
+  if (section === 'worker') await renderWorkerLog();
 }
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
@@ -1791,8 +1791,8 @@ function _formatWLTime(iso) {
   return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
-async function renderWorkerLog() {
-  const panel = document.getElementById('worker-log-panel');
+async function renderWorkerLog(panelEl) {
+  const panel = panelEl || document.getElementById('worker-log-panel');
   if (!panel) return;
   const entries = await window.neurologue.getWorkerLog();
   panel.innerHTML = '';
@@ -1836,13 +1836,48 @@ async function renderWorkerLog() {
   });
 }
 
-document.getElementById('btn-refresh-worker-log').addEventListener('click', renderWorkerLog);
+document.getElementById('btn-refresh-worker-log').addEventListener('click', () => renderWorkerLog());
 
-// Load the worker log whenever the Worker settings tab is activated
-document.querySelectorAll('.settings-tab').forEach((tab) => {
-  if (tab.dataset.tab === 'worker') {
-    tab.addEventListener('click', renderWorkerLog);
+// Load the worker log whenever the Worker settings section is activated
+document.querySelectorAll('.settings-subnav-item').forEach((item) => {
+  if (item.dataset.section === 'worker') {
+    item.addEventListener('click', () => renderWorkerLog());
   }
+});
+
+// ── Worker log popup ──────────────────────────────────────────────────
+
+const workerLogPopup      = document.getElementById('worker-log-popup');
+const workerLogPopupBody  = document.getElementById('worker-log-popup-body');
+const statusWorkerBtn     = document.getElementById('status-worker');
+
+function _isPopupOpen() { return !workerLogPopup.classList.contains('hidden'); }
+
+async function openWorkerLogPopup() {
+  workerLogPopup.classList.remove('hidden');
+  await renderWorkerLog(workerLogPopupBody);
+}
+
+function closeWorkerLogPopup() {
+  workerLogPopup.classList.add('hidden');
+}
+
+statusWorkerBtn.addEventListener('click', async (e) => {
+  e.stopPropagation();
+  if (_isPopupOpen()) { closeWorkerLogPopup(); return; }
+  await openWorkerLogPopup();
+});
+
+document.getElementById('worker-log-popup-close').addEventListener('click', closeWorkerLogPopup);
+
+document.addEventListener('click', (e) => {
+  if (_isPopupOpen() && !workerLogPopup.contains(e.target) && e.target !== statusWorkerBtn) {
+    closeWorkerLogPopup();
+  }
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && _isPopupOpen()) closeWorkerLogPopup();
 });
 
 // ── Scheduled Export settings ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #138. The worker activity log is now accessible directly from the status bar without opening Settings.

## Changes

- **#status-worker** converted from <span> to <button> — clickable to toggle the popup; hover state for discoverability
- **#worker-log-popup**: fixed panel anchored just above the status bar (bottom: 32px, left: 64px to clear the nav rail), 480px wide, max-height 320px with scroll — identical log rows to the Settings panel
- Dismissed by clicking outside, pressing Escape, or the ✕ close button
- **Error badge** now opens the popup directly (previously navigated to Settings → Worker)
- **enderWorkerLog(panelEl?)** generalised to accept an optional target element — popup body and Settings → Worker inline panel share the same render logic
- Fixed stale \.settings-tab[data-tab=worker]\ listener → \.settings-subnav-item[data-section=worker]\
- \loadSettingsView('worker')\ also calls \enderWorkerLog()\ for direct navigation

## Tests
463/463 passing