### PR TITLE
feat(chat): free-text chat with corpus grounding

### DIFF
--- a/src/backend/agents/runner.js
+++ b/src/backend/agents/runner.js
@@ -16,7 +16,10 @@ const {
   getTodayFocusData,
 } = require('../db/agents');
 
-const { generateStream } = require('../../worker/ollama');
+const { generateStream, chatStream, generateEmbedding, isOllamaAvailable } = require('../../worker/ollama');
+const { searchNearest } = require('../vector/store');
+const { searchEntriesText, getEntryWithTags } = require('../db/search');
+const { listThemes } = require('../db/themes');
 
 // ── Agent definitions ────────────────────────────────────────────────────────
 
@@ -195,4 +198,99 @@ async function runAgent(agentId, onToken) {
   }
 }
 
-module.exports = { listAgents, runAgent, abortAgent };
+// ── Chat ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Free-text chat grounded in the user's corpus.
+ * Retrieves relevant entries + theme summaries as system context, then streams
+ * a multi-turn response via /api/chat.
+ *
+ * @param {string}   userMessage  The latest user message
+ * @param {{ role: 'user'|'assistant', content: string }[]} history  Prior turns
+ * @param {function} onToken      Called with each streamed text fragment
+ * @returns {Promise<void>}
+ */
+async function chat(userMessage, history, onToken) {
+  abortAgent(); // cancel any in-flight agent or chat
+
+  const controller = new AbortController();
+  _currentController = controller;
+
+  try {
+    const [contextEntries, themes] = await Promise.all([
+      _buildChatContext(userMessage),
+      listThemes().catch(() => []),
+    ]);
+
+    const systemContent = _buildSystemMessage(contextEntries, themes.slice(0, 3));
+
+    const messages = [
+      { role: 'system', content: systemContent },
+      ...history,
+      { role: 'user', content: userMessage },
+    ];
+
+    await chatStream(messages, onToken, 180_000, controller.signal);
+  } finally {
+    if (_currentController === controller) _currentController = null;
+  }
+}
+
+async function _buildChatContext(query) {
+  let entries = [];
+
+  // Prefer semantic search when Ollama is available
+  try {
+    if (await isOllamaAvailable()) {
+      const queryVector = await generateEmbedding(query);
+      const hits = await searchNearest(queryVector, 5);
+      entries = (await Promise.all(hits.map((h) => getEntryWithTags(h.entry_id)))).filter(Boolean);
+    }
+  } catch { /* fall through to text search */ }
+
+  // Supplement with text search if semantic returned too few results
+  if (entries.length < 3) {
+    try {
+      const textResults = await searchEntriesText(query, { limit: 5 });
+      const seen = new Set(entries.map((e) => e.id));
+      for (const e of textResults) {
+        if (!seen.has(e.id)) entries.push(e);
+      }
+    } catch { /* ignore */ }
+  }
+
+  return entries.slice(0, 5);
+}
+
+function _buildSystemMessage(entries, themes) {
+  const parts = [
+    'You are a helpful assistant for a personal knowledge base called Neurologue. ' +
+    'Answer questions grounded in the notes and themes below. ' +
+    'Be concise and refer to specific notes when relevant.',
+  ];
+
+  if (entries.length > 0) {
+    parts.push('\nRelevant notes:');
+    for (const e of entries) {
+      const date = e.created_at ? e.created_at.slice(0, 10) : '';
+      const cat  = e.category ? ` [${e.category}]` : '';
+      parts.push(`- ${date}${cat}: ${e.content.slice(0, 300)}`);
+    }
+  }
+
+  if (themes.length > 0) {
+    parts.push('\nActive themes:');
+    for (const t of themes) {
+      const desc = t.description ? ` — ${t.description.slice(0, 120)}` : '';
+      parts.push(`- "${t.display_name}"${desc}`);
+    }
+  }
+
+  if (entries.length === 0 && themes.length === 0) {
+    parts.push('\nThe knowledge base is empty. Let the user know they can start by capturing notes.');
+  }
+
+  return parts.join('\n');
+}
+
+module.exports = { listAgents, runAgent, abortAgent, chat };

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -601,10 +601,14 @@
         <!-- ── View: Agents ─────────────────────────────────────────────── -->
         <div id="view-agents" class="view">
           <div id="agents-toolbar">
