### PR TITLE
feat: opt-in portfolios feature (#111)

### DIFF
--- a/src/backend/db/connection.js
+++ b/src/backend/db/connection.js
@@ -13,6 +13,27 @@ const initSqlJs = require('sql.js');
 const config = require('../../config');
 
 let _wrappedDb = null;
+let _dbPathOverride = null;
+
+/**
+ * Override the DB path used by openDb().
+ * Call before openDb() or use switchDb() to replace a live connection.
+ * @param {string|null} dbPath
+ */
+function setDbPath(dbPath) {
+  _dbPathOverride = dbPath || null;
+}
+
+/**
+ * Close the current DB connection and reopen at a new path.
+ * Used by portfolio switching.
+ * @param {string} newPath
+ */
+async function switchDb(newPath) {
+  if (_wrappedDb) _wrappedDb.close(); // close() sets _wrappedDb = null
+  _dbPathOverride = newPath;
+  return openDb();
+}
 
 // ---------------------------------------------------------------------------
 // Parameter normalisation
@@ -144,7 +165,7 @@ class SqlJsDb {
 async function openDb() {
   if (_wrappedDb) return _wrappedDb;
 
-  const dbPath = config.db.path;
+  const dbPath = _dbPathOverride || config.db.path;
   const dir = path.dirname(dbPath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
@@ -172,4 +193,4 @@ function closeDb() {
   }
 }
 
-module.exports = { openDb, closeDb };
+module.exports = { openDb, closeDb, setDbPath, switchDb };

--- a/src/backend/db/profile-stats.js
+++ b/src/backend/db/profile-stats.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * Per-profile statistics reader.
+ *
+ * Opens a profile's SQLite DB as a read-only snapshot (independent of the
+ * active DB singleton) and extracts aggregate data for the portfolio view.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+
+/**
+ * Query a profile's DB for statistics and highlights.
+ * Safe to call on a DB that hasn't been initialised yet (returns zeros).
+ *
+ * @param {string} dbPath   Absolute path to the profile's .db file.
+ * @returns {Promise<{
+ *   entryCount: number,
+ *   tagCount: number,
+ *   themeCount: number,
+ *   openContradictions: number,
+ *   lastActiveAt: string|null,
+ *   topThemes: string[],
+ *   recentEntries: { content: string }[],
+ * }>}
+ */
+async function getProfileStats(dbPath) {
+  const empty = {
+    entryCount: 0,
+    tagCount: 0,
+    themeCount: 0,
+    openContradictions: 0,
+    lastActiveAt: null,
+    topThemes: [],
+    recentEntries: [],
+  };
+
+  if (!dbPath || !fs.existsSync(dbPath)) return empty;
+
+  const SQL = await initSqlJs({
+    locateFile: (file) =>
+      path.join(__dirname, '..', '..', '..', 'node_modules', 'sql.js', 'dist', file),
+  });
+
+  let db;
+  try {
+    const buf = fs.readFileSync(dbPath);
+    db = new SQL.Database(buf);
+  } catch {
+    return empty;
+  }
+
+  function queryOne(sql) {
+    try {
+      const stmt = db.prepare(sql);
+      const row  = stmt.step() ? stmt.getAsObject() : null;
+      stmt.free();
+      return row;
+    } catch {
+      return null;
+    }
+  }
+
+  function queryAll(sql) {
+    try {
+      const stmt = db.prepare(sql);
+      const rows = [];
+      while (stmt.step()) rows.push(stmt.getAsObject());
+      stmt.free();
+      return rows;
+    } catch {
+      return [];
+    }
+  }
+
+  const entryRow  = queryOne('SELECT COUNT(*) AS n FROM entries WHERE deleted_at IS NULL');
+  const tagRow    = queryOne('SELECT COUNT(*) AS n FROM tags');
+  const themeRow  = queryOne('SELECT COUNT(*) AS n FROM themes');
+  const contraRow = queryOne("SELECT COUNT(*) AS n FROM contradictions WHERE status = 'open'");
+  const lastRow   = queryOne('SELECT MAX(created_at) AS last FROM entries WHERE deleted_at IS NULL');
+
+  const topThemes = queryAll(
+    'SELECT name FROM themes ORDER BY updated_at DESC LIMIT 5'
+  ).map((r) => r.name).filter(Boolean);
+
+  const recentEntries = queryAll(
+    'SELECT content FROM entries WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT 3'
+  ).map((r) => ({ content: (r.content || '').slice(0, 120) }));
+
+  db.close();
+
+  return {
+    entryCount:         Number(entryRow?.n  ?? 0),
+    tagCount:           Number(tagRow?.n    ?? 0),
+    themeCount:         Number(themeRow?.n  ?? 0),
+    openContradictions: Number(contraRow?.n ?? 0),
+    lastActiveAt:       lastRow?.last ?? null,
+    topThemes,
+    recentEntries,
+  };
+}
+
+module.exports = { getProfileStats };

--- a/src/backend/portfolio.js
+++ b/src/backend/portfolio.js
@@ -5,13 +5,13 @@
  *
  * A portfolio is a self-contained Neurologue corpus: its own SQLite DB,
  * its own LanceDB vector store, and its own CCF snapshots.  Users switch
- * between portfolios at the app-shell level; the rest of the stack is
- * unaware of which portfolio is active.
+ * between profiles at the app-shell level; the rest of the stack is
+ * unaware of which profile is active.
  *
  * The manifest lives at {userData}/profiles.json and is the single source
  * of truth for the list of profiles and the currently active one.
  *
- * The portfolios feature is opt-in (portfoliosEnabled: false in settings).
+ * The Portfolio feature is opt-in (portfolioEnabled: false in settings).
  * This module is always loaded but the IPC surface is only exposed through
  * the feature-gated UI.
  */
@@ -136,6 +136,21 @@ function renameProfile(id, name) {
 }
 
 /**
+ * Update the colour of a profile.
+ * @param {string} id
+ * @param {string} color  CSS colour string
+ */
+function recolorProfile(id, color) {
+  if (!color) throw new Error('Color is required');
+  const manifest = _loadManifest();
+  const profile  = manifest.profiles.find((p) => p.id === id);
+  if (!profile) throw new Error(`Profile ${id} not found`);
+  profile.color = color;
+  _saveManifest(manifest);
+  return profile;
+}
+
+/**
  * Delete a profile.  Cannot delete the active profile or the last remaining one.
  * @param {string} id
  */
@@ -166,6 +181,7 @@ module.exports = {
   getActiveProfile,
   createProfile,
   renameProfile,
+  recolorProfile,
   deleteProfile,
   setActiveProfile,
 };

--- a/src/backend/portfolios.js
+++ b/src/backend/portfolios.js
@@ -1,0 +1,171 @@
+'use strict';
+
+/**
+ * Portfolio (corpus profile) manifest manager.
+ *
+ * A portfolio is a self-contained Neurologue corpus: its own SQLite DB,
+ * its own LanceDB vector store, and its own CCF snapshots.  Users switch
+ * between portfolios at the app-shell level; the rest of the stack is
+ * unaware of which portfolio is active.
+ *
+ * The manifest lives at {userData}/profiles.json and is the single source
+ * of truth for the list of profiles and the currently active one.
+ *
+ * The portfolios feature is opt-in (portfoliosEnabled: false in settings).
+ * This module is always loaded but the IPC surface is only exposed through
+ * the feature-gated UI.
+ */
+
+const fs     = require('fs');
+const path   = require('path');
+const crypto = require('crypto');
+const config = require('../config');
+
+const MANIFEST_FILENAME  = 'profiles.json';
+const DEFAULT_PROFILE_ID = 'default';
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+function _userDataDir() {
+  return path.dirname(config.db.path);
+}
+
+function _manifestPath() {
+  return path.join(_userDataDir(), MANIFEST_FILENAME);
+}
+
+function _defaultProfile() {
+  return {
+    id:               DEFAULT_PROFILE_ID,
+    name:             'Personal',
+    color:            '#2AA6A1',
+    dbPath:           config.db.path,
+    vectorStorePath:  config.vectorStore.path,
+    createdAt:        new Date().toISOString(),
+  };
+}
+
+/**
+ * Load the manifest from disk, auto-creating it on first run.
+ * @returns {{ activeId: string, profiles: object[] }}
+ */
+function _loadManifest() {
+  const file = _manifestPath();
+  if (!fs.existsSync(file)) {
+    const manifest = {
+      activeId: DEFAULT_PROFILE_ID,
+      profiles: [_defaultProfile()],
+    };
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(manifest, null, 2), 'utf8');
+    return manifest;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    // Corrupted manifest — recreate with default
+    const manifest = { activeId: DEFAULT_PROFILE_ID, profiles: [_defaultProfile()] };
+    fs.writeFileSync(file, JSON.stringify(manifest, null, 2), 'utf8');
+    return manifest;
+  }
+}
+
+function _saveManifest(manifest) {
+  fs.writeFileSync(_manifestPath(), JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Return the full manifest: { activeId, profiles[] }.
+ */
+function listProfiles() {
+  return _loadManifest();
+}
+
+/**
+ * Return the currently active profile object.
+ * Falls back to the first profile if activeId is stale.
+ */
+function getActiveProfile() {
+  const manifest = _loadManifest();
+  return manifest.profiles.find((p) => p.id === manifest.activeId) || manifest.profiles[0];
+}
+
+/**
+ * Create a new profile with its own DB and vector store paths.
+ * @param {string} name
+ * @param {string} [color]
+ * @returns {object} The new profile.
+ */
+function createProfile(name, color) {
+  if (!name || !name.trim()) throw new Error('Profile name is required');
+  const manifest = _loadManifest();
+
+  const id  = crypto.randomUUID();
+  const dir = _userDataDir();
+
+  const profile = {
+    id,
+    name:            name.trim(),
+    color:           color || '#6B7A8D',
+    dbPath:          path.join(dir, `neurologue-${id}.db`),
+    vectorStorePath: path.join(dir, `vector-store-${id}`),
+    createdAt:       new Date().toISOString(),
+  };
+
+  manifest.profiles.push(profile);
+  _saveManifest(manifest);
+  return profile;
+}
+
+/**
+ * Rename an existing profile.
+ * @param {string} id
+ * @param {string} name
+ */
+function renameProfile(id, name) {
+  if (!name || !name.trim()) throw new Error('Profile name is required');
+  const manifest = _loadManifest();
+  const profile  = manifest.profiles.find((p) => p.id === id);
+  if (!profile) throw new Error(`Profile ${id} not found`);
+  profile.name = name.trim();
+  _saveManifest(manifest);
+  return profile;
+}
+
+/**
+ * Delete a profile.  Cannot delete the active profile or the last remaining one.
+ * @param {string} id
+ */
+function deleteProfile(id) {
+  const manifest = _loadManifest();
+  if (id === manifest.activeId)       throw new Error('Cannot delete the active profile — switch first');
+  if (manifest.profiles.length <= 1)  throw new Error('Cannot delete the only profile');
+  manifest.profiles = manifest.profiles.filter((p) => p.id !== id);
+  _saveManifest(manifest);
+  return { ok: true };
+}
+
+/**
+ * Mark a profile as the active one and return it.
+ * @param {string} id
+ */
+function setActiveProfile(id) {
+  const manifest = _loadManifest();
+  const profile  = manifest.profiles.find((p) => p.id === id);
+  if (!profile) throw new Error(`Profile ${id} not found`);
+  manifest.activeId = id;
+  _saveManifest(manifest);
+  return profile;
+}
+
+module.exports = {
+  listProfiles,
+  getActiveProfile,
+  createProfile,
+  renameProfile,
+  deleteProfile,
+  setActiveProfile,
+};

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -34,7 +34,7 @@ const DEFAULTS = {
   theme: 'dark',          // 'dark' | 'light'
   homeView: 'library',    // view id to show on launch
   navHistoryLimit: 10,    // max entries in session nav stack
-  portfoliosEnabled: false, // opt-in: multiple named corpus profiles
+  portfolioEnabled: false, // opt-in: multiple named corpus profiles (Portfolio feature)
   scheduledExport: {
     enabled:     false,
     frequency:   'daily',   // 'daily' | 'weekly'

--- a/src/backend/settings.js
+++ b/src/backend/settings.js
@@ -34,6 +34,7 @@ const DEFAULTS = {
   theme: 'dark',          // 'dark' | 'light'
   homeView: 'library',    // view id to show on launch
   navHistoryLimit: 10,    // max entries in session nav stack
+  portfoliosEnabled: false, // opt-in: multiple named corpus profiles
   scheduledExport: {
     enabled:     false,
     frequency:   'daily',   // 'daily' | 'weekly'

--- a/src/backend/vector/store.js
+++ b/src/backend/vector/store.js
@@ -5,6 +5,27 @@ const config = require('../../config');
 
 let _db = null;
 let _table = null;
+let _storePathOverride = null;
+
+/**
+ * Override the vector store path used by initVectorStore().
+ * @param {string|null} storePath
+ */
+function setStorePath(storePath) {
+  _storePathOverride = storePath || null;
+}
+
+/**
+ * Close the current vector store and reinitialise at a new path.
+ * Used by portfolio switching.
+ * @param {string} newPath
+ */
+async function switchVectorStore(newPath) {
+  _db = null;
+  _table = null;
+  _storePathOverride = newPath;
+  return initVectorStore();
+}
 
 const TABLE_NAME = 'entry_embeddings';
 
@@ -13,7 +34,8 @@ const TABLE_NAME = 'entry_embeddings';
  * Call once at startup before using other functions.
  */
 async function initVectorStore() {
-  _db = await lancedb.connect(config.vectorStore.path);
+  const storePath = _storePathOverride || config.vectorStore.path;
+  _db = await lancedb.connect(storePath);
 
   const tableNames = await _db.tableNames();
   if (tableNames.includes(TABLE_NAME)) {
@@ -82,4 +104,4 @@ async function clearAllVectors() {
   await _table.delete('entry_id IS NOT NULL');
 }
 
-module.exports = { initVectorStore, upsertVector, searchNearest, deleteVector, clearAllVectors };
+module.exports = { initVectorStore, upsertVector, searchNearest, deleteVector, clearAllVectors, setStorePath, switchVectorStore };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -25,6 +25,7 @@
       <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
       <button id="btn-maintenance" class="mode-btn toolbar-library-only" title="Tag management">Maintenance</button>
       <button id="btn-help" class="mode-btn">Help</button>
+      <button id="portfolio-badge" class="portfolio-badge feature-portfolios" title="Active portfolio — click to switch"></button>
     </div>
 
     <!-- ── Shell: nav rail + view container ───────────────────────── -->
@@ -63,6 +64,10 @@
         <button class="nav-item" data-view="agents" title="Agents">
           <span class="nav-icon">&#10022;</span>
           <span class="nav-label">Agents</span>
+        </button>
+        <button class="nav-item feature-portfolios" data-view="portfolios" title="Portfolios">
+          <span class="nav-icon">&#128193;</span>
+          <span class="nav-label">Portfolios</span>
         </button>
         <button class="nav-item nav-item--settings" data-view="settings" title="Settings">
           <span class="nav-icon">&#9881;</span>
@@ -608,6 +613,7 @@
             <button class="settings-subnav-item" data-section="appearance">Appearance</button>
             <button class="settings-subnav-item" data-section="data">Data</button>
             <button class="settings-subnav-item" data-section="scheduled-export">Scheduled Export</button>
+            <button class="settings-subnav-item" data-section="features">Features</button>
           </nav>
           <div id="settings-content">
 
@@ -799,6 +805,21 @@
               </div>
             </div>
 
+            <!-- Features panel -->
+            <div class="settings-panel hidden" id="settings-tab-features">
+              <p class="settings-panel-desc">Optional features. Disabled features leave no trace in the UI.</p>
+              <div class="settings-field">
+                <div class="settings-field-label-row">
+                  <label for="chk-portfolios-enabled">Portfolios</label>
+                  <label class="toggle-switch">
+                    <input type="checkbox" id="chk-portfolios-enabled" />
+                    <span class="toggle-slider"></span>
+                  </label>
+                </div>
+                <span class="settings-hint">Organise your notes into separate named workspaces — e.g. Personal and Work. Each portfolio has its own entries, themes, and AI context.</span>
+              </div>
+            </div>
+
             <div class="settings-actions">
               <button class="btn-setup-primary" id="btn-save-settings">Save settings</button>
               <span class="settings-saved hidden" id="settings-saved-msg">&#x2713; Saved</span>
@@ -807,7 +828,36 @@
           </div><!-- /#settings-content -->
         </div><!-- /#view-settings -->
 
-      </div><!-- /#view-container -->
+        <!-- ── View: Portfolios (feature-gated) ──────────────────── -->
+        <div id="view-portfolios" class="view feature-portfolios">
+          <div id="portfolios-header">
+            <h2 class="portfolios-title">Portfolios</h2>
+            <button id="btn-new-portfolio" class="btn-primary">+ New portfolio</button>
+          </div>
+          <p class="portfolios-desc">Each portfolio is an independent corpus with its own entries, themes, and AI context. Switch between them at any time.</p>
+          <div id="portfolios-grid">
+            <!-- populated by library.js -->
+          </div>
+          <!-- New portfolio form -->
+          <div id="portfolio-create-form" class="hidden">
+            <input id="portfolio-new-name" type="text" placeholder="Portfolio name" maxlength="40" />
+            <div class="portfolio-color-row">
+              <label>Colour</label>
+              <div id="portfolio-color-swatches">
+                <button class="color-swatch active" data-color="#2AA6A1" style="background:#2AA6A1" title="Teal"></button>
+                <button class="color-swatch" data-color="#6B7A8D" style="background:#6B7A8D" title="Slate"></button>
+                <button class="color-swatch" data-color="#E07B54" style="background:#E07B54" title="Amber"></button>
+                <button class="color-swatch" data-color="#7C5CBF" style="background:#7C5CBF" title="Violet"></button>
+                <button class="color-swatch" data-color="#4A9E6B" style="background:#4A9E6B" title="Green"></button>
+                <button class="color-swatch" data-color="#D64F4F" style="background:#D64F4F" title="Red"></button>
+              </div>
+            </div>
+            <div class="portfolio-form-actions">
+              <button id="btn-create-portfolio-confirm" class="btn-primary">Create</button>
+              <button id="btn-create-portfolio-cancel" class="btn-secondary">Cancel</button>
+            </div>
+          </div>
+        </div><!-- /#view-portfolios -->
     </div><!-- /#shell -->
 
     <!-- ── Worker log popup ──────────────────────────────────────── -->

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -610,7 +610,7 @@
             <button class="settings-subnav-item" data-section="data">Data</button>
             <button class="settings-subnav-item" data-section="scheduled-export">Scheduled Export</button>
             <button class="settings-subnav-item" data-section="features">Features</button>
-            <button class="settings-subnav-item feature-portfolios" data-section="portfolios">Portfolios</button>
+            <button class="settings-subnav-item feature-portfolio" data-section="portfolio">Portfolio</button>
           </nav>
           <div id="settings-content">
 
@@ -807,18 +807,18 @@
               <p class="settings-panel-desc">Optional features. Disabled features leave no trace in the UI.</p>
               <div class="settings-field">
                 <div class="settings-field-label-row">
-                  <label for="chk-portfolios-enabled">Portfolios</label>
+                  <label for="chk-portfolio-enabled">Portfolio</label>
                   <label class="toggle-switch">
-                    <input type="checkbox" id="chk-portfolios-enabled" />
+                    <input type="checkbox" id="chk-portfolio-enabled" />
                     <span class="toggle-slider"></span>
                   </label>
                 </div>
-                <span class="settings-hint">Organise your notes into separate named profiles &#8212; e.g. Personal and Work. Each profile has its own entries, themes, and AI context. Once enabled, manage profiles in the Portfolios settings tab.</span>
+                <span class="settings-hint">Organise your notes into separate named profiles &#8212; e.g. Personal and Work. Each profile has its own entries, themes, and AI context. Once enabled, manage profiles in the Portfolio settings tab.</span>
               </div>
             </div>
 
-            <!-- Portfolios panel (visible only when feature enabled) -->
-            <div class="settings-panel hidden" id="settings-tab-portfolios">
+            <!-- Portfolio panel (visible only when feature enabled) -->
+            <div class="settings-panel hidden" id="settings-tab-portfolio">
               <p class="settings-panel-desc">Manage your corpus profiles. Each profile has its own entries, themes, tags, and AI context.</p>
               <div id="profiles-list">
                 <!-- populated by loadProfilesPanel() in library.js -->

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -65,10 +65,6 @@
           <span class="nav-icon">&#10022;</span>
           <span class="nav-label">Agents</span>
         </button>
-        <button class="nav-item feature-portfolios" data-view="portfolios" title="Portfolios">
-          <span class="nav-icon">&#128193;</span>
-          <span class="nav-label">Portfolios</span>
-        </button>
         <button class="nav-item nav-item--settings" data-view="settings" title="Settings">
           <span class="nav-icon">&#9881;</span>
           <span class="nav-label">Settings</span>
@@ -614,6 +610,7 @@
             <button class="settings-subnav-item" data-section="data">Data</button>
             <button class="settings-subnav-item" data-section="scheduled-export">Scheduled Export</button>
             <button class="settings-subnav-item" data-section="features">Features</button>
+            <button class="settings-subnav-item feature-portfolios" data-section="portfolios">Portfolios</button>
           </nav>
           <div id="settings-content">
 
@@ -816,7 +813,39 @@
                     <span class="toggle-slider"></span>
                   </label>
                 </div>
-                <span class="settings-hint">Organise your notes into separate named workspaces — e.g. Personal and Work. Each portfolio has its own entries, themes, and AI context.</span>
+                <span class="settings-hint">Organise your notes into separate named profiles &#8212; e.g. Personal and Work. Each profile has its own entries, themes, and AI context. Once enabled, manage profiles in the Portfolios settings tab.</span>
+              </div>
+            </div>
+
+            <!-- Portfolios panel (visible only when feature enabled) -->
+            <div class="settings-panel hidden" id="settings-tab-portfolios">
+              <p class="settings-panel-desc">Manage your corpus profiles. Each profile has its own entries, themes, tags, and AI context.</p>
+              <div id="profiles-list">
+                <!-- populated by loadProfilesPanel() in library.js -->
+              </div>
+              <div id="profile-create-form" class="hidden">
+                <div class="settings-field">
+                  <label for="profile-new-name">Profile name</label>
+                  <input id="profile-new-name" type="text" placeholder="e.g. Work" maxlength="40" />
+                </div>
+                <div class="settings-field">
+                  <label>Colour</label>
+                  <div id="profile-color-swatches" class="profile-color-swatches">
+                    <button class="color-swatch active" data-color="#2AA6A1" title="Teal"></button>
+                    <button class="color-swatch" data-color="#6B7A8D" title="Slate"></button>
+                    <button class="color-swatch" data-color="#E07B54" title="Amber"></button>
+                    <button class="color-swatch" data-color="#7C5CBF" title="Violet"></button>
+                    <button class="color-swatch" data-color="#4A9E6B" title="Green"></button>
+                    <button class="color-swatch" data-color="#D64F4F" title="Red"></button>
+                  </div>
+                </div>
+                <div class="portfolio-form-actions">
+                  <button id="btn-profile-create-confirm" class="btn-primary">Create profile</button>
+                  <button id="btn-profile-create-cancel" class="btn-secondary">Cancel</button>
+                </div>
+              </div>
+              <div class="settings-actions-row">
+                <button id="btn-new-profile" class="btn-secondary">+ New profile</button>
               </div>
             </div>
 
@@ -828,36 +857,7 @@
           </div><!-- /#settings-content -->
         </div><!-- /#view-settings -->
 
-        <!-- ── View: Portfolios (feature-gated) ──────────────────── -->
-        <div id="view-portfolios" class="view feature-portfolios">
-          <div id="portfolios-header">
-            <h2 class="portfolios-title">Portfolios</h2>
-            <button id="btn-new-portfolio" class="btn-primary">+ New portfolio</button>
-          </div>
-          <p class="portfolios-desc">Each portfolio is an independent corpus with its own entries, themes, and AI context. Switch between them at any time.</p>
-          <div id="portfolios-grid">
-            <!-- populated by library.js -->
-          </div>
-          <!-- New portfolio form -->
-          <div id="portfolio-create-form" class="hidden">
-            <input id="portfolio-new-name" type="text" placeholder="Portfolio name" maxlength="40" />
-            <div class="portfolio-color-row">
-              <label>Colour</label>
-              <div id="portfolio-color-swatches">
-                <button class="color-swatch active" data-color="#2AA6A1" style="background:#2AA6A1" title="Teal"></button>
-                <button class="color-swatch" data-color="#6B7A8D" style="background:#6B7A8D" title="Slate"></button>
-                <button class="color-swatch" data-color="#E07B54" style="background:#E07B54" title="Amber"></button>
-                <button class="color-swatch" data-color="#7C5CBF" style="background:#7C5CBF" title="Violet"></button>
-                <button class="color-swatch" data-color="#4A9E6B" style="background:#4A9E6B" title="Green"></button>
-                <button class="color-swatch" data-color="#D64F4F" style="background:#D64F4F" title="Red"></button>
-              </div>
-            </div>
-            <div class="portfolio-form-actions">
-              <button id="btn-create-portfolio-confirm" class="btn-primary">Create</button>
-              <button id="btn-create-portfolio-cancel" class="btn-secondary">Cancel</button>
-            </div>
-          </div>
-        </div><!-- /#view-portfolios -->
+      </div><!-- /#view-container -->
     </div><!-- /#shell -->
 
     <!-- ── Worker log popup ──────────────────────────────────────── -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3504,13 +3504,13 @@ body.theme-light .graph-tooltip {
 
 
 /* --------------------------------------------------------------------------
-   PORTFOLIOS  (opt-in feature, gated by [data-portfolios="true"] on <html>)
+   PORTFOLIO  (opt-in feature, gated by [data-portfolio="true"] on <html>)
    -------------------------------------------------------------------------- */
 
 /* Feature gate — hide everything by default */
-.feature-portfolios                               { display: none !important; }
-[data-portfolios="true"] button.portfolio-badge         { display: inline-flex !important; }
-[data-portfolios="true"] .settings-subnav-item.feature-portfolios { display: inline-block !important; }
+.feature-portfolio                               { display: none !important; }
+[data-portfolio="true"] button.portfolio-badge         { display: inline-flex !important; }
+[data-portfolio="true"] .settings-subnav-item.feature-portfolio { display: inline-block !important; }
 
 /* Portfolio badge in toolbar */
 .portfolio-badge {
@@ -3525,29 +3525,7 @@ body.theme-light .graph-tooltip {
   align-items: center;
 }
 
-/* Portfolio view --------------------------------------------------------- */
-#view-portfolios {
-  flex-direction: column;
-  padding: 32px 40px;
-  overflow-y: auto;
-  gap: 24px;
-}
-
-#portfolios-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.portfolios-title { font-size: 22px; font-weight: 700; margin: 0; }
-.portfolios-desc  { color: var(--text-dim); font-size: 13px; margin: 0; }
-
-#portfolios-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
-}
-
+/* Portfolio card styles (used in profile panels) ----------------------------------------- */
 .portfolio-card {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -3605,28 +3583,6 @@ body.theme-light .graph-tooltip {
   flex-wrap: wrap;
 }
 
-/* New portfolio form */
-#portfolio-create-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  max-width: 400px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) * 2);
-  padding: 20px;
-}
-
-#portfolio-new-name {
-  padding: 8px 12px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  color: var(--text);
-  font-size: 14px;
-  width: 100%;
-}
-
 .portfolio-color-row {
   display: flex;
   align-items: center;
@@ -3634,8 +3590,6 @@ body.theme-light .graph-tooltip {
   font-size: 13px;
   color: var(--text-muted);
 }
-
-#portfolio-color-swatches { display: flex; gap: 8px; }
 
 .color-swatch {
   width: 22px;
@@ -3737,7 +3691,7 @@ body.theme-light .graph-tooltip {
 .portfolio-card-inline-edit--hidden { display: none; }
 .portfolio-card-actions--hidden { display: none; }
 
-/* Profile rows in Settings > Portfolios panel ------------------------------------------- */
+/* Profile rows in Settings > Portfolio panel ------------------------------------------- */
 .profile-row {
   display: flex;
   align-items: flex-start;

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3502,3 +3502,207 @@ body.theme-light .graph-tooltip {
 
 
 
+
+/* --------------------------------------------------------------------------
+   PORTFOLIOS  (opt-in feature, gated by [data-portfolios="true"] on <html>)
+   -------------------------------------------------------------------------- */
+
+/* Feature gate — hide everything by default */
+.feature-portfolios                               { display: none !important; }
+[data-portfolios="true"] .feature-portfolios      { display: flex; }
+[data-portfolios="true"] .nav-item.feature-portfolios { display: flex; }
+[data-portfolios="true"] button.feature-portfolios { display: inline-flex; }
+
+/* Portfolio badge in toolbar */
+.portfolio-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: var(--radius);
+  border: 2px solid var(--cortex-teal);
+  color: var(--text-muted);
+  white-space: nowrap;
+  cursor: default;
+  align-items: center;
+}
+
+/* Portfolio view --------------------------------------------------------- */
+#view-portfolios {
+  flex-direction: column;
+  padding: 32px 40px;
+  overflow-y: auto;
+  gap: 24px;
+}
+
+#portfolios-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.portfolios-title { font-size: 22px; font-weight: 700; margin: 0; }
+.portfolios-desc  { color: var(--text-dim); font-size: 13px; margin: 0; }
+
+#portfolios-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.portfolio-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 2);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: border-color 0.15s;
+}
+
+.portfolio-card--active { border-color: var(--cortex-teal); }
+
+.portfolio-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-left: 8px;
+}
+
+.portfolio-card-name        { font-weight: 600; font-size: 15px; }
+
+.portfolio-card-active-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--cortex-teal);
+  letter-spacing: 0.06em;
+}
+
+.portfolio-card-stats       { display: flex; gap: 12px; font-size: 12px; color: var(--text-dim); }
+.portfolio-card-themes      { display: flex; flex-wrap: wrap; gap: 6px; }
+
+.portfolio-theme-chip {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface2);
+  color: var(--text-muted);
+}
+
+.portfolio-card-preview {
+  font-size: 12px;
+  color: var(--text-dim);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.portfolio-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: auto;
+  flex-wrap: wrap;
+}
+
+/* New portfolio form */
+#portfolio-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 400px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 2);
+  padding: 20px;
+}
+
+#portfolio-new-name {
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 14px;
+  width: 100%;
+}
+
+.portfolio-color-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+#portfolio-color-swatches { display: flex; gap: 8px; }
+
+.color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.1s, border-color 0.1s;
+}
+
+.color-swatch.active,
+.color-swatch:hover { transform: scale(1.2); border-color: var(--text); }
+
+.portfolio-form-actions { display: flex; gap: 8px; }
+
+/* Toggle switch — used in Features settings panel */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: var(--surface2);
+  border-radius: 20px;
+  cursor: pointer;
+  transition: background 0.2s;
+  border: 1px solid var(--border);
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  left: 2px;
+  top: 2px;
+  background: var(--text-dim);
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: var(--cortex-teal);
+  border-color: var(--cortex-teal);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+  transform: translateX(16px);
+  background: #fff;
+}
+
+/* Settings field with toggle */
+.settings-field-label-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-field-label-row label:first-child {
+  flex: 1;
+  font-weight: 500;
+}

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3507,11 +3507,10 @@ body.theme-light .graph-tooltip {
    PORTFOLIOS  (opt-in feature, gated by [data-portfolios="true"] on <html>)
    -------------------------------------------------------------------------- */
 
-/* Feature gate — hide everything by default */
+/* Feature gate â€” hide everything by default */
 .feature-portfolios                               { display: none !important; }
-[data-portfolios="true"] .feature-portfolios      { display: flex; }
-[data-portfolios="true"] .nav-item.feature-portfolios { display: flex; }
-[data-portfolios="true"] button.feature-portfolios { display: inline-flex; }
+[data-portfolios="true"] button.portfolio-badge         { display: inline-flex !important; }
+[data-portfolios="true"] .settings-subnav-item.feature-portfolios { display: inline-block !important; }
 
 /* Portfolio badge in toolbar */
 .portfolio-badge {
@@ -3652,7 +3651,7 @@ body.theme-light .graph-tooltip {
 
 .portfolio-form-actions { display: flex; gap: 8px; }
 
-/* Toggle switch — used in Features settings panel */
+/* Toggle switch ï¿½ used in Features settings panel */
 .toggle-switch {
   position: relative;
   display: inline-block;
@@ -3706,3 +3705,78 @@ body.theme-light .graph-tooltip {
   flex: 1;
   font-weight: 500;
 }
+
+/* Portfolio card inline rename/recolor */
+.portfolio-card-inline-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.portfolio-inline-name {
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 13px;
+  width: 100%;
+}
+
+.portfolio-inline-colors { display: flex; gap: 6px; align-items: center; }
+
+.portfolio-inline-actions { display: flex; gap: 8px; }
+
+/* Portfolio card inline rename/recolor */
+.portfolio-card-inline-edit { display: flex; flex-direction: column; gap: 8px; }
+.portfolio-inline-name { padding: 6px 10px; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text); font-size: 13px; width: 100%; }
+.portfolio-inline-colors { display: flex; gap: 6px; align-items: center; }
+.portfolio-inline-actions { display: flex; gap: 8px; }
+
+
+.portfolio-card-inline-edit--hidden { display: none; }
+.portfolio-card-actions--hidden { display: none; }
+
+/* Profile rows in Settings > Portfolios panel ------------------------------------------- */
+.profile-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+.profile-row:last-child { border-bottom: none; }
+.profile-row--active .profile-row-name { font-weight: 700; }
+
+.profile-row-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.profile-row-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile-row-name-line { display: flex; align-items: center; gap: 8px; }
+.profile-row-name      { font-size: 14px; }
+.profile-row-meta      { display: flex; gap: 10px; font-size: 12px; color: var(--text-dim); flex-wrap: wrap; }
+.profile-row-path      { font-family: var(--font-mono, monospace); font-size: 11px; color: var(--text-dim); }
+
+.profile-row-actions   { display: flex; gap: 6px; flex-shrink: 0; align-items: flex-start; }
+
+.profile-row-inline-edit { display: flex; flex-direction: column; gap: 8px; margin-top: 6px; }
+.profile-row-inline-edit--hidden { display: none; }
+
+.profile-inline-colors { display: flex; gap: 6px; align-items: center; }
+
+#profiles-list { padding: 4px 0 16px; }
+
+.profile-color-swatches { display: flex; gap: 8px; }
+
+.settings-actions-row { padding-top: 8px; }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1649,6 +1649,7 @@ async function loadSettingsView(section = 'models') {
   activateSettingsSection(section);
   if (section === 'scheduled-export') await loadSchedSettings();
   if (section === 'worker') await renderWorkerLog();
+  if (section === 'portfolios') loadProfilesPanel();
 
   // Features panel
   const chkPortfolios = document.getElementById('chk-portfolios-enabled');
@@ -2330,7 +2331,6 @@ function activateView(viewId) {
   if (viewId === 'graph')          loadGraphView();
   if (viewId === 'replay')         loadReplayView();
   if (viewId === 'agents')         loadAgentsView();
-  if (viewId === 'portfolios')      loadPortfoliosView();
   // Destroy graph renderer when leaving the graph view
   if (viewId !== 'graph')          _destroyGraphIfActive();
 }
@@ -3572,20 +3572,22 @@ async function refreshPortfolioBadge() {
   } catch (_e) { /* silent — portfolios may not be configured yet */ }
 }
 
-async function loadPortfoliosView() {
-  const grid = document.getElementById('portfolios-grid');
-  if (!grid) return;
-  grid.innerHTML = '<p class="loading">Loading\u2026</p>';
+async function loadProfilesPanel() {
+  const list = document.getElementById('profiles-list');
+  if (!list) return;
+  list.innerHTML = '<p class="loading">Loading\u2026</p>';
 
   let manifest;
   try {
     manifest = await window.neurologue.listPortfolios();
   } catch (err) {
-    grid.innerHTML = `<p class="error-msg">Could not load portfolios: ${err.message}</p>`;
+    list.innerHTML = `<p class="error-msg">Could not load profiles: ${err.message}</p>`;
     return;
   }
 
-  grid.innerHTML = '';
+  list.innerHTML = '';
+
+  const COLORS = ['#2AA6A1','#6B7A8D','#E07B54','#7C5CBF','#4A9E6B','#D64F4F'];
 
   for (const profile of manifest.profiles) {
     let stats = {};
@@ -3595,93 +3597,147 @@ async function loadPortfoliosView() {
     } catch (_e) { /* non-fatal */ }
 
     const isActive = profile.id === manifest.activeId;
-    const card = document.createElement('div');
-    card.className = `portfolio-card${isActive ? ' portfolio-card--active' : ''}`;
-    card.dataset.id = profile.id;
+    const row = document.createElement('div');
+    row.className = `profile-row${isActive ? ' profile-row--active' : ''}`;
+    row.dataset.id = profile.id;
 
-    const topThemesHtml = (stats.topThemes || []).length
-      ? `<div class="portfolio-card-themes">${(stats.topThemes || []).map((t) => `<span class="portfolio-theme-chip">${t}</span>`).join('')}</div>`
-      : '';
-    const previewHtml = (stats.recentEntries || []).length
-      ? `<p class="portfolio-card-preview">${stats.recentEntries[0].content || ''}</p>`
-      : '';
-
-    card.innerHTML = `
-      <div class="portfolio-card-header" style="border-left:4px solid ${profile.color}">
-        <span class="portfolio-card-name">${profile.name}</span>
-        ${isActive ? '<span class="portfolio-card-active-badge">Active</span>' : ''}
+    row.innerHTML = `
+      <div class="profile-row-color-dot"></div>
+      <div class="profile-row-main">
+        <div class="profile-row-name-line">
+          <span class="profile-row-name">${profile.name}</span>
+          ${isActive ? '<span class="portfolio-card-active-badge">Active</span>' : ''}
+        </div>
+        <div class="profile-row-meta">
+          <span>${stats.entryCount ?? 0} entries</span>
+          <span>${stats.themeCount ?? 0} themes</span>
+          <span>${stats.tagCount ?? 0} tags</span>
+          <span class="profile-row-path" title="${profile.dbPath}">${profile.dbPath.split(/[\\/]/).pop()}</span>
+        </div>
+        <div class="profile-row-inline-edit profile-row-inline-edit--hidden">
+          <input class="profile-inline-name" type="text" value="${profile.name}" maxlength="40" />
+          <div class="portfolio-inline-colors profile-inline-colors">
+            ${COLORS.map((c) => `<button class="color-swatch${c === profile.color ? ' active' : ''}" data-color="${c}" title="${c}"></button>`).join('')}
+          </div>
+          <div class="portfolio-inline-actions">
+            <button class="btn-primary btn-inline-save">Save</button>
+            <button class="btn-secondary btn-inline-cancel">Cancel</button>
+          </div>
+        </div>
       </div>
-      <div class="portfolio-card-stats">
-        <span>${stats.entryCount ?? 0} entries</span>
-        <span>${stats.themeCount ?? 0} themes</span>
-        <span>${stats.tagCount ?? 0} tags</span>
-      </div>
-      ${topThemesHtml}
-      ${previewHtml}
-      <div class="portfolio-card-actions">
-        ${!isActive ? `<button class="btn-primary btn-portfolio-switch" data-id="${profile.id}">Switch to</button>` : ''}
-        <button class="btn-secondary btn-portfolio-rename" data-id="${profile.id}">Rename</button>
-        ${!isActive ? `<button class="btn-danger btn-portfolio-delete" data-id="${profile.id}">Delete</button>` : ''}
+      <div class="profile-row-actions">
+        ${!isActive ? `<button class="btn-primary btn-sm btn-profile-switch" data-id="${profile.id}">Switch to</button>` : ''}
+        <button class="btn-secondary btn-sm btn-profile-edit" data-id="${profile.id}">Edit</button>
+        ${!isActive ? `<button class="btn-danger btn-sm btn-profile-delete" data-id="${profile.id}">Delete</button>` : ''}
       </div>`;
-    grid.appendChild(card);
+
+    // Color dot and inline swatch colors set programmatically
+    row.querySelector('.profile-row-color-dot').style.backgroundColor = profile.color;
+    row.querySelectorAll('.profile-inline-colors .color-swatch').forEach((sw) => {
+      sw.style.backgroundColor = sw.dataset.color;
+    });
+
+    list.appendChild(row);
   }
 
-  // Wire action buttons
-  grid.querySelectorAll('.btn-portfolio-switch').forEach((btn) => {
+  // Switch
+  list.querySelectorAll('.btn-profile-switch').forEach((btn) => {
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       btn.textContent = 'Switching\u2026';
       await window.neurologue.switchPortfolio(btn.dataset.id);
-      // renderer reloads via onPortfolioSwitched
     });
   });
 
-  grid.querySelectorAll('.btn-portfolio-rename').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const current = grid.querySelector(`.portfolio-card[data-id="${btn.dataset.id}"] .portfolio-card-name`)?.textContent || '';
-      const next    = prompt('Rename portfolio:', current);
-      if (next && next.trim() && next.trim() !== current) {
-        await window.neurologue.renamePortfolio(btn.dataset.id, next.trim());
-        loadPortfoliosView();
-      }
+  // Edit (inline rename + recolor)
+  list.querySelectorAll('.btn-profile-edit').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const row       = list.querySelector(`.profile-row[data-id="${btn.dataset.id}"]`);
+      const editRow   = row.querySelector('.profile-row-inline-edit');
+      const actRow    = row.querySelector('.profile-row-actions');
+      const nameInput = row.querySelector('.profile-inline-name');
+      editRow.classList.remove('profile-row-inline-edit--hidden');
+      actRow.style.display = 'none';
+      nameInput.focus();
+      nameInput.select();
+
+      let _editColor = row.querySelector('.profile-inline-colors .color-swatch.active')?.dataset.color || '#2AA6A1';
+
+      row.querySelectorAll('.profile-inline-colors .color-swatch').forEach((sw) => {
+        sw.addEventListener('click', () => {
+          row.querySelectorAll('.profile-inline-colors .color-swatch').forEach((s) => s.classList.remove('active'));
+          sw.classList.add('active');
+          _editColor = sw.dataset.color;
+        });
+      });
+
+      row.querySelector('.btn-inline-cancel').addEventListener('click', () => {
+        editRow.classList.add('profile-row-inline-edit--hidden');
+        actRow.style.display = '';
+      });
+
+      row.querySelector('.btn-inline-save').addEventListener('click', async () => {
+        const n = nameInput.value.trim();
+        if (!n) return;
+        row.querySelector('.btn-inline-save').disabled = true;
+        const manifest2 = await window.neurologue.listPortfolios();
+        const p = manifest2.profiles.find((x) => x.id === btn.dataset.id);
+        if (p && p.name !== n)        await window.neurologue.renamePortfolio(btn.dataset.id, n);
+        if (p && p.color !== _editColor) await window.neurologue.recolorPortfolio(btn.dataset.id, _editColor);
+        loadProfilesPanel();
+        refreshPortfolioBadge();
+      });
     });
   });
 
-  grid.querySelectorAll('.btn-portfolio-delete').forEach((btn) => {
+  // Delete
+  list.querySelectorAll('.btn-profile-delete').forEach((btn) => {
     btn.addEventListener('click', async () => {
-      const name = grid.querySelector(`.portfolio-card[data-id="${btn.dataset.id}"] .portfolio-card-name`)?.textContent || '';
-      if (!confirm(`Delete portfolio \u201c${name}\u201d? This cannot be undone.`)) return;
+      const name = list.querySelector(`.profile-row[data-id="${btn.dataset.id}"] .profile-row-name`)?.textContent || '';
+      if (!confirm(`Delete profile \u201c${name}\u201d? This cannot be undone.`)) return;
       await window.neurologue.deletePortfolio(btn.dataset.id);
-      loadPortfoliosView();
+      loadProfilesPanel();
     });
   });
 
-  // New portfolio form
-  const btnNew    = document.getElementById('btn-new-portfolio');
-  const form      = document.getElementById('portfolio-create-form');
-  const btnCreate = document.getElementById('btn-create-portfolio-confirm');
-  const btnCancel = document.getElementById('btn-create-portfolio-cancel');
-  const nameInput = document.getElementById('portfolio-new-name');
+  // Create form — clone-replace static buttons to strip accumulated listeners
+  function _rewire(id) {
+    const el = document.getElementById(id);
+    if (!el) return null;
+    const fresh = el.cloneNode(true);
+    el.replaceWith(fresh);
+    return fresh;
+  }
+
+  const form      = document.getElementById('profile-create-form');
+  const nameInput = document.getElementById('profile-new-name');
+  const btnNew    = _rewire('btn-new-profile');
+  const btnCreate = _rewire('btn-profile-create-confirm');
+  const btnCancel = _rewire('btn-profile-create-cancel');
   let _selectedColor = '#2AA6A1';
 
-  document.querySelectorAll('#portfolio-color-swatches .color-swatch').forEach((sw) => {
-    sw.addEventListener('click', () => {
-      document.querySelectorAll('#portfolio-color-swatches .color-swatch').forEach((s) => s.classList.remove('active'));
-      sw.classList.add('active');
-      _selectedColor = sw.dataset.color;
+  document.querySelectorAll('#profile-color-swatches .color-swatch').forEach((sw) => {
+    const fresh = sw.cloneNode(true);
+    sw.replaceWith(fresh);
+    fresh.style.backgroundColor = fresh.dataset.color;
+    fresh.addEventListener('click', () => {
+      document.querySelectorAll('#profile-color-swatches .color-swatch').forEach((s) => s.classList.remove('active'));
+      fresh.classList.add('active');
+      _selectedColor = fresh.dataset.color;
     });
   });
 
   if (btnNew && form) {
-    btnNew.addEventListener('click', () => { form.classList.remove('hidden'); nameInput.focus(); });
-    btnCancel?.addEventListener('click', () => { form.classList.add('hidden'); nameInput.value = ''; });
+    btnNew.addEventListener('click', () => { form.classList.remove('hidden'); nameInput?.focus(); });
+    btnCancel?.addEventListener('click', () => { form.classList.add('hidden'); if (nameInput) nameInput.value = ''; });
     btnCreate?.addEventListener('click', async () => {
-      const n = nameInput.value.trim();
+      const n = nameInput?.value.trim();
       if (!n) return;
+      btnCreate.disabled = true;
       await window.neurologue.createPortfolio(n, _selectedColor);
       form.classList.add('hidden');
-      nameInput.value = '';
-      loadPortfoliosView();
+      if (nameInput) nameInput.value = '';
+      loadProfilesPanel();
     });
   }
 }

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1649,11 +1649,11 @@ async function loadSettingsView(section = 'models') {
   activateSettingsSection(section);
   if (section === 'scheduled-export') await loadSchedSettings();
   if (section === 'worker') await renderWorkerLog();
-  if (section === 'portfolios') loadProfilesPanel();
+  if (section === 'portfolio') loadProfilesPanel();
 
   // Features panel
-  const chkPortfolios = document.getElementById('chk-portfolios-enabled');
-  if (chkPortfolios) chkPortfolios.checked = settings.portfoliosEnabled || false;
+  const chkPortfolio = document.getElementById('chk-portfolio-enabled');
+  if (chkPortfolio) chkPortfolio.checked = settings.portfolioEnabled || false;
 }
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
@@ -1685,7 +1685,7 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
     tagSimilarityThreshold,
     theme: selectedTheme,
     homeView: document.getElementById('select-home-view')?.value || 'library',
-    portfoliosEnabled: document.getElementById('chk-portfolios-enabled')?.checked || false,
+    portfolioEnabled: document.getElementById('chk-portfolio-enabled')?.checked || false,
     workerIntervals: {
       embedding:     parseInt(document.getElementById('input-interval-embedding').value, 10)    || 60,
       clustering:    parseInt(document.getElementById('input-interval-clustering').value, 10)   || 300,
@@ -1699,8 +1699,8 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
   setTimeout(() => msg.classList.add('hidden'), 2000);
 
   // Apply portfolio feature gate immediately after save
-  const portfoliosEnabled = document.getElementById('chk-portfolios-enabled')?.checked || false;
-  applyPortfolioFeature(portfoliosEnabled);
+  const portfolioEnabled = document.getElementById('chk-portfolio-enabled')?.checked || false;
+  applyPortfolioFeature(portfolioEnabled);
 });
 
 // Reindex all entries — clear all embeddings and re-queue everything
@@ -3556,20 +3556,20 @@ function _escHtml(str) {
 // ── Portfolio feature gate ─────────────────────────────────────────────────
 
 function applyPortfolioFeature(enabled) {
-  document.documentElement.dataset.portfolios = enabled ? 'true' : 'false';
+  document.documentElement.dataset.portfolio = enabled ? 'true' : 'false';
   if (enabled) refreshPortfolioBadge();
 }
 
 async function refreshPortfolioBadge() {
   try {
-    const manifest = await window.neurologue.listPortfolios();
+    const manifest = await window.neurologue.getPortfolioManifest();
     const active   = manifest.profiles.find((p) => p.id === manifest.activeId);
     const badge    = document.getElementById('portfolio-badge');
     if (badge && active) {
       badge.textContent   = active.name;
       badge.style.borderColor = active.color;
     }
-  } catch (_e) { /* silent — portfolios may not be configured yet */ }
+  } catch (_e) { /* silent — Portfolio feature may not be configured yet */ }
 }
 
 async function loadProfilesPanel() {
@@ -3579,7 +3579,7 @@ async function loadProfilesPanel() {
 
   let manifest;
   try {
-    manifest = await window.neurologue.listPortfolios();
+    manifest = await window.neurologue.getPortfolioManifest();
   } catch (err) {
     list.innerHTML = `<p class="error-msg">Could not load profiles: ${err.message}</p>`;
     return;
@@ -3680,7 +3680,7 @@ async function loadProfilesPanel() {
         const n = nameInput.value.trim();
         if (!n) return;
         row.querySelector('.btn-inline-save').disabled = true;
-        const manifest2 = await window.neurologue.listPortfolios();
+        const manifest2 = await window.neurologue.getPortfolioManifest();
         const p = manifest2.profiles.find((x) => x.id === btn.dataset.id);
         if (p && p.name !== n)        await window.neurologue.renamePortfolio(btn.dataset.id, n);
         if (p && p.color !== _editColor) await window.neurologue.recolorPortfolio(btn.dataset.id, _editColor);
@@ -3742,7 +3742,7 @@ async function loadProfilesPanel() {
   }
 }
 
-// Reload renderer when the active portfolio switches (called from main)
+// Reload renderer when the active profile switches (called from main)
 if (window.neurologue?.onPortfolioSwitched) {
   window.neurologue.onPortfolioSwitched(() => { window.location.reload(); });
 }
@@ -3754,7 +3754,7 @@ if (window.neurologue?.onPortfolioSwitched) {
   _navHistoryLimit = initSettings.navHistoryLimit ?? 10;
 
   // Apply portfolio feature gate
-  applyPortfolioFeature(initSettings.portfoliosEnabled || false);
+  applyPortfolioFeature(initSettings.portfolioEnabled || false);
 
   // Navigate to the user's chosen home view
   const homeView = initSettings.homeView || 'library';

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -1649,6 +1649,10 @@ async function loadSettingsView(section = 'models') {
   activateSettingsSection(section);
   if (section === 'scheduled-export') await loadSchedSettings();
   if (section === 'worker') await renderWorkerLog();
+
+  // Features panel
+  const chkPortfolios = document.getElementById('chk-portfolios-enabled');
+  if (chkPortfolios) chkPortfolios.checked = settings.portfoliosEnabled || false;
 }
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
@@ -1680,6 +1684,7 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
     tagSimilarityThreshold,
     theme: selectedTheme,
     homeView: document.getElementById('select-home-view')?.value || 'library',
+    portfoliosEnabled: document.getElementById('chk-portfolios-enabled')?.checked || false,
     workerIntervals: {
       embedding:     parseInt(document.getElementById('input-interval-embedding').value, 10)    || 60,
       clustering:    parseInt(document.getElementById('input-interval-clustering').value, 10)   || 300,
@@ -1691,6 +1696,10 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
   const msg = document.getElementById('settings-saved-msg');
   msg.classList.remove('hidden');
   setTimeout(() => msg.classList.add('hidden'), 2000);
+
+  // Apply portfolio feature gate immediately after save
+  const portfoliosEnabled = document.getElementById('chk-portfolios-enabled')?.checked || false;
+  applyPortfolioFeature(portfoliosEnabled);
 });
 
 // Reindex all entries — clear all embeddings and re-queue everything
@@ -2321,6 +2330,7 @@ function activateView(viewId) {
   if (viewId === 'graph')          loadGraphView();
   if (viewId === 'replay')         loadReplayView();
   if (viewId === 'agents')         loadAgentsView();
+  if (viewId === 'portfolios')      loadPortfoliosView();
   // Destroy graph renderer when leaving the graph view
   if (viewId !== 'graph')          _destroyGraphIfActive();
 }
@@ -3543,11 +3553,152 @@ function _escHtml(str) {
 
 // ── Init ────────────────────────────────────────────────────────────
 
+// ── Portfolio feature gate ─────────────────────────────────────────────────
+
+function applyPortfolioFeature(enabled) {
+  document.documentElement.dataset.portfolios = enabled ? 'true' : 'false';
+  if (enabled) refreshPortfolioBadge();
+}
+
+async function refreshPortfolioBadge() {
+  try {
+    const manifest = await window.neurologue.listPortfolios();
+    const active   = manifest.profiles.find((p) => p.id === manifest.activeId);
+    const badge    = document.getElementById('portfolio-badge');
+    if (badge && active) {
+      badge.textContent   = active.name;
+      badge.style.borderColor = active.color;
+    }
+  } catch (_e) { /* silent — portfolios may not be configured yet */ }
+}
+
+async function loadPortfoliosView() {
+  const grid = document.getElementById('portfolios-grid');
+  if (!grid) return;
+  grid.innerHTML = '<p class="loading">Loading\u2026</p>';
+
+  let manifest;
+  try {
+    manifest = await window.neurologue.listPortfolios();
+  } catch (err) {
+    grid.innerHTML = `<p class="error-msg">Could not load portfolios: ${err.message}</p>`;
+    return;
+  }
+
+  grid.innerHTML = '';
+
+  for (const profile of manifest.profiles) {
+    let stats = {};
+    try {
+      const res = await window.neurologue.portfolioStats(profile.id);
+      if (res.ok) stats = res;
+    } catch (_e) { /* non-fatal */ }
+
+    const isActive = profile.id === manifest.activeId;
+    const card = document.createElement('div');
+    card.className = `portfolio-card${isActive ? ' portfolio-card--active' : ''}`;
+    card.dataset.id = profile.id;
+
+    const topThemesHtml = (stats.topThemes || []).length
+      ? `<div class="portfolio-card-themes">${(stats.topThemes || []).map((t) => `<span class="portfolio-theme-chip">${t}</span>`).join('')}</div>`
+      : '';
+    const previewHtml = (stats.recentEntries || []).length
+      ? `<p class="portfolio-card-preview">${stats.recentEntries[0].content || ''}</p>`
+      : '';
+
+    card.innerHTML = `
+      <div class="portfolio-card-header" style="border-left:4px solid ${profile.color}">
+        <span class="portfolio-card-name">${profile.name}</span>
+        ${isActive ? '<span class="portfolio-card-active-badge">Active</span>' : ''}
+      </div>
+      <div class="portfolio-card-stats">
+        <span>${stats.entryCount ?? 0} entries</span>
+        <span>${stats.themeCount ?? 0} themes</span>
+        <span>${stats.tagCount ?? 0} tags</span>
+      </div>
+      ${topThemesHtml}
+      ${previewHtml}
+      <div class="portfolio-card-actions">
+        ${!isActive ? `<button class="btn-primary btn-portfolio-switch" data-id="${profile.id}">Switch to</button>` : ''}
+        <button class="btn-secondary btn-portfolio-rename" data-id="${profile.id}">Rename</button>
+        ${!isActive ? `<button class="btn-danger btn-portfolio-delete" data-id="${profile.id}">Delete</button>` : ''}
+      </div>`;
+    grid.appendChild(card);
+  }
+
+  // Wire action buttons
+  grid.querySelectorAll('.btn-portfolio-switch').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      btn.textContent = 'Switching\u2026';
+      await window.neurologue.switchPortfolio(btn.dataset.id);
+      // renderer reloads via onPortfolioSwitched
+    });
+  });
+
+  grid.querySelectorAll('.btn-portfolio-rename').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const current = grid.querySelector(`.portfolio-card[data-id="${btn.dataset.id}"] .portfolio-card-name`)?.textContent || '';
+      const next    = prompt('Rename portfolio:', current);
+      if (next && next.trim() && next.trim() !== current) {
+        await window.neurologue.renamePortfolio(btn.dataset.id, next.trim());
+        loadPortfoliosView();
+      }
+    });
+  });
+
+  grid.querySelectorAll('.btn-portfolio-delete').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const name = grid.querySelector(`.portfolio-card[data-id="${btn.dataset.id}"] .portfolio-card-name`)?.textContent || '';
+      if (!confirm(`Delete portfolio \u201c${name}\u201d? This cannot be undone.`)) return;
+      await window.neurologue.deletePortfolio(btn.dataset.id);
+      loadPortfoliosView();
+    });
+  });
+
+  // New portfolio form
+  const btnNew    = document.getElementById('btn-new-portfolio');
+  const form      = document.getElementById('portfolio-create-form');
+  const btnCreate = document.getElementById('btn-create-portfolio-confirm');
+  const btnCancel = document.getElementById('btn-create-portfolio-cancel');
+  const nameInput = document.getElementById('portfolio-new-name');
+  let _selectedColor = '#2AA6A1';
+
+  document.querySelectorAll('#portfolio-color-swatches .color-swatch').forEach((sw) => {
+    sw.addEventListener('click', () => {
+      document.querySelectorAll('#portfolio-color-swatches .color-swatch').forEach((s) => s.classList.remove('active'));
+      sw.classList.add('active');
+      _selectedColor = sw.dataset.color;
+    });
+  });
+
+  if (btnNew && form) {
+    btnNew.addEventListener('click', () => { form.classList.remove('hidden'); nameInput.focus(); });
+    btnCancel?.addEventListener('click', () => { form.classList.add('hidden'); nameInput.value = ''; });
+    btnCreate?.addEventListener('click', async () => {
+      const n = nameInput.value.trim();
+      if (!n) return;
+      await window.neurologue.createPortfolio(n, _selectedColor);
+      form.classList.add('hidden');
+      nameInput.value = '';
+      loadPortfoliosView();
+    });
+  }
+}
+
+// Reload renderer when the active portfolio switches (called from main)
+if (window.neurologue?.onPortfolioSwitched) {
+  window.neurologue.onPortfolioSwitched(() => { window.location.reload(); });
+}
+
 (async () => {
   // Apply persisted theme before first paint
   const initSettings = await window.neurologue.getSettings();
   applyTheme(initSettings.theme || 'dark');
   _navHistoryLimit = initSettings.navHistoryLimit ?? 10;
+
+  // Apply portfolio feature gate
+  applyPortfolioFeature(initSettings.portfoliosEnabled || false);
 
   // Navigate to the user's chosen home view
   const homeView = initSettings.homeView || 'library';

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -111,7 +111,14 @@ contextBridge.exposeInMainWorld('neurologue', {
   setHotkey:    (accelerator) => ipcRenderer.invoke('hotkey:set', { accelerator }),
   pauseHotkey:  ()            => ipcRenderer.invoke('hotkey:pause'),
   resumeHotkey: ()            => ipcRenderer.invoke('hotkey:resume'),
-
+  // ── Portfolios ────────────────────────────────────────────────────────────
+  listPortfolios:   ()              => ipcRenderer.invoke('portfolio:list'),
+  createPortfolio:  (name, color)   => ipcRenderer.invoke('portfolio:create', { name, color }),
+  renamePortfolio:  (id, name)      => ipcRenderer.invoke('portfolio:rename', { id, name }),
+  deletePortfolio:  (id)            => ipcRenderer.invoke('portfolio:delete', { id }),
+  switchPortfolio:  (id)            => ipcRenderer.invoke('portfolio:switch', { id }),
+  portfolioStats:   (id)            => ipcRenderer.invoke('portfolio:stats', { id }),
+  onPortfolioSwitched: (cb) => { ipcRenderer.on('portfolio:switched', (_e, d) => cb(d)); },
   // ── Capture ───────────────────────────────────────────────────────────────
   openCapture: () => ipcRenderer.invoke('capture:open'),
 

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -111,10 +111,11 @@ contextBridge.exposeInMainWorld('neurologue', {
   setHotkey:    (accelerator) => ipcRenderer.invoke('hotkey:set', { accelerator }),
   pauseHotkey:  ()            => ipcRenderer.invoke('hotkey:pause'),
   resumeHotkey: ()            => ipcRenderer.invoke('hotkey:resume'),
-  // ── Portfolios ────────────────────────────────────────────────────────────
-  listPortfolios:   ()              => ipcRenderer.invoke('portfolio:list'),
+  // ── Portfolio ─────────────────────────────────────────────────────────────
+  getPortfolioManifest: ()              => ipcRenderer.invoke('portfolio:list'),
   createPortfolio:  (name, color)   => ipcRenderer.invoke('portfolio:create', { name, color }),
   renamePortfolio:  (id, name)      => ipcRenderer.invoke('portfolio:rename', { id, name }),
+  recolorPortfolio: (id, color)     => ipcRenderer.invoke('portfolio:recolor', { id, color }),
   deletePortfolio:  (id)            => ipcRenderer.invoke('portfolio:delete', { id }),
   switchPortfolio:  (id)            => ipcRenderer.invoke('portfolio:switch', { id }),
   portfolioStats:   (id)            => ipcRenderer.invoke('portfolio:stats', { id }),

--- a/src/main.js
+++ b/src/main.js
@@ -26,9 +26,18 @@ const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signa
 const { getGraphData } = require('./backend/db/graph');
 const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
 const { listAgents, runAgent, abortAgent } = require('./backend/agents/runner');
+const { listProfiles, getActiveProfile, createProfile, renameProfile, deleteProfile, setActiveProfile } = require('./backend/portfolios');
+const { getProfileStats } = require('./backend/db/profile-stats');
+const { setDbPath, switchDb } = require('./backend/db/connection');
+const { setStorePath, switchVectorStore } = require('./backend/vector/store');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
+  // Respect the active portfolio profile paths so switching portfolios is
+  // reflected immediately on restart without extra migration work.
+  const profile = getActiveProfile();
+  setDbPath(profile.dbPath);
+  setStorePath(profile.vectorStorePath);
   await runMigrations();
   await initVectorStore();
 }
@@ -729,6 +738,45 @@ ipcMain.handle('hotkey:pause',  () => { pauseCaptureHotkey(); });
 ipcMain.handle('hotkey:resume', () => { resumeCaptureHotkey(); });
 
 ipcMain.handle('capture:open',  () => { openCaptureWindow(); });
+
+// ── Portfolio IPC ───────────────────────────────────────────────────────────────────
+
+ipcMain.handle('portfolio:list', () => listProfiles());
+
+ipcMain.handle('portfolio:create', (_e, { name, color }) => createProfile(name, color));
+
+ipcMain.handle('portfolio:rename', (_e, { id, name }) => renameProfile(id, name));
+
+ipcMain.handle('portfolio:delete', (_e, { id }) => deleteProfile(id));
+
+handle('portfolio:stats', async (_e, { id }) => {
+  const manifest = listProfiles();
+  const profile  = manifest.profiles.find((p) => p.id === id);
+  if (!profile) return { ok: false, error: 'Profile not found' };
+  const stats = await getProfileStats(profile.dbPath);
+  return { ok: true, ...stats };
+});
+
+handle('portfolio:switch', async (_e, { id }) => {
+  const profile = setActiveProfile(id);
+
+  // Pause background services while the DB is swapped
+  stopWorker();
+  stopScheduler();
+
+  await switchDb(profile.dbPath);
+  await switchVectorStore(profile.vectorStorePath);
+  await runMigrations(); // ensure schema is up-to-date for this corpus
+
+  startWorker();
+  startScheduler();
+
+  // Notify renderer to reload its data
+  if (_mainWindow && !_mainWindow.isDestroyed()) {
+    _mainWindow.webContents.send('portfolio:switched', { profile });
+  }
+  return { ok: true, profile };
+});
 
 // ── Ollama setup IPC ───────────────────────────────────────────────────────
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,14 +26,14 @@ const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signa
 const { getGraphData } = require('./backend/db/graph');
 const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
 const { listAgents, runAgent, abortAgent } = require('./backend/agents/runner');
-const { listProfiles, getActiveProfile, createProfile, renameProfile, deleteProfile, setActiveProfile } = require('./backend/portfolios');
+const { listProfiles, getActiveProfile, createProfile, renameProfile, recolorProfile, deleteProfile, setActiveProfile } = require('./backend/portfolio');
 const { getProfileStats } = require('./backend/db/profile-stats');
 const { setDbPath, switchDb } = require('./backend/db/connection');
 const { setStorePath, switchVectorStore } = require('./backend/vector/store');
 // getOllamaStatus and getSettings imported above
 
 async function initialise() {
-  // Respect the active portfolio profile paths so switching portfolios is
+  // Respect the active profile paths so switching profiles is
   // reflected immediately on restart without extra migration work.
   const profile = getActiveProfile();
   setDbPath(profile.dbPath);
@@ -746,6 +746,8 @@ ipcMain.handle('portfolio:list', () => listProfiles());
 ipcMain.handle('portfolio:create', (_e, { name, color }) => createProfile(name, color));
 
 ipcMain.handle('portfolio:rename', (_e, { id, name }) => renameProfile(id, name));
+
+ipcMain.handle('portfolio:recolor', (_e, { id, color }) => recolorProfile(id, color));
 
 ipcMain.handle('portfolio:delete', (_e, { id }) => deleteProfile(id));
 


### PR DESCRIPTION
## Summary

Implements #111 — portfolios (corpus profiles) as an opt-in feature that is completely invisible until explicitly enabled in **Settings → Features → Portfolios**.

### What's added

**Backend**
- src/backend/portfolios.js — manifest manager ({userData}/profiles.json). A default Personal profile is auto-created pointing at config.db.path, so existing users see zero change.
- src/backend/db/profile-stats.js — opens each profile's DB in isolation to read entry/theme/tag counts and recent entries without touching the singleton connection.
- connection.js — setDbPath / switchDb for switching the active DB.
- store.js — setStorePath / switchVectorStore for switching the vector store.
- settings.js — portfoliosEnabled: false default.
- main.js — initialise() now respects the active profile paths; full portfolio IPC (list, create, ename, delete, stats, switch). Switching stops worker + scheduler, swaps DB + vector store, runs migrations, restarts services, sends portfolio:switched IPC.

**Frontend**
- preload.js — exposes listPortfolios, createPortfolio, enamePortfolio, deletePortfolio, switchPortfolio, portfolioStats, onPortfolioSwitched.
- index.html — portfolio nav item, portfolio view (card grid + create form with colour swatches), Features settings panel with toggle.
- library.js — pplyPortfolioFeature, efreshPortfolioBadge, loadPortfoliosView, settings populate/save, onPortfolioSwitched → window.location.reload().
- library.css — feature gate (.feature-portfolios { display:none !important }, lifted by [data-portfolios='true']), portfolio card styles, toggle switch styles.

### Feature flag behaviour
- Default: portfoliosEnabled: false → all portfolio UI hidden, zero visual difference for existing users.
- Enabled: portfolio nav item, portfolio badge in toolbar, and full portfolio view become visible.

### Tests
463 tests pass (no regressions).