### PR TITLE
Portfolio: profile switcher dropdown + dashboard scope toggle

### DIFF
--- a/src/backend/db/profile-stats.js
+++ b/src/backend/db/profile-stats.js
@@ -75,11 +75,11 @@ async function getProfileStats(dbPath) {
     }
   }
 
-  const entryRow  = queryOne('SELECT COUNT(*) AS n FROM entries WHERE deleted_at IS NULL');
+  const entryRow  = queryOne('SELECT COUNT(*) AS n FROM entries');
   const tagRow    = queryOne('SELECT COUNT(*) AS n FROM tags');
   const themeRow  = queryOne('SELECT COUNT(*) AS n FROM themes');
-  const contraRow = queryOne("SELECT COUNT(*) AS n FROM contradictions WHERE status = 'open'");
-  const lastRow   = queryOne('SELECT MAX(created_at) AS last FROM entries WHERE deleted_at IS NULL');
+  const contraRow = queryOne("SELECT COUNT(*) AS n FROM contradictions WHERE status = 'active'");
+  const lastRow   = queryOne('SELECT MAX(created_at) AS last FROM entries');
 
   const topThemes = queryAll(
     'SELECT name FROM themes ORDER BY updated_at DESC LIMIT 5'

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -25,7 +25,18 @@
       <button id="btn-new-note" class="mode-btn btn-new-note" title="New note (Ctrl+Shift+Space)">+ New note</button>
       <button id="btn-maintenance" class="mode-btn toolbar-library-only" title="Tag management">Maintenance</button>
       <button id="btn-help" class="mode-btn">Help</button>
-      <button id="portfolio-badge" class="portfolio-badge feature-portfolios" title="Active portfolio — click to switch"></button>
+      <div id="portfolio-switcher" class="portfolio-switcher feature-portfolio">
+        <button id="portfolio-badge" class="portfolio-badge" title="Switch profile">
+          <span id="portfolio-badge-name"></span>
+          <span class="portfolio-badge-caret">&#9660;</span>
+        </button>
+        <div id="portfolio-dropdown" class="portfolio-dropdown" hidden>
+          <div id="portfolio-dropdown-list"></div>
+          <div class="portfolio-dropdown-footer">
+            <button id="btn-portfolio-manage" class="portfolio-dropdown-manage">Manage profiles&#x2026;</button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- ── Shell: nav rail + view container ───────────────────────── -->

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -433,6 +433,15 @@
             <span id="dash-title">Dashboard</span>
             <button id="btn-dash-refresh" class="btn-sm" title="Refresh">↻</button>
           </div>
+          <!-- scope toggle — only visible when Portfolio feature is enabled -->
+          <div id="dash-scope-toggle" class="feature-portfolio">
+            <button class="dash-scope-btn dash-scope-btn--active" data-scope="profile">This profile</button>
+            <button class="dash-scope-btn" data-scope="portfolio">All profiles</button>
+          </div>
+          <!-- portfolio overview body — shown when scope = "portfolio" -->
+          <div id="dash-portfolio-body" style="display:none">
+            <div id="dash-portfolio-grid"></div>
+          </div>
           <div id="dash-body">
 
             <!-- Row 1: stat cards -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3509,10 +3509,10 @@ body.theme-light .graph-tooltip {
 
 /* Feature gate — hide everything by default */
 .feature-portfolio                               { display: none !important; }
-[data-portfolio="true"] button.portfolio-badge         { display: inline-flex !important; }
+[data-portfolio="true"] div.portfolio-switcher.feature-portfolio { display: flex !important; align-items: center; position: relative; }
 [data-portfolio="true"] .settings-subnav-item.feature-portfolio { display: inline-block !important; }
 
-/* Portfolio badge in toolbar */
+/* Portfolio badge + dropdown */
 .portfolio-badge {
   font-size: 11px;
   font-weight: 600;
@@ -3521,9 +3521,81 @@ body.theme-light .graph-tooltip {
   border: 2px solid var(--cortex-teal);
   color: var(--text-muted);
   white-space: nowrap;
-  cursor: default;
+  cursor: pointer;
+  display: inline-flex;
   align-items: center;
+  gap: 5px;
 }
+.portfolio-badge:hover { color: var(--text); }
+
+.portfolio-badge-caret {
+  font-size: 8px;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.portfolio-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 2);
+  box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.portfolio-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 9px 14px;
+  font-size: 13px;
+  color: var(--text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+.portfolio-dropdown-item:hover { background: var(--surface2); }
+.portfolio-dropdown-item--active { cursor: default; color: var(--text-muted); }
+.portfolio-dropdown-item--active:hover { background: none; }
+
+.portfolio-dd-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.portfolio-dd-name { flex: 1; }
+
+.portfolio-dd-check {
+  font-size: 11px;
+  color: var(--cortex-teal);
+  font-weight: 700;
+}
+
+.portfolio-dropdown-footer {
+  border-top: 1px solid var(--border);
+  padding: 6px 8px;
+}
+
+.portfolio-dropdown-manage {
+  width: 100%;
+  padding: 7px 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  border-radius: var(--radius);
+}
+.portfolio-dropdown-manage:hover { background: var(--surface2); color: var(--text); }
 
 /* Portfolio card styles (used in profile panels) ----------------------------------------- */
 .portfolio-card {

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3511,6 +3511,125 @@ body.theme-light .graph-tooltip {
 .feature-portfolio                               { display: none !important; }
 [data-portfolio="true"] div.portfolio-switcher.feature-portfolio { display: flex !important; align-items: center; position: relative; }
 [data-portfolio="true"] .settings-subnav-item.feature-portfolio { display: inline-block !important; }
+[data-portfolio="true"] #dash-scope-toggle.feature-portfolio    { display: flex !important; gap: 4px; padding: 6px 16px 0; }
+
+/* Dashboard scope toggle */
+.dash-scope-btn {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.dash-scope-btn:hover { color: var(--text); border-color: var(--text-muted); }
+.dash-scope-btn--active {
+  background: var(--cortex-teal);
+  border-color: var(--cortex-teal);
+  color: #fff;
+}
+
+/* Dashboard portfolio overview grid */
+#dash-portfolio-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 16px;
+}
+#dash-portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+.dash-profile-card {
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--surface);
+}
+.dash-profile-card--active {
+  border-color: var(--profile-color, var(--cortex-teal));
+}
+.dash-profile-card-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.dash-profile-color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dash-profile-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dash-profile-active-badge {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: var(--profile-color, var(--cortex-teal));
+  color: #fff;
+  border-radius: 8px;
+  padding: 2px 6px;
+  flex-shrink: 0;
+}
+.dash-profile-stats {
+  display: flex;
+  gap: 12px;
+}
+.dash-profile-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+.dash-profile-stat-num {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+.dash-profile-stat-label {
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  margin-top: 2px;
+}
+.dash-profile-themes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-height: 20px;
+}
+.dash-profile-chip {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 8px;
+  background: var(--surface-raised, var(--surface));
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+.dash-profile-last-active {
+  font-size: 10px;
+  color: var(--text-muted);
+}
 
 /* Portfolio badge + dropdown */
 .portfolio-badge {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -3083,6 +3083,7 @@ const dashOpenLoops        = document.getElementById('dash-open-loops');
 const dashLoopsCount       = document.getElementById('dash-loops-count');
 const dashRecentCaptures   = document.getElementById('dash-recent-captures');
 const btnDashRefresh       = document.getElementById('btn-dash-refresh');
+let _dashScope = 'profile'; // 'profile' | 'portfolio'
 
 function _truncate(text, len = 72) {
   if (!text) return '—';
@@ -3096,6 +3097,15 @@ function _dashNavigate(viewId, action) {
 }
 
 async function loadDashboardView() {
+  const dashBody          = document.getElementById('dash-body');
+  const dashPortfolioBody = document.getElementById('dash-portfolio-body');
+  if (_dashScope === 'portfolio') {
+    dashBody.style.display = 'none';
+    dashPortfolioBody.style.display = '';
+    return _loadPortfolioOverview();
+  }
+  dashBody.style.display = '';
+  dashPortfolioBody.style.display = 'none';
   try {
     const d = await window.neurologue.getDashboardSummary();
 
@@ -3208,6 +3218,69 @@ async function loadDashboardView() {
 }
 
 btnDashRefresh.addEventListener('click', loadDashboardView);
+
+// Wire Dashboard scope toggle (Portfolio feature)
+document.querySelectorAll('.dash-scope-btn').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    _dashScope = btn.dataset.scope;
+    document.querySelectorAll('.dash-scope-btn').forEach((b) =>
+      b.classList.toggle('dash-scope-btn--active', b === btn)
+    );
+    loadDashboardView();
+  });
+});
+
+async function _loadPortfolioOverview() {
+  const grid = document.getElementById('dash-portfolio-grid');
+  grid.innerHTML = '<div class="dash-empty">Loading\u2026</div>';
+  try {
+    const manifest = await window.neurologue.getPortfolioManifest();
+    const statsArr = await Promise.all(
+      manifest.profiles.map((p) =>
+        window.neurologue.portfolioStats(p.id).then((s) => ({ profile: p, stats: s }))
+      )
+    );
+    grid.innerHTML = '';
+    statsArr.forEach(({ profile, stats }) => {
+      const isActive = profile.id === manifest.activeId;
+      const card = document.createElement('div');
+      card.className = 'dash-profile-card' + (isActive ? ' dash-profile-card--active' : '');
+      card.style.setProperty('--profile-color', profile.color);
+      const topChips = (stats.topThemes || []).slice(0, 3)
+        .map((t) => `<span class="dash-profile-chip">${t}</span>`).join('');
+      const lastActive = stats.lastActiveAt
+        ? new Date(stats.lastActiveAt).toLocaleDateString()
+        : 'No activity';
+      card.innerHTML = `
+        <div class="dash-profile-card-header">
+          <span class="dash-profile-color-dot" style="background:${profile.color}"></span>
+          <span class="dash-profile-name">${profile.name}</span>
+          ${isActive ? '<span class="dash-profile-active-badge">active</span>' : ''}
+        </div>
+        <div class="dash-profile-stats">
+          <div class="dash-profile-stat">
+            <span class="dash-profile-stat-num">${stats.entryCount}</span>
+            <span class="dash-profile-stat-label">notes</span>
+          </div>
+          <div class="dash-profile-stat">
+            <span class="dash-profile-stat-num">${stats.themeCount}</span>
+            <span class="dash-profile-stat-label">themes</span>
+          </div>
+          <div class="dash-profile-stat">
+            <span class="dash-profile-stat-num">${stats.openContradictions}</span>
+            <span class="dash-profile-stat-label">conflicts</span>
+          </div>
+        </div>
+        <div class="dash-profile-themes">${topChips || '<span class="dash-empty">No themes yet</span>'}</div>
+        <div class="dash-profile-last-active">Last active: ${lastActive}</div>
+      `;
+      grid.appendChild(card);
+    });
+  } catch (err) {
+    grid.innerHTML = '<div class="dash-empty">Could not load portfolio stats.</div>';
+    console.error('[dashboard] _loadPortfolioOverview failed:', err);
+  }
+}
 
 // ── Memory Replay view controller ────────────────────────────────────────────
 
@@ -3557,7 +3630,14 @@ function _escHtml(str) {
 
 function applyPortfolioFeature(enabled) {
   document.documentElement.dataset.portfolio = enabled ? 'true' : 'false';
-  if (enabled) refreshPortfolioBadge();
+  if (enabled) {
+    refreshPortfolioBadge();
+  } else if (_dashScope === 'portfolio') {
+    _dashScope = 'profile';
+    document.querySelectorAll('.dash-scope-btn').forEach((b) =>
+      b.classList.toggle('dash-scope-btn--active', b.dataset.scope === 'profile')
+    );
+  }
 }
 
 async function refreshPortfolioBadge() {

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -3562,15 +3562,68 @@ function applyPortfolioFeature(enabled) {
 
 async function refreshPortfolioBadge() {
   try {
-    const manifest = await window.neurologue.getPortfolioManifest();
-    const active   = manifest.profiles.find((p) => p.id === manifest.activeId);
-    const badge    = document.getElementById('portfolio-badge');
+    const manifest  = await window.neurologue.getPortfolioManifest();
+    const active    = manifest.profiles.find((p) => p.id === manifest.activeId);
+    const nameSpan  = document.getElementById('portfolio-badge-name');
+    const badge     = document.getElementById('portfolio-badge');
     if (badge && active) {
-      badge.textContent   = active.name;
+      if (nameSpan) nameSpan.textContent = active.name;
       badge.style.borderColor = active.color;
     }
+    _populateProfileDropdown(manifest);
   } catch (_e) { /* silent — Portfolio feature may not be configured yet */ }
 }
+
+function _populateProfileDropdown(manifest) {
+  const list = document.getElementById('portfolio-dropdown-list');
+  if (!list) return;
+  list.innerHTML = '';
+  for (const p of manifest.profiles) {
+    const isActive = p.id === manifest.activeId;
+    const item = document.createElement('button');
+    item.className = `portfolio-dropdown-item${isActive ? ' portfolio-dropdown-item--active' : ''}`;
+    item.innerHTML = `<span class="portfolio-dd-dot"></span><span class="portfolio-dd-name">${p.name}</span>${isActive ? '<span class="portfolio-dd-check">&#x2713;</span>' : ''}`;
+    item.querySelector('.portfolio-dd-dot').style.backgroundColor = p.color;
+    if (!isActive) {
+      item.addEventListener('click', async () => {
+        _closeProfileDropdown();
+        item.disabled = true;
+        await window.neurologue.switchPortfolio(p.id);
+      });
+    }
+    list.appendChild(item);
+  }
+}
+
+function _closeProfileDropdown() {
+  const dd = document.getElementById('portfolio-dropdown');
+  if (dd) dd.hidden = true;
+}
+
+// Badge click — toggle dropdown
+(function _wireProfileDropdown() {
+  const badge = document.getElementById('portfolio-badge');
+  const dd    = document.getElementById('portfolio-dropdown');
+  const mgr   = document.getElementById('btn-portfolio-manage');
+
+  if (badge && dd) {
+    badge.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      if (!dd.hidden) { _closeProfileDropdown(); return; }
+      await refreshPortfolioBadge(); // always refresh before opening
+      dd.hidden = false;
+    });
+    dd.addEventListener('click', (e) => e.stopPropagation());
+  }
+  if (mgr) {
+    mgr.addEventListener('click', () => {
+      _closeProfileDropdown();
+      activateView('settings');
+      loadSettingsView('portfolio');
+    });
+  }
+  document.addEventListener('click', _closeProfileDropdown);
+}());
 
 async function loadProfilesPanel() {
   const list = document.getElementById('profiles-list');


### PR DESCRIPTION
Closes #149, closes #155

## Changes

### #149 - Profile switcher dropdown on portfolio badge
- Badge in the toolbar opens a dropdown listing all profiles with colour dot, name, and checkmark on the active one
- Clicking a profile triggers portfolio:switch IPC -> DB/vector store swap -> reload
- Footer link navigates to Settings > Portfolio panel
- Outside click closes the dropdown
- CSS feature-gated: only visible when portfolioEnabled = true

### #155 - Cross-profile overview toggle on Dashboard
- Scope toggle row appears below the Dashboard header when Portfolio is enabled
- This profile (default): existing dashboard content, no change in behaviour
- All profiles: card grid showing entry count, theme count, open conflicts, top 3 themes, last active date; active profile card accented with its profile colour
- Stats fetched in parallel via existing portfolioStats IPC and getProfileStats backend
- Disabling Portfolio resets scope back to This profile

### Fixes
- profile-stats.js: removed non-existent deleted_at filter on entries count/lastActiveAt
- profile-stats.js: contradiction status filter corrected from 'open' to 'active'