-            <span id="agents-title">Agents</span>
-            <span class="agents-subtitle">Local AI agents that work on your corpus</span>
+            <div class="agents-tab-bar">
+              <button class="agents-tab active" data-tab="agents">Agents</button>
+              <button class="agents-tab" data-tab="chat">Chat</button>
+            </div>
           </div>
-          <div id="agents-body">
+
+          <!-- Agents tab -->
+          <div id="agents-tab-agents" class="agents-tab-content">
             <div id="agents-grid">
               <!-- Agent cards injected by library.js -->
             </div>
@@ -618,6 +622,20 @@
                 </div>
               </div>
               <div id="agents-output" class="agents-output-body"></div>
+            </div>
+          </div>
+
+          <!-- Chat tab -->
+          <div id="agents-tab-chat" class="agents-tab-content" style="display:none">
+            <div id="chat-thread" class="chat-thread"></div>
+            <div id="chat-controls" class="chat-controls">
+              <textarea id="chat-input" class="chat-input" rows="2"
+                placeholder="Ask something about your notes… (Enter to send, Shift+Enter for new line)"></textarea>
+              <div class="chat-buttons">
+                <button id="btn-chat-send" class="btn-primary">Send</button>
+                <button id="btn-chat-stop" class="btn-sm" style="display:none">&#9632; Stop</button>
+                <button id="btn-chat-clear" class="btn-sm">Clear</button>
+              </div>
             </div>
           </div>
         </div><!-- /#view-agents -->

--- a/src/frontend/library.css
+++ b/src/frontend/library.css
@@ -3442,7 +3442,36 @@ body.theme-light .graph-tooltip {
   color:     var(--text-muted);
 }
 
