### PR TITLE
fix: capture window draft persistence (#124)

### DIFF
--- a/src/capture/hotkey.js
+++ b/src/capture/hotkey.js
@@ -86,7 +86,8 @@ function openCaptureWindow() {
   });
 
   _captureWin.on('blur', () => {
-    // Close the popup if it loses focus (user clicked away)
+    // Close the popup if it loses focus (user clicked away).
+    // Draft is auto-saved by the renderer on input, so content is preserved.
     if (_captureWin && !_captureWin.isDestroyed()) {
       _captureWin.close();
     }
@@ -164,4 +165,58 @@ function resumeCaptureHotkey() {
   if (_currentHotkey) globalShortcut.register(_currentHotkey, openCaptureWindow);
 }
 
-module.exports = { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow, closeCaptureWindow, DEFAULT_HOTKEY };
+// ── Draft persistence ─────────────────────────────────────────────────────
+
+function _draftFile() {
+  try {
+    return path.join(app.getPath('userData'), 'capture-draft.json');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a capture draft to disk. Clears the draft if content is empty.
+ * @param {{ content: string, tags: string }} data
+ */
+function saveDraft({ content, tags }) {
+  try {
+    const file = _draftFile();
+    if (!file) return;
+    if (!content || !content.trim()) {
+      clearDraft();
+      return;
+    }
+    fs.writeFileSync(file, JSON.stringify({ content, tags: tags || '' }), 'utf8');
+  } catch {
+    // non-fatal
+  }
+}
+
+/**
+ * Load a previously saved draft, or return null if none exists.
+ * @returns {{ content: string, tags: string } | null}
+ */
+function loadDraft() {
+  try {
+    const file = _draftFile();
+    if (!file || !fs.existsSync(file)) return null;
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete the draft file, if present.
+ */
+function clearDraft() {
+  try {
+    const file = _draftFile();
+    if (file && fs.existsSync(file)) fs.unlinkSync(file);
+  } catch {
+    // non-fatal
+  }
+}
+
+module.exports = { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow, closeCaptureWindow, DEFAULT_HOTKEY, saveDraft, loadDraft, clearDraft };

--- a/src/frontend/capture-preload.js
+++ b/src/frontend/capture-preload.js
@@ -18,4 +18,9 @@ contextBridge.exposeInMainWorld('capture', {
 
   /** Read persisted settings. */
   getSettings: () => ipcRenderer.invoke('settings:get'),
+
+  /** Draft persistence — survives accidental blur/dismiss. */
+  saveDraft:  (data) => ipcRenderer.invoke('capture:save-draft', data),
+  loadDraft:  ()     => ipcRenderer.invoke('capture:load-draft'),
+  clearDraft: ()     => ipcRenderer.invoke('capture:clear-draft'),
 });

--- a/src/frontend/capture.js
+++ b/src/frontend/capture.js
@@ -20,6 +20,16 @@ let _mdMode       = false;
 let _previewMode  = false;
 let _pastePlain   = false;
 let _suggestTimer = null;
+let _draftTimer   = null;
+
+// ── Draft helpers ─────────────────────────────────────────────────────────
+
+function _scheduleDraftSave() {
+  clearTimeout(_draftTimer);
+  _draftTimer = setTimeout(() => {
+    window.capture.saveDraft({ content: contentEl.value, tags: tagsEl.value });
+  }, 800);
+}
 
 // ── Tag suggestions ───────────────────────────────────────────────────────
 
@@ -81,7 +91,11 @@ contentEl.addEventListener('input', () => {
   // Debounce tag suggestions — fire 900ms after user stops typing
   clearTimeout(_suggestTimer);
   _suggestTimer = setTimeout(_fetchSuggestions, 900);
+  // Auto-save draft
+  _scheduleDraftSave();
 });
+
+tagsEl.addEventListener('input', _scheduleDraftSave);
 
 // ── Markdown toggle ───────────────────────────────────────────────────────
 
@@ -254,6 +268,7 @@ document.getElementById('tb-link')  .addEventListener('click', () => wrapSelecti
 
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
+    window.capture.clearDraft(); // explicit discard — don't restore next time
     window.capture.close();
     return;
   }
@@ -319,6 +334,7 @@ async function save() {
   try {
     const result = await window.capture.save({ content, tags });
     if (result.ok) {
+      window.capture.clearDraft(); // saved successfully — no need to restore
       window.capture.close();
     } else {
       showError('Failed to save. Please try again.');
@@ -344,7 +360,21 @@ function hideError() {
 
 contentEl.focus();
 
-// Apply persisted theme
+// Apply persisted theme + restore any unsaved draft
 window.capture.getSettings().then((s) => {
   document.documentElement.setAttribute('data-theme', (s && s.theme) || 'dark');
+});
+
+window.capture.loadDraft().then((draft) => {
+  if (draft && draft.content && draft.content.trim()) {
+    contentEl.value = draft.content;
+    tagsEl.value    = draft.tags || '';
+    saveBtn.disabled = false;
+    // Brief visual cue that a draft was restored
+    const hint = document.querySelector('.titlebar__hint');
+    if (hint) {
+      hint.textContent = 'Draft restored — Esc to discard';
+      hint.style.color = 'var(--cortex-teal, #2AA6A1)';
+    }
+  }
 });

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ const { exportCCF }  = require('./backend/export/ccf');
 const { importCCF }  = require('./backend/import/ccf-import');
 const { listAdapters, getAdapter } = require('./backend/export/adapters/registry');
 const { startScheduler, stopScheduler, runScheduledExport, getExportHistory, getSchedulerStatus } = require('./backend/export/scheduler/index');
-const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow } = require('./capture/hotkey');
+const { registerCaptureHotkey, reRegisterCaptureHotkey, pauseCaptureHotkey, resumeCaptureHotkey, openCaptureWindow, saveDraft, loadDraft, clearDraft } = require('./capture/hotkey');
 const { startWorker, stopWorker, setMainWindow, workerStatus, getWorkerLog, setWorkerIntervals, reindexAll, reindexEntry, scanContradictions, cancelContradictionScan, resetContradictionCursor, recomputeMetrics } = require('./worker/index');
 const { listLatestThemeMetrics, getThemeMetricsHistory, listThemesWithDrift } = require('./backend/db/theme_metrics');
 const { getDashboardSummary } = require('./backend/db/dashboard');
@@ -85,6 +85,11 @@ ipcMain.on('capture:close', (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (win) win.close();
 });
+
+// IPC: capture draft persistence
+ipcMain.handle('capture:save-draft', (_event, data) => { saveDraft(data); return { ok: true }; });
+ipcMain.handle('capture:load-draft', ()           => loadDraft());
+ipcMain.handle('capture:clear-draft', ()          => { clearDraft(); return { ok: true }; });
 
 // ── Library IPC ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #124.

## Problem
Alt+Tabbing away from the capture window triggered blur → close, silently discarding any typed content.

## Solution
The blur→close behaviour is kept (good UX for an always-on-top popup), but content is now preserved via automatic draft persistence:

1. **Auto-save** — 800ms after the user stops typing (debounced), content + tags are written to \userData/capture-draft.json\
2. **Restore on open** — when the capture window opens, if a draft exists it is restored and the titlebar shows *'Draft restored — Esc to discard'* in teal
3. **Clear on intent** — Escape (explicit discard) and a successful Ctrl+Enter save both call \clearDraft()\, so stale content is never re-surfaced

## Changed files
| File | Change |
|---|---|
| \src/capture/hotkey.js\ | \saveDraft\ / \loadDraft\ / \clearDraft\ helpers |
| \src/main.js\ | IPC handlers \capture:save-draft\, \capture:load-draft\, \capture:clear-draft\ |
| \src/frontend/capture-preload.js\ | Expose three draft IPC calls |
| \src/frontend/capture.js\ | Auto-save on input; restore on load; clear on save/discard |

## Tests
463/463 passing