### PR TITLE
feat: navigation history + back button (#136)

### DIFF
--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -33,6 +33,7 @@ const DEFAULTS = {
   contradictionScheduledCap: 15, // max pairs checked per scheduled scan run
   theme: 'dark',          // 'dark' | 'light'
   homeView: 'library',    // view id to show on launch
+  navHistoryLimit: 10,    // max entries in session nav stack
   scheduledExport: {
     enabled:     false,
     frequency:   'daily',   // 'daily' | 'weekly'

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -14,6 +14,7 @@
     <!-- ── Toolbar ─────────────────────────────────────────────────── -->
     <div id="toolbar">
       <span class="logo">Neurologue</span>
+      <button id="btn-back" class="btn-back hidden" title="Back (Alt+Left)">&#8592;</button>
       <input id="search-input" type="text" placeholder="Search entries…" autocomplete="off" />
       <div id="search-mode">
         <button id="btn-text" class="mode-btn active">Text</button>

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -73,9 +73,23 @@ html, body {
   font-size: 15px;
   color: var(--cortex-teal);
   letter-spacing: 0.04em;
-  margin-right: 8px;
+  margin-right: 4px;
   white-space: nowrap;
 }
+
+.btn-back {
+  padding: 4px 8px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-muted);
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.btn-back:hover { border-color: var(--cortex-teal); color: var(--text); }
+.btn-back.hidden { display: none; }
 
 #search-input {
   flex: 1;

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -2280,7 +2280,34 @@ const navItems        = document.querySelectorAll('.nav-item');
 const views           = document.querySelectorAll('.view');
 const libraryOnlyEls  = document.querySelectorAll('.toolbar-library-only');
 
+// Session-only navigation history stack
+let _navHistory      = [];   // stack of viewIds
+let _navHistoryLimit = 10;   // overridden from settings on init
+let _isNavigatingBack = false;
+
+const btnBack = document.getElementById('btn-back');
+
+function _updateBackButton() {
+  btnBack.classList.toggle('hidden', _navHistory.length === 0);
+}
+
+function navigateBack() {
+  if (_navHistory.length === 0) return;
+  const prev = _navHistory.pop();
+  _isNavigatingBack = true;
+  activateView(prev);
+  _isNavigatingBack = false;
+  _updateBackButton();
+}
+
 function activateView(viewId) {
+  const current = document.querySelector('.nav-item.active')?.dataset.view;
+  if (!_isNavigatingBack && current && current !== viewId) {
+    _navHistory.push(current);
+    if (_navHistory.length > _navHistoryLimit) _navHistory.shift();
+    _updateBackButton();
+  }
+
   navItems.forEach(btn => btn.classList.toggle('active', btn.dataset.view === viewId));
   views.forEach(v   => v.classList.toggle('active-view', v.id === `view-${viewId}`));
 
@@ -2297,6 +2324,15 @@ function activateView(viewId) {
   // Destroy graph renderer when leaving the graph view
   if (viewId !== 'graph')          _destroyGraphIfActive();
 }
+
+btnBack.addEventListener('click', navigateBack);
+
+document.addEventListener('keydown', (e) => {
+  if (e.altKey && e.key === 'ArrowLeft' && !e.ctrlKey && !e.metaKey) {
+    e.preventDefault();
+    navigateBack();
+  }
+});
 
 navItems.forEach(btn => {
   btn.addEventListener('click', async () => {
@@ -3511,6 +3547,7 @@ function _escHtml(str) {
   // Apply persisted theme before first paint
   const initSettings = await window.neurologue.getSettings();
   applyTheme(initSettings.theme || 'dark');
+  _navHistoryLimit = initSettings.navHistoryLimit ?? 10;
 
   // Navigate to the user's chosen home view
   const homeView = initSettings.homeView || 'library';


### PR DESCRIPTION
## Summary

Closes #136.

## Changes

- **Back button** (←) appears in the toolbar whenever there is navigation history to return to; hidden otherwise
- **Alt+Left** keyboard shortcut triggers the same back action
- **Session-only stack**: each ctivateView() call pushes the current view; capped at 
avHistoryLimit (default 10, stored in settings)
- **\settings.js\**: \
avHistoryLimit: 10\ added to DEFAULTS
- Stack is never persisted — cleared on app restart

## Not in scope
Recent-views dropdown (optional per issue) — the back button satisfies the primary acceptance criteria.

## Tests
463/463 passing