-#agents-body {
+/* Tab bar */
+.agents-tab-bar {
+  display: flex;
+  gap:     4px;
+}
+
+.agents-tab {
+  padding:       5px 14px;
+  border:        1px solid transparent;
+  border-radius: 4px;
+  background:    transparent;
+  color:         var(--text-muted);
+  font-size:     13px;
+  font-weight:   500;
+  cursor:        pointer;
+  font-family:   inherit;
+  transition:    color 0.15s, border-color 0.15s;
+}
+
+.agents-tab:hover {
+  color:        var(--text-primary);
+}
+
+.agents-tab.active {
+  color:        var(--cortex-teal);
+  border-color: var(--cortex-teal);
+}
+
+/* Tab content panels */
+.agents-tab-content {
   flex:           1;
   overflow:       auto;
   padding:        16px;
@@ -3590,6 +3619,110 @@ body.theme-light .graph-tooltip {
 
 
 
+
+/* --------------------------------------------------------------------------
+   CHAT
+   -------------------------------------------------------------------------- */
+
+#agents-tab-chat {
+  display:        flex;
+  flex-direction: column;
+  padding:        0;
+  gap:            0;
+  overflow:       hidden;
+}
+
+.chat-thread {
+  flex:        1;
+  overflow-y:  auto;
+  padding:     16px;
+  display:     flex;
+  flex-direction: column;
+  gap:         12px;
+}
+
+.chat-bubble {
+  max-width:     78%;
+  padding:       10px 14px;
+  border-radius: 10px;
+  font-size:     14px;
+  line-height:   1.6;
+  word-break:    break-word;
+  white-space:   pre-wrap;
+}
+
+.chat-bubble-user {
+  align-self:  flex-end;
+  background:  var(--cortex-teal);
+  color:       #fff;
+  border-bottom-right-radius: 2px;
+}
+
+.chat-bubble-assistant {
+  align-self:  flex-start;
+  background:  var(--bg-card);
+  color:       var(--text-primary);
+  border:      1px solid var(--border);
+  border-bottom-left-radius: 2px;
+  min-width:   60px;
+  min-height:  38px;
+}
+
+.chat-controls {
+  display:       flex;
+  flex-direction: column;
+  gap:           8px;
+  padding:       12px 16px;
+  border-top:    1px solid var(--border);
+  background:    var(--bg-secondary);
+  flex-shrink:   0;
+}
+
+.chat-input {
+  width:         100%;
+  resize:        none;
+  padding:       8px 12px;
+  border:        1px solid var(--border);
+  border-radius: 6px;
+  background:    var(--bg-input, var(--bg-primary));
+  color:         var(--text-primary);
+  font-size:     13px;
+  font-family:   inherit;
+  line-height:   1.5;
+  box-sizing:    border-box;
+  transition:    border-color 0.15s;
+}
+
+.chat-input:focus {
+  outline:      none;
+  border-color: var(--cortex-teal);
+}
+
+.chat-input:disabled {
+  opacity: 0.5;
+}
+
+.chat-buttons {
+  display:     flex;
+  gap:         8px;
+  align-items: center;
+}
+
+.btn-primary {
+  padding:       5px 16px;
+  border:        none;
+  border-radius: 4px;
+  background:    var(--cortex-teal);
+  color:         #fff;
+  font-size:     13px;
+  font-weight:   500;
+  cursor:        pointer;
+  font-family:   inherit;
+  transition:    opacity 0.15s;
+}
+
+.btn-primary:hover    { opacity: 0.88; }
+.btn-primary:disabled { opacity: 0.4; cursor: default; }
 
 /* --------------------------------------------------------------------------
    PORTFOLIO  (opt-in feature, gated by [data-portfolio="true"] on <html>)

--- a/src/frontend/library.js
+++ b/src/frontend/library.js
@@ -3646,6 +3646,109 @@ function _escHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+// ── Agents tab switching ──────────────────────────────────────────────────────
+
+document.querySelectorAll('.agents-tab').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const tab = btn.dataset.tab;
+    document.querySelectorAll('.agents-tab').forEach((b) => b.classList.toggle('active', b === btn));
+    document.querySelectorAll('.agents-tab-content').forEach((panel) => {
+      panel.style.display = panel.id === `agents-tab-${tab}` ? '' : 'none';
+    });
+    if (tab === 'agents') loadAgentsView();
+  });
+});
+
+// ── Chat view controller ──────────────────────────────────────────────────────
+
+const chatThread   = document.getElementById('chat-thread');
+const chatInput    = document.getElementById('chat-input');
+const btnChatSend  = document.getElementById('btn-chat-send');
+const btnChatStop  = document.getElementById('btn-chat-stop');
+const btnChatClear = document.getElementById('btn-chat-clear');
+
+let _chatHistory         = []; // { role: 'user'|'assistant', content: string }[]
+let _chatRunning         = false;
+let _chatAssistantBubble = null; // DOM node receiving streaming tokens
+
+function _setChatRunning(running) {
+  _chatRunning           = running;
+  chatInput.disabled     = running;
+  btnChatSend.disabled   = running;
+  btnChatStop.style.display = running ? '' : 'none';
+}
+
+function _appendChatBubble(role, text = '') {
+  const bubble = document.createElement('div');
+  bubble.className = `chat-bubble chat-bubble-${role}`;
+  bubble.textContent = text;
+  chatThread.appendChild(bubble);
+  chatThread.scrollTop = chatThread.scrollHeight;
+  return bubble;
+}
+
+async function _sendChatMessage() {
+  const message = chatInput.value.trim();
+  if (!message || _chatRunning) return;
+
+  chatInput.value = '';
+
+  _appendChatBubble('user', message);
+
+  // Snapshot history before appending the new user turn (sent to backend)
+  const historySnapshot = [..._chatHistory];
+  _chatHistory.push({ role: 'user', content: message });
+
+  _setChatRunning(true);
+  _chatAssistantBubble = _appendChatBubble('assistant', '');
+
+  try {
+    await window.neurologue.chat(message, historySnapshot);
+  } catch (err) {
+    if (_chatAssistantBubble) _chatAssistantBubble.textContent += `\n[Error: ${err.message}]`;
+    _setChatRunning(false);
+  }
+  // Normal completion handled by onChatDone
+}
+
+window.neurologue.onChatToken(({ token }) => {
+  if (_chatAssistantBubble) {
+    _chatAssistantBubble.textContent += token;
+    chatThread.scrollTop = chatThread.scrollHeight;
+  }
+});
+
+window.neurologue.onChatDone(() => {
+  if (_chatAssistantBubble) {
+    _chatHistory.push({ role: 'assistant', content: _chatAssistantBubble.textContent });
+    _chatAssistantBubble = null;
+  }
+  _setChatRunning(false);
+});
+
+btnChatSend.addEventListener('click', _sendChatMessage);
+
+chatInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    _sendChatMessage();
+  }
+});
+
+btnChatStop.addEventListener('click', () => {
+  if (_chatAssistantBubble) {
+    _chatAssistantBubble.textContent += '\n[Stopped]';
+    _chatAssistantBubble = null;
+  }
+  window.neurologue.abortAgent(); // reuses the same AbortController
+  _setChatRunning(false);
+});
+
+btnChatClear.addEventListener('click', () => {
+  _chatHistory = [];
+  chatThread.innerHTML = '';
+});
+
 // ── Init ────────────────────────────────────────────────────────────
 
 // ── Portfolio feature gate ─────────────────────────────────────────────────

--- a/src/frontend/preload.js
+++ b/src/frontend/preload.js
@@ -87,6 +87,11 @@ contextBridge.exposeInMainWorld('neurologue', {
   onAgentToken:  (cb)      => { ipcRenderer.on('agent:token', (_e, d) => cb(d)); },
   onAgentDone:   (cb)      => { ipcRenderer.on('agent:done',  ()       => cb()); },
 
+  // ── Chat ─────────────────────────────────────────────────────────────────
+  chat:        (message, history) => ipcRenderer.invoke('agents:chat', { message, history }),
+  onChatToken: (cb) => { ipcRenderer.on('chat:token', (_e, d) => cb(d)); },
+  onChatDone:  (cb) => { ipcRenderer.on('chat:done',  ()       => cb()); },
+
   // ── Memory Replay ─────────────────────────────────────────────────────────
   listActiveMonths:   ()                          => ipcRenderer.invoke('replay:active-months'),
   getMonthSnapshot:   (year, month)               => ipcRenderer.invoke('replay:month-snapshot',  { year, month }),

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ const { getDashboardSummary } = require('./backend/db/dashboard');
 const { getEntrySignals, getSignalsByTheme } = require('./backend/db/entry_signals');
 const { getGraphData } = require('./backend/db/graph');
 const { getMonthSnapshot, comparePeriods, getAbandonedIdeas, listActiveMonths } = require('./backend/db/replay');
-const { listAgents, runAgent, abortAgent } = require('./backend/agents/runner');
+const { listAgents, runAgent, abortAgent, chat } = require('./backend/agents/runner');
 const { listProfiles, getActiveProfile, createProfile, renameProfile, recolorProfile, deleteProfile, setActiveProfile } = require('./backend/portfolio');
 const { getProfileStats } = require('./backend/db/profile-stats');
 const { setDbPath, switchDb } = require('./backend/db/connection');
@@ -396,6 +396,18 @@ handle('agents:run', async (event, { agentId }) => {
 
 handle('agents:abort', async () => {
   abortAgent();
+  return { ok: true };
+});
+
+handle('agents:chat', async (event, { message, history = [] }) => {
+  await chat(message, history, (token) => {
+    if (!event.sender.isDestroyed()) {
+      event.sender.send('chat:token', { token });
+    }
+  });
+  if (!event.sender.isDestroyed()) {
+    event.sender.send('chat:done');
+  }
   return { ok: true };
 });
 

--- a/src/worker/ollama.js
+++ b/src/worker/ollama.js
@@ -532,4 +532,84 @@ function generateStream(prompt, onToken, timeoutMs = 180_000, signal = null) {
   });
 }
 
-module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry, suggestTags, setAvailableModels, detectContradiction, computeEntrySignals, generateStream };
+/**
+ * Stream a multi-turn chat completion from Ollama using /api/chat.
+ *
+ * @param {{ role: 'system'|'user'|'assistant', content: string }[]} messages
+ * @param {function}    onToken       Called with each text fragment (string)
+ * @param {number}      [timeoutMs=180000]
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<void>}
+ */
+function chatStream(messages, onToken, timeoutMs = 180_000, signal = null) {
+  return new Promise((resolve, reject) => {
+    if (signal && signal.aborted) return resolve();
+
+    const settings = getSettings();
+    const model    = settings.llmModel || 'phi3:mini';
+    const payload  = JSON.stringify({ model, messages, stream: true });
+    const url      = new URL(config.ollama.baseUrl);
+
+    const options = {
+      hostname: url.hostname,
+      port:     url.port || 11434,
+      path:     '/api/chat',
+      method:   'POST',
+      headers: {
+        'Content-Type':   'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+
+    let settled = false;
+    function finish() { if (!settled) { settled = true; resolve(); } }
+    function fail(err) { if (!settled) { settled = true; reject(err); } }
+
+    if (signal) {
+      signal.addEventListener('abort', () => { req.destroy(); finish(); }, { once: true });
+    }
+
+    const req = http.request(options, (res) => {
+      if (res.statusCode >= 400) {
+        res.resume();
+        return fail(new Error(`Ollama chatStream HTTP ${res.statusCode}`));
+      }
+
+      let buf = '';
+      res.on('data', (chunk) => {
+        buf += chunk.toString('utf8');
+        const lines = buf.split('\n');
+        buf = lines.pop();
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const obj = JSON.parse(line);
+            if (obj.message && obj.message.content) onToken(obj.message.content);
+            if (obj.done) finish();
+          } catch { /* ignore malformed line */ }
+        }
+      });
+
+      res.on('end', () => {
+        if (buf.trim()) {
+          try {
+            const obj = JSON.parse(buf);
+            if (obj.message && obj.message.content) onToken(obj.message.content);
+          } catch { /* ignore */ }
+        }
+        finish();
+      });
+
+      res.on('error', (err) => { if (!settled) fail(err); });
+    });
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`chatStream timed out after ${timeoutMs / 1000}s`));
+    });
+    req.on('error', (err) => { if (!settled) fail(err); });
+    req.write(payload);
+    req.end();
+  });
+}
+
+module.exports = { generateEmbedding, isOllamaAvailable, getOllamaStatus, checkOllamaInstalled, pullModel, classifyEntry, suggestTags, setAvailableModels, detectContradiction, computeEntrySignals, generateStream, chatStream };


