### PR TITLE
feat: minimal Electron menu bar (#139)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow, globalShortcut, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, globalShortcut, ipcMain, shell, Menu } = require('electron');
 const path = require('path');
 const { runMigrations } = require('./db/migrate');
 const { initVectorStore, searchNearest, deleteVector } = require('./backend/vector/store');
@@ -629,6 +629,29 @@ handle('export:adapter', async (_event, { id } = {}) => {
 
 app.whenReady().then(async () => {
   await initialise();
+
+  // Minimal application menu — removes default nav/view clutter
+  const isMac = process.platform === 'darwin';
+  const template = [
+    ...(isMac ? [{ role: 'appMenu' }] : []),
+    { role: 'editMenu' },
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: `About Neurologue v${app.getVersion()}`,
+          click: () => {
+            const win = BrowserWindow.getFocusedWindow();
+            if (win) win.webContents.send('app:show-about');
+          },
+        },
+        { type: 'separator' },
+        { label: 'Open DevTools', accelerator: 'CmdOrCtrl+Shift+I', click: () => BrowserWindow.getFocusedWindow()?.webContents.openDevTools() },
+      ],
+    },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+
   createMainWindow();
   const { captureHotkey } = getSettings();
   registerCaptureHotkey(captureHotkey);


### PR DESCRIPTION
## Summary

Closes #139.

Replaces Electron's default menu (which duplicated nav views and added noise) with a minimal custom menu:

- **App** (macOS only — standard app menu role)
- **Edit** — cut, copy, paste, select all via \ole: 'editMenu'\
- **Help** — About Neurologue (sends \pp:show-about\ IPC to renderer), Open DevTools

Navigation items that duplicated the nav rail are removed. No existing IPC-triggered actions are broken.

## Tests
463/463 passing