### PR DESCRIPTION
Closes #115

## Summary

- Adds a **Chat tab** to the Agents view, toggling between the existing agent cards and a new chat interface
- Chat responses are grounded in the user's corpus via semantic search (nearest entries) + text search fallback + top 3 theme summaries, assembled as a system message
- Streams token-by-token using a new `chatStream()` function that calls Ollama's `/api/chat` endpoint (multi-turn messages format)
- Conversation history is maintained in-session and sent with each request; Clear button resets it
- Uses separate `chat:token` / `chat:done` IPC channels to avoid collision with `agent:token` / `agent:done`

## Changes

| File | Change |
|---|---|
| `src/worker/ollama.js` | `chatStream()` — streams `/api/chat` with messages array |
| `src/backend/agents/runner.js` | `chat()` — context builder + `chatStream` dispatch |
| `src/main.js` | `agents:chat` IPC handler |
| `src/frontend/preload.js` | `chat`, `onChatToken`, `onChatDone` preload methods |
| `src/frontend/index.html` | Tab bar + chat panel added to `#view-agents` |
| `src/frontend/library.js` | Tab switching + full chat UI controller |
| `src/frontend/library.css` | Tab bar + chat bubble + input styles |

## Test plan

- [ ] `npm run dev` → Agents view → Chat tab
- [ ] Type a question about notes → response streams into chat panel
- [ ] Verify conversation history carries forward in multi-turn exchange
- [ ] Stop button aborts mid-stream
- [ ] Clear button resets thread and history
- [ ] Agents tab still works normally (no regression)
- [ ] `npm test` — 463 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)